### PR TITLE
Re-enable SLO-based autorollbacks

### DIFF
--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import asyncio
+import importlib.metadata
 from unittest import mock
 from unittest.mock import ANY
 from unittest.mock import AsyncMock
@@ -19,6 +20,7 @@ from unittest.mock import MagicMock
 from unittest.mock import call
 from unittest.mock import patch
 
+import pytest
 from pytest import fixture
 from pytest import raises
 from slackclient import SlackClient
@@ -1052,3 +1054,26 @@ def test_MarkForDeployProcess_send_manual_rollback_instructions_same_version():
 
         mfdp.update_slack_thread.assert_not_called()
         mock_print.assert_not_called()
+
+
+def _slo_transcoder_installed() -> bool:
+    try:
+        importlib.metadata.distribution("slo-transcoder")
+        return True
+    except importlib.metadata.PackageNotFoundError:
+        return False
+
+
+@pytest.mark.skipif(
+    not _slo_transcoder_installed(),
+    reason="slo-transcoder not installed (not on Yelp infra)",
+)
+def test_slo_transcoder_is_importable():
+    # this test only makes sense on yelpy boxes that have slo_transcoder installed
+    # ... and it will catch shenanigans like being unable to load slo_transcoder
+    # ... since we otherwise throw any exceptions into the void
+    # e.g., at one point this was broken due to a Python upgrade breaking a transitive
+    # dependency's importability in a way that we couldn't see without a debugger/LLM
+    from sticht.rollbacks.slo import SLO_TRANSCODER_LOADED
+
+    assert SLO_TRANSCODER_LOADED is True

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -22,7 +22,7 @@ pygpgme==0.3                        # vault-tools dependency
 pyjwt==2.9.0                        # okta-auth dependency
 pyopenssl==19.0.0                   # vault-tools dependency
 PySubnetTree==0.34                  # yelp-lib dependency
-python-jsonschema-objects==0.3.1    # slo-transcoder dependency
+python-jsonschema-objects==0.4.1    # slo-transcoder dependency
 saml-helper==3.1.2                  # okta-auth dependency
 scribereader==1.1.1
 signalform-tools==0.0.16            # slo-transcoder dependency


### PR DESCRIPTION
This is a tiny bit silly :p

SLO-based autorollbacks have been silently broken since Yelp/paasta#4065 - python-jsonschema-objects==0.3.1 tries to import some types from `collections`, but some of those types were moved to `collections.abc` in 3.10.

However...as we do a blanket try-except with no logging - we totally missed this breakage as the only way to see this is to first notice that these SLO rollbacks are missing (usage of these is pretty spotty given some known issues) and then either hook up a debugger or point an LLM to mark-for-deployment to debug as this is otherwise a completely silent failure :p

I've gone ahead and bumped python-jsonschema-objects to a version compatible with 3.10 and added a somewhat silly test to ensure that slo_transcoder is loadable - this test is skipped if slo_transcoder is not installed (i.e., if you're running the tests outside of Yelp)

Once I bumped this package, I was able to see autorollbacks working for my test service as expected :D