### PR TITLE
FLINK-5911: Extract job display functions to flink_tools (PR 3/4)

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -12,11 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import asyncio
 import concurrent.futures
 import difflib
 import os
-import shutil
 import signal
 import sys
 from collections import Counter
@@ -25,7 +23,6 @@ from datetime import datetime
 from datetime import timedelta
 from datetime import timezone
 from enum import Enum
-from itertools import groupby
 from threading import Event
 from threading import Lock
 from typing import Any
@@ -79,7 +76,6 @@ from paasta_tools.kubernetes_tools import paasta_prefixed
 from paasta_tools.monitoring_tools import get_team
 from paasta_tools.monitoring_tools import list_teams
 from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
-from paasta_tools.paastaapi.model.flink_checkpoint_status import FlinkCheckpointStatus
 from paasta_tools.paastaapi.model.flink_job_details import FlinkJobDetails
 from paasta_tools.paastaapi.model.flink_jobs import FlinkJobs
 from paasta_tools.paastaapi.models import InstanceStatusKubernetesV2
@@ -749,18 +745,6 @@ def status_kubernetes_job_human(
         )
 
 
-def get_flink_job_name(flink_job: FlinkJobDetails) -> str:
-    return flink_job["name"].split(".", 2)[-1]
-
-
-def should_job_info_be_shown(cluster_state):
-    return (
-        cluster_state == "running"
-        or cluster_state == "stoppingsupervisor"
-        or cluster_state == "cleanupsupervisor"
-    )
-
-
 def get_pod_uptime(pod_deployed_timestamp: str):
     # NOTE: the k8s API returns timestamps in UTC, so we make sure to always work in UTC
     pod_creation_time = datetime.strptime(
@@ -902,7 +886,7 @@ def _print_flink_status_from_job_manager(
     job_details = flink_tools.collect_flink_job_details(status, overview, [])
     output.extend(flink_tools.format_flink_state_and_pods(job_details))
 
-    if not should_job_info_be_shown(status["state"]):
+    if not flink_tools.should_job_info_be_shown(status["state"]):
         # In case where the jobmanager of cluster is in crashloopbackoff
         # The pods for the cluster will be available and we need to show the pods.
         # So that paasta status -v and kubectl get pods show the same consistent result.
@@ -928,7 +912,9 @@ def _print_flink_status_from_job_manager(
     if flink_jobs.get("jobs"):
         job_ids = [job.id for job in flink_jobs.get("jobs")]
     try:
-        jobs = run_sync(get_flink_job_details, service, instance, job_ids, client)
+        jobs = run_sync(
+            flink_tools._fetch_flink_job_details, service, instance, job_ids, client
+        )
     except Exception as e:
         output.append(PaastaColors.red("Exception when talking to the API:"))
         output.append(str(e))
@@ -938,112 +924,20 @@ def _print_flink_status_from_job_manager(
     if verbose > 1 and job_ids:
         try:
             checkpoint_data = run_sync(
-                get_flink_job_checkpoints, service, instance, job_ids, client
+                flink_tools._fetch_flink_job_checkpoints,
+                service,
+                instance,
+                job_ids,
+                client,
             )
         except Exception:
             pass  # checkpoints are informational, don't fail status
 
-    # Avoid cutting job name. As opposed to default hardcoded value of 32, we will use max length of job name
-    if jobs:
-        max_job_name_length = max([len(get_flink_job_name(job)) for job in jobs])
-    else:
-        max_job_name_length = 10
-
-    # Apart from this column total length of one row is around 52 columns, using remaining terminal columns for job name
-    # Note: for terminals smaller than 90 columns the row will overflow in verbose printing
-    allowed_max_job_name_length = min(
-        max(10, shutil.get_terminal_size().columns - 52), max_job_name_length
-    )
-
-    output.append("    Jobs:")
-    if verbose > 1:
-        output.append(
-            f'      {"Job Name": <{allowed_max_job_name_length}} State       Job ID                           Started'
-        )
-    else:
-        output.append(
-            f'      {"Job Name": <{allowed_max_job_name_length}} State       Started'
-        )
-
-    # Use only the most recent jobs
-    unique_jobs = (
-        sorted(jobs, key=lambda j: -j["start_time"])[0]  # type: ignore
-        for _, jobs in groupby(
-            sorted(
-                (j for j in jobs if j.get("name") and j.get("start_time")),
-                key=lambda j: j["name"],
-            ),
-            lambda j: j["name"],
+    output.extend(
+        flink_tools.format_flink_jobs_table(
+            jobs, job_ids, checkpoint_data, dashboard_url, verbose
         )
     )
-
-    allowed_max_jobs_printed = 3
-    job_printed_count = 0
-
-    for job in unique_jobs:
-        job_id = job["jid"]
-        if verbose > 1:
-            fmt = """      {job_name: <{allowed_max_job_name_length}.{allowed_max_job_name_length}} {state: <11} {job_id} {start_time}
-        {dashboard_url}"""
-        else:
-            fmt = "      {job_name: <{allowed_max_job_name_length}.{allowed_max_job_name_length}} {state: <11} {start_time}"
-        start_time = datetime.fromtimestamp(int(job["start_time"]) // 1000)
-        if verbose or job_printed_count < allowed_max_jobs_printed:
-            job_printed_count += 1
-            color_fn = (
-                PaastaColors.green
-                if job.get("state") and job.get("state") == "RUNNING"
-                else (
-                    PaastaColors.red
-                    if job.get("state") and job.get("state") in ("FAILED", "FAILING")
-                    else PaastaColors.yellow
-                )
-            )
-            job_info_str = fmt.format(
-                job_id=job_id,
-                job_name=get_flink_job_name(job),
-                allowed_max_job_name_length=allowed_max_job_name_length,
-                state=color_fn((job.get("state").title() or "Unknown")),
-                start_time=f"{str(start_time)} ({humanize.naturaltime(start_time)})",
-                dashboard_url=PaastaColors.grey(f"{dashboard_url}/#/jobs/{job_id}"),
-            )
-            output.append(job_info_str)
-            if verbose > 1 and job_id in checkpoint_data:
-                ckpt = checkpoint_data[job_id]
-                if (
-                    not isinstance(ckpt, Exception)
-                    and hasattr(ckpt, "counts")
-                    and ckpt.counts is not None
-                ):
-                    counts = ckpt.counts
-                    output.append(
-                        f"        Checkpoints:"
-                        f" {counts['completed']} completed,"
-                        f" {counts['failed']} failed,"
-                        f" {counts['in_progress']} in progress,"
-                        f" {counts['restored']} restored"
-                    )
-            if verbose > 1 and job.get("timestamps"):
-                restarting_ts = job["timestamps"].get("RESTARTING", 0)
-                if restarting_ts and restarting_ts > 0:
-                    try:
-                        last_restart = datetime.fromtimestamp(
-                            int(restarting_ts) // 1000
-                        )
-                        output.append(
-                            f"        Last restart:"
-                            f" {last_restart}"
-                            f" ({humanize.naturaltime(last_restart)})"
-                        )
-                    except (ValueError, TypeError, OSError):
-                        pass  # timestamps are informational
-        else:
-            output.append(
-                PaastaColors.yellow(
-                    f"    Only showing {allowed_max_jobs_printed} Flink jobs, use -v to show all"
-                )
-            )
-            break
 
     if verbose and len(status["pod_status"]) > 0:
         append_pod_status(status["pod_status"], output)
@@ -1125,36 +1019,6 @@ def print_flinkeks_status(
         flink_eks_instance_config,
         verbose,
     )
-
-
-async def get_flink_job_details(
-    service: str, instance: str, job_ids: List[str], client: PaastaOApiClient
-) -> List[FlinkJobDetails]:
-    jobs_details = await asyncio.gather(
-        *[
-            flink_tools.get_flink_job_details_from_paasta_api_client(
-                service, instance, job_id, client
-            )
-            for job_id in job_ids
-        ]
-    )
-    return [jd for jd in jobs_details]
-
-
-async def get_flink_job_checkpoints(
-    service: str, instance: str, job_ids: List[str], client: PaastaOApiClient
-) -> Dict[str, Union[FlinkCheckpointStatus, BaseException]]:
-    """Fetch checkpoint status for all jobs in parallel, return dict keyed by job_id."""
-    results = await asyncio.gather(
-        *[
-            flink_tools.get_flink_job_checkpoints_from_paasta_api_client(
-                service, instance, job_id, client
-            )
-            for job_id in job_ids
-        ],
-        return_exceptions=True,
-    )
-    return dict(zip(job_ids, results))
 
 
 def print_kubernetes_status_v2(

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -471,7 +471,7 @@ def get_flink_instance_details(
 def format_flink_instance_header(
     details: FlinkInstanceDetails, verbose: bool
 ) -> List[str]:
-    """Format running cluster info (version, dashboard URL). Config SHA is shown separately."""
+    """Format running cluster info (version, dashboard URL, etc)."""
     output: List[str] = []
 
     if verbose:

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -10,14 +10,21 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import asyncio
 import json
+import shutil
+from datetime import datetime
+from itertools import groupby
 from typing import Any
+from typing import Dict
 from typing import List
 from typing import Mapping
 from typing import Optional
+from typing import Union
 from urllib.parse import urljoin
 from urllib.parse import urlparse
 
+import humanize
 import requests
 import service_configuration_lib
 from mypy_extensions import TypedDict
@@ -641,5 +648,158 @@ def format_flink_state_and_pods(job_details: FlinkJobDetailsDict) -> List[str]:
             f"    {taskmanagers} taskmanagers,"
             f" {slots_available}/{slots_total} slots available"
         )
+
+    return output
+
+
+def get_flink_job_name(flink_job: FlinkJobDetails) -> str:
+    return flink_job["name"].split(".", 2)[-1]
+
+
+def should_job_info_be_shown(cluster_state: str) -> bool:
+    return cluster_state in ("running", "stoppingsupervisor", "cleanupsupervisor")
+
+
+async def _fetch_flink_job_details(
+    service: str, instance: str, job_ids: List[str], client: PaastaOApiClient
+) -> List[FlinkJobDetails]:
+    jobs_details = await asyncio.gather(
+        *[
+            get_flink_job_details_from_paasta_api_client(
+                service, instance, job_id, client
+            )
+            for job_id in job_ids
+        ]
+    )
+    return list(jobs_details)
+
+
+async def _fetch_flink_job_checkpoints(
+    service: str, instance: str, job_ids: List[str], client: PaastaOApiClient
+) -> Dict[str, Union[FlinkCheckpointStatus, BaseException]]:
+    """Fetch checkpoint status for all jobs in parallel, return dict keyed by job_id."""
+    results = await asyncio.gather(
+        *[
+            get_flink_job_checkpoints_from_paasta_api_client(
+                service, instance, job_id, client
+            )
+            for job_id in job_ids
+        ],
+        return_exceptions=True,
+    )
+    return dict(zip(job_ids, results))
+
+
+def format_flink_jobs_table(
+    jobs: List[FlinkJobDetails],
+    job_ids: List[str],
+    checkpoint_data: Dict[str, Any],
+    dashboard_url: Optional[str],
+    verbose: int,
+) -> List[str]:
+    """Format the per-job rows table (name, state, timestamps, checkpoints)."""
+    output: List[str] = []
+
+    # Avoid cutting job name — use max length of actual job names
+    if jobs:
+        max_job_name_length = max([len(get_flink_job_name(job)) for job in jobs])
+    else:
+        max_job_name_length = 10
+
+    # Apart from this column total length of one row is around 52 columns, using remaining terminal columns for job name
+    # Note: for terminals smaller than 90 columns the row will overflow in verbose printing
+    allowed_max_job_name_length = min(
+        max(10, shutil.get_terminal_size().columns - 52), max_job_name_length
+    )
+
+    output.append("    Jobs:")
+    if verbose > 1:
+        output.append(
+            f'      {"Job Name": <{allowed_max_job_name_length}} State       Job ID                           Started'
+        )
+    else:
+        output.append(
+            f'      {"Job Name": <{allowed_max_job_name_length}} State       Started'
+        )
+
+    # Use only the most recent job per name
+    unique_jobs = (
+        sorted(job_list, key=lambda j: -j["start_time"])[0]  # type: ignore
+        for _, job_list in groupby(
+            sorted(
+                (j for j in jobs if j.get("name") and j.get("start_time")),
+                key=lambda j: j["name"],
+            ),
+            lambda j: j["name"],
+        )
+    )
+
+    allowed_max_jobs_printed = 3
+    job_printed_count = 0
+
+    for job in unique_jobs:
+        job_id = job["jid"]
+        if verbose > 1:
+            fmt = """      {job_name: <{allowed_max_job_name_length}.{allowed_max_job_name_length}} {state: <11} {job_id} {start_time}
+        {dashboard_url}"""
+        else:
+            fmt = "      {job_name: <{allowed_max_job_name_length}.{allowed_max_job_name_length}} {state: <11} {start_time}"
+        start_time = datetime.fromtimestamp(int(job["start_time"]) // 1000)
+        if verbose or job_printed_count < allowed_max_jobs_printed:
+            job_printed_count += 1
+            color_fn = (
+                PaastaColors.green
+                if job.get("state") and job.get("state") == "RUNNING"
+                else (
+                    PaastaColors.red
+                    if job.get("state") and job.get("state") in ("FAILED", "FAILING")
+                    else PaastaColors.yellow
+                )
+            )
+            job_info_str = fmt.format(
+                job_id=job_id,
+                job_name=get_flink_job_name(job),
+                allowed_max_job_name_length=allowed_max_job_name_length,
+                state=color_fn((job.get("state").title() or "Unknown")),
+                start_time=f"{str(start_time)} ({humanize.naturaltime(start_time)})",
+                dashboard_url=PaastaColors.grey(f"{dashboard_url}/#/jobs/{job_id}"),
+            )
+            output.append(job_info_str)
+            if verbose > 1 and job_id in checkpoint_data:
+                ckpt = checkpoint_data[job_id]
+                if (
+                    not isinstance(ckpt, Exception)
+                    and hasattr(ckpt, "counts")
+                    and ckpt.counts is not None
+                ):
+                    counts = ckpt.counts
+                    output.append(
+                        f"        Checkpoints:"
+                        f" {counts['completed']} completed,"
+                        f" {counts['failed']} failed,"
+                        f" {counts['in_progress']} in progress,"
+                        f" {counts['restored']} restored"
+                    )
+            if verbose > 1 and job.get("timestamps"):
+                restarting_ts = job["timestamps"].get("RESTARTING", 0)
+                if restarting_ts and restarting_ts > 0:
+                    try:
+                        last_restart = datetime.fromtimestamp(
+                            int(restarting_ts) // 1000
+                        )
+                        output.append(
+                            f"        Last restart:"
+                            f" {last_restart}"
+                            f" ({humanize.naturaltime(last_restart)})"
+                        )
+                    except (ValueError, TypeError, OSError):
+                        pass  # timestamps are informational
+        else:
+            output.append(
+                PaastaColors.yellow(
+                    f"    Only showing {allowed_max_jobs_printed} Flink jobs, use -v to show all"
+                )
+            )
+            break
 
     return output

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -762,7 +762,9 @@ def format_flink_jobs_table(
                 allowed_max_job_name_length=allowed_max_job_name_length,
                 state=color_fn((job.get("state").title() or "Unknown")),
                 start_time=f"{str(start_time)} ({humanize.naturaltime(start_time)})",
-                dashboard_url=PaastaColors.grey(f"{dashboard_url}/#/jobs/{job_id}"),
+                dashboard_url=PaastaColors.grey(f"{dashboard_url}/#/jobs/{job_id}")
+                if dashboard_url
+                else "",
             )
             output.append(job_info_str)
             if verbose > 1 and job_id in checkpoint_data:

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -97,6 +97,11 @@ class FlinkJobDetailsDict(TypedDict):
     overview_available: bool
 
 
+class FlinkClusterStatusDict(TypedDict):
+    state: str
+    pod_status: List[Mapping[str, Any]]
+
+
 class FlinkInstanceDetails(TypedDict):
     config_sha: str
     version: str
@@ -538,7 +543,7 @@ def format_flink_monitoring_links(
 
 
 def collect_flink_job_details(
-    status: Mapping[str, Any],
+    status: FlinkClusterStatusDict,
     overview: Optional[FlinkClusterOverview],
     jobs: List[FlinkJobDetails],
 ) -> FlinkJobDetailsDict:

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -36,7 +36,6 @@ from paasta_tools.cli.cmds.status import build_smartstack_backends_table
 from paasta_tools.cli.cmds.status import desired_state_human
 from paasta_tools.cli.cmds.status import format_kubernetes_pod_table
 from paasta_tools.cli.cmds.status import format_kubernetes_replicaset_table
-from paasta_tools.cli.cmds.status import get_flink_job_name
 from paasta_tools.cli.cmds.status import get_instance_state
 from paasta_tools.cli.cmds.status import get_smartstack_status_human
 from paasta_tools.cli.cmds.status import get_versions_table
@@ -53,6 +52,7 @@ from paasta_tools.cli.cmds.status import recent_container_restart
 from paasta_tools.cli.cmds.status import report_invalid_whitelist_values
 from paasta_tools.cli.utils import NoSuchService
 from paasta_tools.cli.utils import PaastaColors
+from paasta_tools.flink_tools import get_flink_job_name
 from paasta_tools.paastaapi import ApiException
 from paasta_tools.utils import DeploymentVersion
 from paasta_tools.utils import remove_ansi_escape_sequences


### PR DESCRIPTION
Ticket: https://jira.yelpcorp.com/browse/FLINK-5911

Refactors the monolithic _print_flink_status_from_job_manager() function (~335 lines) in status.py into modular, independently testable functions in flink_tools.py.

Part 3 of 4. Extracts the jobs table formatting and async fetch helpers out of \`status.py\` into \`flink_tools.py\`.

Also addresses feedback from PR 2 (#4284):
- \`format_flink_instance_header\` docstring simplified
- Guard \`dashboard_url=None\` in verbose job URL line — avoids printing \`None/#/jobs/...\` when dashboard annotation is absent
- \`FlinkClusterStatusDict\` TypedDict added for the \`status\` param of \`collect_flink_job_details\` (\`pod_status\` remains \`List[Mapping[str, Any]]\` — full pod TypedDict deferred until \`append_pod_status\` also moves)

### Changes

**\`paasta_tools/flink_tools.py\`**
- \`FlinkClusterStatusDict\` TypedDict — \`state: str\`, \`pod_status: List[Mapping[str, Any]]\`
- \`get_flink_job_name(flink_job)\` — moved from \`status.py\`
- \`should_job_info_be_shown(cluster_state)\` — moved from \`status.py\`, added type hint
- \`_fetch_flink_job_details(service, instance, job_ids, client)\` — async, moved from \`status.py\`
- \`_fetch_flink_job_checkpoints(service, instance, job_ids, client)\` — async, moved from \`status.py\`
- \`format_flink_jobs_table(jobs, job_ids, checkpoint_data, dashboard_url, verbose)\` — encapsulates the full jobs table loop including checkpoints and restart timestamps

**\`paasta_tools/cli/cmds/status.py\`**
- Replaced ~100 lines of jobs table logic with \`flink_tools.format_flink_jobs_table()\` call
- Removed \`asyncio\`, \`shutil\`, \`groupby\`, \`FlinkCheckpointStatus\` imports (no longer needed)

**\`tests/cli/test_cmds_status.py\`**
- Updated \`get_flink_job_name\` import to \`flink_tools\`


### Paasta status output test

```
(py310-linux) nathanleigh@dev55-uswest1adevc:~/source/paasta$ .tox/py310-linux/bin/paasta status -s beam_happyhour -c pnw-devc -i main -vvv


beam_happyhour.main in pnw-devc (EKS)
    Version:    DeploymentVersion(sha=f66b1c1d, image_version=20260327T041614) (desired)
    Config SHA: d3574868
    Flink version: 1.13.5 0ff28a7 @ 2021-12-14T23:26:04+01:00
    URL: http://flink.eks.pnw-devc.paasta:31080/beam--happyhour-7f797b79f6/
    Repo(git): https://github.yelpcorp.com/services/beam_happyhour
    Repo(sourcegraph): https://sourcegraph.yelpcorp.com/services/beam_happyhour
    Flink Pool: flink-spot
    Owner: core-streaming
    Flink Runbook: y/todo
    Yelpsoa configs: https://github.yelpcorp.com/sysgit/yelpsoa-configs/tree/master/beam_happyhour
    Srv configs: https://github.yelpcorp.com/sysgit/srv-configs/tree/master/ecosystem/devc/beam_happyhour
==================================================================
    Flink Log Commands:
      Service:     paasta logs -a 1h -c pnw-devc -s beam_happyhour -i main
      Taskmanager: paasta logs -a 1h -c pnw-devc -s beam_happyhour -i main.TASKMANAGER
      Jobmanager:  paasta logs -a 1h -c pnw-devc -s beam_happyhour -i main.JOBMANAGER
      Supervisor:  paasta logs -a 1h -c pnw-devc -s beam_happyhour -i main.SUPERVISOR
==================================================================
    Flink Monitoring:
      Job Metrics: https://grafana.yelpcorp.com/d/flink-metrics/flink-job-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-devc&var-service=beam_happyhour&var-instance=main&var-job=All&from=now-24h&to=now
      Container Metrics: https://grafana.yelpcorp.com/d/flink-container-metrics/flink-container-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-devc&var-service=beam_happyhour&var-instance=main&from=now-24h&to=now
      JVM Metrics: https://grafana.yelpcorp.com/d/flink-jvm-metrics/flink-jvm-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-devc&var-service=beam_happyhour&var-instance=main&from=now-24h&to=now
      Flink Cost: https://app.cloudzero.com/explorer?activeCostType=invoiced_amortized_cost&partitions=costcontext%3AResource%20Summary&dateRange=Last%2030%20Days&costcontext%3AKube%20Paasta%20Cluster=pnw-devc&costcontext%3APaasta%20Instance=main&costcontext%3APaasta%20Service=beam_happyhour&showRightFlyout=filters
==================================================================
    State: Running
    Pods: 3 running, 0 evicted, 0 other, 3 total
    Jobs: 1 running, 0 finished, 0 failed, 0 cancelled, 1 total
    1 taskmanagers, 2/24 slots available
    Jobs:
      Job Name State       Job ID                           Started
      test_job Running 26c1a43ec5d7a9d4d22a32a76c1e5f77 2026-04-06 18:03:03 (9 hours ago)
        http://flink.eks.pnw-devc.paasta:31080/beam--happyhour-7f797b79f6/#/jobs/26c1a43ec5d7a9d4d22a32a76c1e5f77
        Checkpoints: 565 completed, 0 failed, 0 in progress, 1 restored
    Pods:
      Pod Name                                                 Host                                        Phase    Uptime
      beam--happyhour-7f797b79f6-jobmanager-d588f887b-l5xfg    ip-10-81-17-179.us-west-2.compute.internal  Running  0d9h51m19s
      beam--happyhour-7f797b79f6-supervisor-9r745              ip-10-81-17-226.us-west-2.compute.internal  Running  0d12h1m20s
      beam--happyhour-7f797b79f6-taskmanager-5986cb449c-jggdq  ip-10-81-19-51.us-west-2.compute.internal   Running  0d12h10m25s
```