### PR TITLE
FLINK-5911: Orchestrator cleanup in status.py  (PR 4/4)

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -61,9 +61,6 @@ from paasta_tools.cli.utils import validate_service_name
 from paasta_tools.cli.utils import verify_instances
 from paasta_tools.eks_tools import EksDeploymentConfig
 from paasta_tools.flink_tools import FlinkDeploymentConfig
-from paasta_tools.flink_tools import get_flink_config_from_paasta_api_client
-from paasta_tools.flink_tools import get_flink_jobs_from_paasta_api_client
-from paasta_tools.flink_tools import get_flink_overview_from_paasta_api_client
 from paasta_tools.flink_tools import load_flink_instance_config
 from paasta_tools.flinkeks_tools import FlinkEksDeploymentConfig
 from paasta_tools.flinkeks_tools import load_flinkeks_instance_config
@@ -830,7 +827,7 @@ def _print_flink_status_from_job_manager(
 
     if status["state"] == "running":
         try:
-            flink_config = get_flink_config_from_paasta_api_client(
+            flink_config = flink_tools.get_flink_config_from_paasta_api_client(
                 service=service, instance=instance, client=client
             )
         except Exception as e:
@@ -876,7 +873,7 @@ def _print_flink_status_from_job_manager(
     overview = None
     if status["state"] == "running":
         try:
-            overview = get_flink_overview_from_paasta_api_client(
+            overview = flink_tools.get_flink_overview_from_paasta_api_client(
                 service=service, instance=instance, client=client
             )
         except Exception as e:
@@ -900,7 +897,7 @@ def _print_flink_status_from_job_manager(
     flink_jobs.jobs = []
     if status["state"] == "running":
         try:
-            flink_jobs = get_flink_jobs_from_paasta_api_client(
+            flink_jobs = flink_tools.get_flink_jobs_from_paasta_api_client(
                 service=service, instance=instance, client=client
             )
         except Exception as e:

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -907,7 +907,7 @@ def _print_flink_status_from_job_manager(
             except Exception:
                 pass  # checkpoints are informational, don't fail status
 
-    job_details = flink_tools.collect_flink_job_details(status, overview, [])
+    job_details = flink_tools.collect_flink_job_details(status, overview)
     output.extend(flink_tools.format_flink_state_and_pods(job_details))
 
     if not flink_tools.should_job_info_be_shown(status["state"]):

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -75,7 +75,6 @@ from paasta_tools.monitoring_tools import list_teams
 from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
 from paasta_tools.paastaapi.model.flink_checkpoint_status import FlinkCheckpointStatus
 from paasta_tools.paastaapi.model.flink_job_details import FlinkJobDetails
-from paasta_tools.paastaapi.model.flink_jobs import FlinkJobs
 from paasta_tools.paastaapi.models import InstanceStatusKubernetesV2
 from paasta_tools.paastaapi.models import KubernetesContainerV2
 from paasta_tools.paastaapi.models import KubernetesPodV2
@@ -825,6 +824,13 @@ def _print_flink_status_from_job_manager(
     config_sha = labels.get(paasta_prefixed("config_sha"), "").removeprefix("config")
     output.append(f"    Config SHA: {config_sha}")
 
+    # Initialize all vars upfront; populated only when cluster is running
+    dashboard_url = None
+    overview = None
+    jobs: List[FlinkJobDetails] = []
+    job_ids: List[str] = []
+    checkpoint_data: Dict[str, Union[FlinkCheckpointStatus, BaseException]] = {}
+
     if status["state"] == "running":
         try:
             flink_config = flink_tools.get_flink_config_from_paasta_api_client(
@@ -865,13 +871,7 @@ def _print_flink_status_from_job_manager(
                 )
             )
             output.append(OUTPUT_HORIZONTAL_RULE)
-    else:
-        dashboard_url = None
 
-    # Fetch overview only when running; pass None otherwise so collect_flink_job_details
-    # can distinguish "not running" from "running but jobmanager not responding"
-    overview = None
-    if status["state"] == "running":
         try:
             overview = flink_tools.get_flink_overview_from_paasta_api_client(
                 service=service, instance=instance, client=client
@@ -880,6 +880,32 @@ def _print_flink_status_from_job_manager(
             output.append(PaastaColors.red("Exception when talking to the API:"))
             output.append(str(e))
             return 1
+
+        try:
+            flink_jobs = flink_tools.get_flink_jobs_from_paasta_api_client(
+                service=service, instance=instance, client=client
+            )
+            if flink_jobs.get("jobs"):
+                job_ids = [job.id for job in flink_jobs.get("jobs")]
+            jobs = run_sync(
+                flink_tools.fetch_flink_job_details, service, instance, job_ids, client
+            )
+        except Exception as e:
+            output.append(PaastaColors.red("Exception when talking to the API:"))
+            output.append(str(e))
+            return 1
+
+        if verbose > 1 and job_ids:
+            try:
+                checkpoint_data = run_sync(
+                    flink_tools.fetch_flink_job_checkpoints,
+                    service,
+                    instance,
+                    job_ids,
+                    client,
+                )
+            except Exception:
+                pass  # checkpoints are informational, don't fail status
 
     job_details = flink_tools.collect_flink_job_details(status, overview, [])
     output.extend(flink_tools.format_flink_state_and_pods(job_details))
@@ -892,44 +918,6 @@ def _print_flink_status_from_job_manager(
             append_pod_status(status["pod_status"], output)
         output.append("    No other information available in non-running state")
         return 0
-
-    flink_jobs = FlinkJobs()
-    flink_jobs.jobs = []
-    if status["state"] == "running":
-        try:
-            flink_jobs = flink_tools.get_flink_jobs_from_paasta_api_client(
-                service=service, instance=instance, client=client
-            )
-        except Exception as e:
-            output.append(PaastaColors.red("Exception when talking to the API:"))
-            output.append(str(e))
-            return 1
-
-    jobs: List[FlinkJobDetails] = []
-    job_ids: List[str] = []
-    if flink_jobs.get("jobs"):
-        job_ids = [job.id for job in flink_jobs.get("jobs")]
-    try:
-        jobs = run_sync(
-            flink_tools.fetch_flink_job_details, service, instance, job_ids, client
-        )
-    except Exception as e:
-        output.append(PaastaColors.red("Exception when talking to the API:"))
-        output.append(str(e))
-        return 1
-
-    checkpoint_data: Dict[str, Union[FlinkCheckpointStatus, BaseException]] = {}
-    if verbose > 1 and job_ids:
-        try:
-            checkpoint_data = run_sync(
-                flink_tools.fetch_flink_job_checkpoints,
-                service,
-                instance,
-                job_ids,
-                client,
-            )
-        except Exception:
-            pass  # checkpoints are informational, don't fail status
 
     output.extend(
         flink_tools.format_flink_jobs_table(

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -76,6 +76,7 @@ from paasta_tools.kubernetes_tools import paasta_prefixed
 from paasta_tools.monitoring_tools import get_team
 from paasta_tools.monitoring_tools import list_teams
 from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
+from paasta_tools.paastaapi.model.flink_checkpoint_status import FlinkCheckpointStatus
 from paasta_tools.paastaapi.model.flink_job_details import FlinkJobDetails
 from paasta_tools.paastaapi.model.flink_jobs import FlinkJobs
 from paasta_tools.paastaapi.models import InstanceStatusKubernetesV2
@@ -920,7 +921,7 @@ def _print_flink_status_from_job_manager(
         output.append(str(e))
         return 1
 
-    checkpoint_data: Dict[str, Any] = {}
+    checkpoint_data: Dict[str, Union[FlinkCheckpointStatus, BaseException]] = {}
     if verbose > 1 and job_ids:
         try:
             checkpoint_data = run_sync(

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -911,7 +911,7 @@ def _print_flink_status_from_job_manager(
         job_ids = [job.id for job in flink_jobs.get("jobs")]
     try:
         jobs = run_sync(
-            flink_tools._fetch_flink_job_details, service, instance, job_ids, client
+            flink_tools.fetch_flink_job_details, service, instance, job_ids, client
         )
     except Exception as e:
         output.append(PaastaColors.red("Exception when talking to the API:"))
@@ -922,7 +922,7 @@ def _print_flink_status_from_job_manager(
     if verbose > 1 and job_ids:
         try:
             checkpoint_data = run_sync(
-                flink_tools._fetch_flink_job_checkpoints,
+                flink_tools.fetch_flink_job_checkpoints,
                 service,
                 instance,
                 job_ids,

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -921,7 +921,7 @@ def _print_flink_status_from_job_manager(
 
     output.extend(
         flink_tools.format_flink_jobs_table(
-            jobs, job_ids, checkpoint_data, dashboard_url, verbose
+            jobs, dashboard_url, verbose, checkpoint_data=checkpoint_data
         )
     )
 

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -665,7 +665,7 @@ def should_job_info_be_shown(cluster_state: str) -> bool:
     return cluster_state in ("running", "stoppingsupervisor", "cleanupsupervisor")
 
 
-async def _fetch_flink_job_details(
+async def fetch_flink_job_details(
     service: str, instance: str, job_ids: List[str], client: PaastaOApiClient
 ) -> List[FlinkJobDetails]:
     jobs_details = await asyncio.gather(
@@ -679,7 +679,7 @@ async def _fetch_flink_job_details(
     return list(jobs_details)
 
 
-async def _fetch_flink_job_checkpoints(
+async def fetch_flink_job_checkpoints(
     service: str, instance: str, job_ids: List[str], client: PaastaOApiClient
 ) -> Dict[str, Union[FlinkCheckpointStatus, BaseException]]:
     """Fetch checkpoint status for all jobs in parallel, return dict keyed by job_id."""

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -662,7 +662,7 @@ def get_flink_job_name(flink_job: FlinkJobDetails) -> str:
 
 
 def should_job_info_be_shown(cluster_state: str) -> bool:
-    return cluster_state in ("running", "stoppingsupervisor", "cleanupsupervisor")
+    return cluster_state in {"running", "stoppingsupervisor", "cleanupsupervisor"}
 
 
 async def fetch_flink_job_details(

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -697,13 +697,16 @@ async def fetch_flink_job_checkpoints(
 
 def format_flink_jobs_table(
     jobs: List[FlinkJobDetails],
-    job_ids: List[str],
-    checkpoint_data: Dict[str, Union[FlinkCheckpointStatus, BaseException]],
     dashboard_url: Optional[str],
     verbose: int,
+    checkpoint_data: Optional[
+        Dict[str, Union[FlinkCheckpointStatus, BaseException]]
+    ] = None,
 ) -> List[str]:
     """Format the per-job rows table (name, state, timestamps, checkpoints)."""
     output: List[str] = []
+    if checkpoint_data is None:
+        checkpoint_data = {}
 
     # Avoid cutting job name — use max length of actual job names
     if jobs:

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -93,7 +93,6 @@ class FlinkJobDetailsDict(TypedDict):
     taskmanagers: Optional[int]
     slots_available: Optional[int]
     slots_total: Optional[int]
-    jobs: List[FlinkJobDetails]
     overview_available: bool
 
 
@@ -545,7 +544,6 @@ def format_flink_monitoring_links(
 def collect_flink_job_details(
     status: FlinkClusterStatusDict,
     overview: Optional[FlinkClusterOverview],
-    jobs: List[FlinkJobDetails],
 ) -> FlinkJobDetailsDict:
     """Collect job, pod, and resource information from status and overview."""
     pod_running_count = 0
@@ -598,7 +596,6 @@ def collect_flink_job_details(
         "taskmanagers": taskmanagers,
         "slots_available": slots_available,
         "slots_total": slots_total,
-        "jobs": jobs,
         "overview_available": overview is not None,
     }
 

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -698,7 +698,7 @@ async def _fetch_flink_job_checkpoints(
 def format_flink_jobs_table(
     jobs: List[FlinkJobDetails],
     job_ids: List[str],
-    checkpoint_data: Dict[str, Any],
+    checkpoint_data: Dict[str, Union[FlinkCheckpointStatus, BaseException]],
     dashboard_url: Optional[str],
     verbose: int,
 ) -> List[str]:

--- a/tests/test_flink_tools.py
+++ b/tests/test_flink_tools.py
@@ -684,3 +684,89 @@ class TestFormatFlinkStateAndPods:
         slots_line = next(line for line in result if "taskmanagers" in line)
         assert "1 taskmanagers" in slots_line
         assert "2/8 slots available" in slots_line
+
+
+@mock.patch("paasta_tools.flink_tools.shutil.get_terminal_size")
+class TestFormatFlinkJobsTable:
+    def _make_job(self, fields):
+        defaults = {
+            "jid": "abc123",
+            "name": "beam.main.test_job",
+            "state": "RUNNING",
+            "start_time": 1655053223341.0,
+            "timestamps": {},
+        }
+        defaults.update(fields)
+        return defaults
+
+    def test_verbose_shows_job_id(self, mock_terminal_size):
+        mock_terminal_size.return_value = mock.Mock(columns=120)
+        job = self._make_job({"jid": "abc123def456"})
+        result = flink_tools.format_flink_jobs_table([job], "http://dashboard", 2)
+        output_text = "\n".join(result)
+        assert "Job ID" in output_text
+        assert "abc123def456" in output_text
+
+    def test_non_verbose_limits_to_3_jobs(self, mock_terminal_size):
+        mock_terminal_size.return_value = mock.Mock(columns=120)
+        jobs = [
+            self._make_job(
+                {
+                    "jid": f"id_job{i}",
+                    "name": f"beam.main.job{i}",
+                    "start_time": 1000000000000.0 + i * 1000000,
+                }
+            )
+            for i in range(4)
+        ]
+        result = flink_tools.format_flink_jobs_table(jobs, "http://dashboard", 0)
+        output_text = "\n".join(result)
+        assert "Only showing 3" in output_text
+
+    def test_verbose_shows_all_jobs(self, mock_terminal_size):
+        mock_terminal_size.return_value = mock.Mock(columns=120)
+        jobs = [
+            self._make_job(
+                {
+                    "jid": f"id_job{i}",
+                    "name": f"beam.main.job{i}",
+                    "start_time": 1000000000000.0 + i * 1000000,
+                }
+            )
+            for i in range(4)
+        ]
+        result = flink_tools.format_flink_jobs_table(jobs, "http://dashboard", 1)
+        output_text = "\n".join(result)
+        assert "Only showing" not in output_text
+        assert "job3" in output_text
+
+    def test_failed_job_state(self, mock_terminal_size):
+        from paasta_tools.utils import PaastaColors
+
+        mock_terminal_size.return_value = mock.Mock(columns=120)
+        job = self._make_job({"state": "FAILED"})
+        result = flink_tools.format_flink_jobs_table([job], "http://dashboard", 0)
+        output_text = "\n".join(result)
+        assert PaastaColors.red("Failed") in output_text
+
+    def test_checkpoint_and_restart_display(self, mock_terminal_size):
+        mock_terminal_size.return_value = mock.Mock(columns=120)
+        job = self._make_job({"timestamps": {"RESTARTING": 1655842393301.0}})
+        ckpt = mock.Mock()
+        ckpt.counts = {"completed": 100, "failed": 2, "in_progress": 1, "restored": 0}
+        result = flink_tools.format_flink_jobs_table(
+            [job], "http://dashboard", 2, checkpoint_data={"abc123": ckpt}
+        )
+        output_text = "\n".join(result)
+        assert (
+            "Checkpoints: 100 completed, 2 failed, 1 in progress, 0 restored"
+            in output_text
+        )
+        assert "Last restart:" in output_text
+
+    def test_no_dashboard_url(self, mock_terminal_size):
+        mock_terminal_size.return_value = mock.Mock(columns=120)
+        job = self._make_job({})
+        result = flink_tools.format_flink_jobs_table([job], None, 2)
+        output_text = "\n".join(result)
+        assert "None" not in output_text

--- a/tests/test_flink_tools.py
+++ b/tests/test_flink_tools.py
@@ -559,7 +559,7 @@ class TestCollectFlinkJobDetails:
         overview.slots_available = 3
         overview.slots_total = 8
 
-        result = flink_tools.collect_flink_job_details(status, overview, [])
+        result = flink_tools.collect_flink_job_details(status, overview)
 
         assert result["state"] == "running"
         assert result["pod_counts"]["running"] == 2
@@ -580,7 +580,7 @@ class TestCollectFlinkJobDetails:
         overview = mock.Mock()
         overview.jobs_running = None
 
-        result = flink_tools.collect_flink_job_details(status, overview, [])
+        result = flink_tools.collect_flink_job_details(status, overview)
 
         assert result["job_counts"] is None
         assert result["overview_available"] is True
@@ -588,7 +588,7 @@ class TestCollectFlinkJobDetails:
     def test_not_running_no_overview(self):
         status = {"state": "stopped", "pod_status": [{"phase": "Running"}]}
 
-        result = flink_tools.collect_flink_job_details(status, None, [])
+        result = flink_tools.collect_flink_job_details(status, None)
 
         assert result["job_counts"] is None
         assert result["overview_available"] is False
@@ -603,7 +603,7 @@ class TestCollectFlinkJobDetails:
                 {"phase": "Failed", "reason": "OOMKilled"},
             ],
         }
-        result = flink_tools.collect_flink_job_details(status, None, [])
+        result = flink_tools.collect_flink_job_details(status, None)
 
         assert result["pod_counts"]["other"] == 3
         assert result["pod_counts"]["evicted"] == 0


### PR DESCRIPTION
Ticket: https://jira.yelpcorp.com/browse/FLINK-5911

Part 4 of 4. Final cleanup — all Flink logic now lives in \`flink_tools.py\`; \`status.py\` is a thin orchestrator.

Also addresses feedback from PR 3 (#4285):
- \`checkpoint_data\` typed as \`Dict[str, Union[FlinkCheckpointStatus, BaseException]]\` (was \`Dict[str, Any]\`) in both \`format_flink_jobs_table\` and the call site in \`status.py\`
- \`_fetch_flink_job_details\` / \`_fetch_flink_job_checkpoints\` renamed to drop the \`_\` prefix — they are called cross-module so the private prefix was misleading
- \`should_job_info_be_shown\` uses a set literal instead of a tuple
- \`format_flink_jobs_table\` signature simplified: \`job_ids\` removed (was never used inside the function; job IDs are accessed via \`job["jid"]\`), \`checkpoint_data\` made an optional keyword arg defaulting to \`None\`
- \`TestFormatFlinkJobsTable\` test class added: verbose job ID display, 3-job non-verbose limit, verbose shows all jobs, failed state color, checkpoint/restart display, \`None\` dashboard URL guard

### Changes

**\`paasta_tools/flink_tools.py\`**
- \`format_flink_jobs_table\` signature: \`(jobs, dashboard_url, verbose, checkpoint_data=None)\`
- \`fetch_flink_job_details\` / \`fetch_flink_job_checkpoints\`: public names (no \`_\` prefix)
- \`should_job_info_be_shown\`: set literal
- \`checkpoint_data\` typed as \`Dict[str, Union[FlinkCheckpointStatus, BaseException]]\`

**\`paasta_tools/cli/cmds/status.py\`**
- Removed direct imports of \`get_flink_config/overview/jobs_from_paasta_api_client\` — now called as \`flink_tools.*\`
- Removed \`FlinkJobs\` import and \`FlinkJobs()\` fallback; \`jobs\`/\`job_ids\`/\`overview\`/\`checkpoint_data\` initialized upfront
- All API fetches (config, overview, jobs, checkpoints) consolidated into a single \`if state == "running":\` block
- \`checkpoint_data\` type annotation updated to match \`fetch_flink_job_checkpoints\` return type

**\`tests/test_flink_tools.py\`**
- \`TestFormatFlinkJobsTable\`: 6 tests covering job table rendering, job limit, verbose mode, state colors, checkpoints/restarts, missing dashboard URL