### PR TITLE
Fix pre-commit rerun on new devboxes

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -76,7 +76,7 @@ whitelist_externals = bash
 commands =
     check-requirements -vv
     pre-commit install -f --install-hooks
-    bash -c 'pre-commit run --all-files || (if [[ $HOSTNAME =~ dev.* ]]; then echo "Re-running pre-commit since this is a dev box"; pre-commit run --all-files; else false; fi)'
+    bash -c 'FQDN=$(hostname -f); pre-commit run --all-files || (if [[ $HOSTNAME =~ dev.* || $FQDN =~ \.devbox\.yelpcorp\.com$ ]]; then echo "Re-running pre-commit since this is a dev box"; pre-commit run --all-files; else false; fi)'
     mypy -p paasta_tools
     coverage erase
     coverage run -m py.test {posargs:tests}


### PR DESCRIPTION
New devboxes no longer have hostnames that start with `dev`, so this updates our one check that depended on this naming pattern to validate the fqdn instead. 