### PR TITLE
AIRFLOW-3: Add a new extra-namespaces option to paasta secrets to support secret syncing without adding paasta instances

### DIFF
--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -209,6 +209,7 @@ def _add_and_update_args(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--extra-namespaces",
         default=None,
+        type=lambda v: v.split(",") if v else [],
         help=(
             "A comma-separated list of additional Kubernetes namespaces to sync this secret to, "
             "beyond those derived from PaaSTA instance configs. "
@@ -401,12 +402,11 @@ def _get_secret_provider_for_service(
     )
 
 
-def _update_extra_namespaces(secret_path: str, extra_namespaces_arg: str) -> None:
+def _update_extra_namespaces(secret_path: str, namespaces: List[str]) -> None:
     """Update the extra_namespaces field in a secret JSON file in-place."""
     # TODO: Add metadata support to secret_provider impl (vault_tools) instead
     # vault_tools owns the normal write path for secret JSON files; this patches
     # only the extra_namespaces metadata field after the ciphertext has been written.
-    namespaces: List[str] = [n for n in extra_namespaces_arg.split(",") if n]
     with open(secret_path, "r") as f:
         data = json.load(f)
     if namespaces:

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -403,6 +403,7 @@ def _get_secret_provider_for_service(
 
 def _update_extra_namespaces(secret_path: str, extra_namespaces_arg: str) -> None:
     """Update the extra_namespaces field in a secret JSON file in-place."""
+    # TODO: Add metadata support to secret_provider impl (vault_tools) instead
     # vault_tools owns the normal write path for secret JSON files; this patches
     # only the extra_namespaces metadata field after the ciphertext has been written.
     namespaces: List[str] = [n for n in extra_namespaces_arg.split(",") if n]

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -13,11 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+import json
 import os
 import re
 import sys
 from typing import Any
 from typing import Dict
+from typing import List
 from typing import Optional
 
 from service_configuration_lib import DEFAULT_SOA_DIR
@@ -36,6 +38,7 @@ from paasta_tools.secret_tools import SHARED_SECRET_SERVICE
 from paasta_tools.secret_tools import decrypt_secret_environment_variables
 from paasta_tools.secret_tools import get_secret_provider
 from paasta_tools.utils import _log_audit
+from paasta_tools.utils import atomic_file_write
 from paasta_tools.utils import is_secrets_for_teams_enabled
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import list_services
@@ -202,6 +205,18 @@ def _add_and_update_args(parser: argparse.ArgumentParser):
         "Defaults to all clusters in which the service runs. "
         "For example: --clusters pnw-prod,nova-prod ",
     ).completer = lazy_choices_completer(list_clusters)
+
+    parser.add_argument(
+        "--extra-namespaces",
+        default=None,
+        help=(
+            "A comma-separated list of additional Kubernetes namespaces to sync this secret to, "
+            "beyond those derived from PaaSTA instance configs. "
+            "Use this for namespaces not managed by PaaSTA instances (e.g. 'mwaa'). "
+            "Pass an empty string to clear any previously set extra namespaces."
+        ),
+        metavar="NAMESPACES",
+    )
 
 
 def _add_vault_auth_args(parser: argparse.ArgumentParser):
@@ -386,6 +401,22 @@ def _get_secret_provider_for_service(
     )
 
 
+def _update_extra_namespaces(secret_path: str, extra_namespaces_arg: str) -> None:
+    """Update the extra_namespaces field in a secret JSON file in-place."""
+    # vault_tools owns the normal write path for secret JSON files; this patches
+    # only the extra_namespaces metadata field after the ciphertext has been written.
+    namespaces: List[str] = [n for n in extra_namespaces_arg.split(",") if n]
+    with open(secret_path, "r") as f:
+        data = json.load(f)
+    if namespaces:
+        data["extra_namespaces"] = namespaces
+    else:
+        data.pop("extra_namespaces", None)
+    with atomic_file_write(secret_path) as f:
+        json.dump(data, f, indent=4, sort_keys=True)
+        f.write("\n")
+
+
 def paasta_secret(args):
     if args.shared:
         service = SHARED_SECRET_SERVICE
@@ -470,6 +501,8 @@ def paasta_secret(args):
         secret_path = os.path.join(
             secret_provider.secret_dir, f"{args.secret_name}.json"
         )
+        if args.extra_namespaces is not None:
+            _update_extra_namespaces(secret_path, args.extra_namespaces)
         _log_audit(
             action=f"{args.action}-secret",
             action_details={"secret_name": args.secret_name, "clusters": args.clusters},

--- a/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
+++ b/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
@@ -104,11 +104,22 @@ def parse_args() -> argparse.Namespace:
         default=DEFAULT_SOA_DIR,
         help="define a different soa config directory",
     )
-    parser.add_argument(
+    namespace_group = parser.add_mutually_exclusive_group()
+    namespace_group.add_argument(
         "-n",
         "--namespace",
         dest="namespace",
         help="Overwrite destination namespace for secrets",
+    )
+    namespace_group.add_argument(
+        "--only-extra-namespaces",
+        action="store_true",
+        dest="only_extra_namespaces",
+        help=(
+            "Instead of deriving target namespaces from instance configs, sync secrets "
+            "only to the namespaces declared in each secret's 'extra_namespaces' field. "
+            "Use this for services that have no PaaSTA instances (e.g. MWAA workloads)."
+        ),
     )
     parser.add_argument(
         "-t",
@@ -133,16 +144,6 @@ def parse_args() -> argparse.Namespace:
         default="all",
         type=str,
         help="Define which type of secret to add/update. Default is 'all' (which does not include datastore-credentials)",
-    )
-    parser.add_argument(
-        "--only-extra-namespaces",
-        action="store_true",
-        dest="only_extra_namespaces",
-        help=(
-            "Instead of deriving target namespaces from instance configs, sync secrets "
-            "only to the namespaces declared in each secret's 'extra_namespaces' field. "
-            "Use this for services that have no PaaSTA instances (e.g. MWAA workloads)."
-        ),
     )
     args = parser.parse_args()
     return args

--- a/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
+++ b/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
@@ -134,6 +134,16 @@ def parse_args() -> argparse.Namespace:
         type=str,
         help="Define which type of secret to add/update. Default is 'all' (which does not include datastore-credentials)",
     )
+    parser.add_argument(
+        "--only-extra-namespaces",
+        action="store_true",
+        dest="only_extra_namespaces",
+        help=(
+            "Instead of deriving target namespaces from instance configs, sync secrets "
+            "only to the namespaces declared in each secret's 'extra_namespaces' field. "
+            "Use this for services that have no PaaSTA instances (e.g. MWAA workloads)."
+        ),
+    )
     args = parser.parse_args()
     return args
 
@@ -181,14 +191,22 @@ def main() -> None:
     secret_provider_name = system_paasta_config.get_secret_provider_name()
     vault_cluster_config = system_paasta_config.get_vault_cluster_config()
     kube_client = KubeClient()
-    services_to_k8s_namespaces_to_allowlist = (
-        get_services_to_k8s_namespaces_to_allowlist(
-            service_list=args.service_list,
-            cluster=cluster,
-            soa_dir=args.soa_dir,
-            kube_client=kube_client,
+    if args.only_extra_namespaces:
+        services_to_k8s_namespaces_to_allowlist = (
+            get_services_to_k8s_namespaces_from_extra_namespaces(
+                service_list=args.service_list,
+                soa_dir=args.soa_dir,
+            )
         )
-    )
+    else:
+        services_to_k8s_namespaces_to_allowlist = (
+            get_services_to_k8s_namespaces_to_allowlist(
+                service_list=args.service_list,
+                cluster=cluster,
+                soa_dir=args.soa_dir,
+                kube_client=kube_client,
+            )
+        )
 
     result = sync_all_secrets(
         kube_client=kube_client,
@@ -294,6 +312,53 @@ def get_services_to_k8s_namespaces_to_allowlist(
                     services_to_k8s_namespaces_to_allowlist["_shared"][
                         INSTANCE_TYPE_TO_K8S_NAMESPACE[instance_type]
                     ] = None
+
+    return dict(services_to_k8s_namespaces_to_allowlist)
+
+
+def get_services_to_k8s_namespaces_from_extra_namespaces(
+    service_list: List[str],
+    soa_dir: str,
+) -> Dict[
+    str,  # service
+    Dict[
+        str,  # namespace
+        Optional[Set[str]],  # allowlist of secret names, None means allow all.
+    ],
+]:
+    """
+    Build a service -> namespace -> allowlist mapping by scanning secret JSON files
+    for the 'extra_namespaces' field, rather than deriving namespaces from instance configs.
+
+    Only secrets that declare 'extra_namespaces' are included. Each such secret is added
+    to the allowlist for each namespace it declares. This is intended for use with
+    --only-extra-namespaces, for services that have no PaaSTA instances (e.g. MWAA workloads)
+    but still need secrets synced to specific namespaces.
+    """
+    services_to_k8s_namespaces_to_allowlist: Dict[
+        str, Dict[str, Optional[Set[str]]]
+    ] = defaultdict(dict)
+
+    for service in service_list:
+        secret_dir = os.path.join(soa_dir, service, "secrets")
+        if not os.path.isdir(secret_dir):
+            log.debug(f"No secrets dir for {service}, skipping extra_namespaces scan")
+            continue
+
+        with os.scandir(secret_dir) as secret_file_paths:
+            for secret_file_path in secret_file_paths:
+                if not secret_file_path.path.endswith(".json"):
+                    continue
+                with open(secret_file_path, "r") as f:
+                    data = json.load(f)
+                extra_namespaces = data.get("extra_namespaces", [])
+                if not extra_namespaces:
+                    continue
+                secret_name = secret_file_path.name[: -len(".json")]
+                for namespace in extra_namespaces:
+                    services_to_k8s_namespaces_to_allowlist[service].setdefault(
+                        namespace, set()
+                    ).add(secret_name)
 
     return dict(services_to_k8s_namespaces_to_allowlist)
 

--- a/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
+++ b/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
@@ -355,7 +355,7 @@ def get_services_to_k8s_namespaces_from_extra_namespaces(
                 extra_namespaces = data.get("extra_namespaces", [])
                 if not extra_namespaces:
                     continue
-                secret_name = secret_file_path.name[: -len(".json")]
+                secret_name = secret_file_path.name.removesuffix(".json")
                 for namespace in extra_namespaces:
                     services_to_k8s_namespaces_to_allowlist[service].setdefault(
                         namespace, set()

--- a/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
+++ b/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
@@ -526,7 +526,7 @@ def sync_secrets(
     with os.scandir(secret_dir) as secret_file_paths:
         for secret_file_path in secret_file_paths:
             if secret_file_path.path.endswith("json"):
-                secret = secret_file_path.name.replace(".json", "")
+                secret = secret_file_path.name.removesuffix(".json")
                 if secret_allowlist is not None:
                     if secret not in secret_allowlist:
                         log.debug(

--- a/tests/cli/test_cmds_secret.py
+++ b/tests/cli/test_cmds_secret.py
@@ -363,7 +363,7 @@ def test_update_extra_namespaces_set(tmp_path):
     secret_path = tmp_path / "my-secret.json"
     secret_path.write_text('{"environments": {}}')
 
-    secret._update_extra_namespaces(str(secret_path), "mwaa,other-ns")
+    secret._update_extra_namespaces(str(secret_path), ["mwaa", "other-ns"])
 
     data = json.loads(secret_path.read_text())
     assert data["extra_namespaces"] == ["mwaa", "other-ns"]
@@ -373,7 +373,7 @@ def test_update_extra_namespaces_update(tmp_path):
     secret_path = tmp_path / "my-secret.json"
     secret_path.write_text('{"extra_namespaces": ["old-ns"], "environments": {}}')
 
-    secret._update_extra_namespaces(str(secret_path), "mwaa")
+    secret._update_extra_namespaces(str(secret_path), ["mwaa"])
 
     data = json.loads(secret_path.read_text())
     assert data["extra_namespaces"] == ["mwaa"]
@@ -383,7 +383,7 @@ def test_update_extra_namespaces_clear(tmp_path):
     secret_path = tmp_path / "my-secret.json"
     secret_path.write_text('{"extra_namespaces": ["mwaa"], "environments": {}}')
 
-    secret._update_extra_namespaces(str(secret_path), "")
+    secret._update_extra_namespaces(str(secret_path), [])
 
     data = json.loads(secret_path.read_text())
     assert "extra_namespaces" not in data

--- a/tests/cli/test_cmds_secret.py
+++ b/tests/cli/test_cmds_secret.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import json
 from argparse import ArgumentTypeError
 from unittest import mock
 
@@ -165,6 +166,7 @@ def test_paasta_secret():
             clusters="mesosstage",
             shared=False,
             cross_env_motivation="because ...",
+            extra_namespaces=None,
         )
         secret.paasta_secret(mock_args)
         mock_get_secret_provider_for_service.assert_called_with(
@@ -192,6 +194,7 @@ def test_paasta_secret():
             clusters="mesosstage",
             shared=False,
             cross_env_motivation=None,
+            extra_namespaces=None,
         )
         secret.paasta_secret(mock_args)
         mock_get_secret_provider_for_service.assert_called_with(
@@ -278,6 +281,7 @@ def test_paasta_secret():
             service=None,
             clusters="mesosstage",
             shared=True,
+            extra_namespaces=None,
         )
         secret.paasta_secret(mock_args)
         mock_get_secret_provider_for_service.assert_called_with(
@@ -301,6 +305,7 @@ def test_paasta_secret():
             service=None,
             clusters=None,
             shared=True,
+            extra_namespaces=None,
         )
         with raises(SystemExit):
             secret.paasta_secret(mock_args)
@@ -352,3 +357,33 @@ def test_paasta_secret_run():
         assert (
             mock_exec.call_args[0][2].get("PAASTA_SECRET_TEST") == "test secret value"
         )
+
+
+def test_update_extra_namespaces_set(tmp_path):
+    secret_path = tmp_path / "my-secret.json"
+    secret_path.write_text('{"environments": {}}')
+
+    secret._update_extra_namespaces(str(secret_path), "mwaa,other-ns")
+
+    data = json.loads(secret_path.read_text())
+    assert data["extra_namespaces"] == ["mwaa", "other-ns"]
+
+
+def test_update_extra_namespaces_update(tmp_path):
+    secret_path = tmp_path / "my-secret.json"
+    secret_path.write_text('{"extra_namespaces": ["old-ns"], "environments": {}}')
+
+    secret._update_extra_namespaces(str(secret_path), "mwaa")
+
+    data = json.loads(secret_path.read_text())
+    assert data["extra_namespaces"] == ["mwaa"]
+
+
+def test_update_extra_namespaces_clear(tmp_path):
+    secret_path = tmp_path / "my-secret.json"
+    secret_path.write_text('{"extra_namespaces": ["mwaa"], "environments": {}}')
+
+    secret._update_extra_namespaces(str(secret_path), "")
+
+    data = json.loads(secret_path.read_text())
+    assert "extra_namespaces" not in data

--- a/tests/kubernetes/bin/test_paasta_secrets_sync.py
+++ b/tests/kubernetes/bin/test_paasta_secrets_sync.py
@@ -7,6 +7,9 @@ from kubernetes.client.rest import ApiException
 
 from paasta_tools.kubernetes.bin.paasta_secrets_sync import _get_dict_signature
 from paasta_tools.kubernetes.bin.paasta_secrets_sync import (
+    get_services_to_k8s_namespaces_from_extra_namespaces,
+)
+from paasta_tools.kubernetes.bin.paasta_secrets_sync import (
     get_services_to_k8s_namespaces_to_allowlist,
 )
 from paasta_tools.kubernetes.bin.paasta_secrets_sync import main
@@ -1635,3 +1638,72 @@ def test_sync_ssm_secrets_tron_configs(ssm_patches):
     _, kwargs = mock_create_or_update.call_args
     assert kwargs["namespace"] == "tron"
     assert kwargs["get_secret_data"]() == {"TRON_VAR": "dHJvbl9zZWNyZXRfdmFsdWU="}
+
+
+def test_get_services_to_k8s_namespaces_from_extra_namespaces(tmp_path):
+    # Set up a service with two secrets: one with extra_namespaces, one without.
+    svc_dir = tmp_path / "my-service" / "secrets"
+    svc_dir.mkdir(parents=True)
+    (svc_dir / "my-secret.json").write_text(
+        '{"extra_namespaces": ["mwaa", "other-ns"], "environments": {}}'
+    )
+    (svc_dir / "plain-secret.json").write_text('{"environments": {}}')
+
+    result = get_services_to_k8s_namespaces_from_extra_namespaces(
+        service_list=["my-service"],
+        soa_dir=str(tmp_path),
+    )
+
+    assert result == {
+        "my-service": {
+            "mwaa": {"my-secret"},
+            "other-ns": {"my-secret"},
+        }
+    }
+
+
+def test_get_services_to_k8s_namespaces_from_extra_namespaces_shared(tmp_path):
+    # _shared service secrets with extra_namespaces are handled the same way.
+    svc_dir = tmp_path / "_shared" / "secrets"
+    svc_dir.mkdir(parents=True)
+    (svc_dir / "shared-secret.json").write_text(
+        '{"extra_namespaces": ["mwaa"], "environments": {}}'
+    )
+
+    result = get_services_to_k8s_namespaces_from_extra_namespaces(
+        service_list=["_shared"],
+        soa_dir=str(tmp_path),
+    )
+
+    assert result == {"_shared": {"mwaa": {"shared-secret"}}}
+
+
+def test_get_services_to_k8s_namespaces_from_extra_namespaces_no_secrets_dir(tmp_path):
+    # Services with no secrets dir produce an empty result.
+    result = get_services_to_k8s_namespaces_from_extra_namespaces(
+        service_list=["no-secrets-service"],
+        soa_dir=str(tmp_path),
+    )
+    assert result == {}
+
+
+def test_get_services_to_k8s_namespaces_from_extra_namespaces_multiple_services(
+    tmp_path,
+):
+    # Multiple services are each scanned independently.
+    for svc, ns in [("svc-a", "mwaa"), ("svc-b", "other-ns")]:
+        svc_dir = tmp_path / svc / "secrets"
+        svc_dir.mkdir(parents=True)
+        (svc_dir / "sec.json").write_text(
+            f'{{"extra_namespaces": ["{ns}"], "environments": {{}}}}'
+        )
+
+    result = get_services_to_k8s_namespaces_from_extra_namespaces(
+        service_list=["svc-a", "svc-b"],
+        soa_dir=str(tmp_path),
+    )
+
+    assert result == {
+        "svc-a": {"mwaa": {"sec"}},
+        "svc-b": {"other-ns": {"sec"}},
+    }


### PR DESCRIPTION
## Summary

  Adds support for syncing PaaSTA secrets to Kubernetes namespaces that have no PaaSTA instances (e.g. MWAA workloads). Previously the only way to get a secret into a namespace was to have a PaaSTA instance running there; now secrets can declare target namespaces directly in their JSON file.

  **Two new options:**

  - `paasta secret add/update --extra-namespaces <ns1,ns2>`: writes an `extra_namespaces` field into the secret's JSON file. Pass an empty string to clear it. Consistent with the existing `--clusters` comma-separated convention eg.
    - Note that this does sort of break conventions of only touching the json secret files thru vault_tools -- I think the more 'proper' path would be to have vault_tools support some sort of arbitrary metadata we could pass along, but for now, i think this achieves what we want
    - Just slightly clunky interface -- every time they use `paasta secret update` with `--extra-namespaces`, they need to list the *full* extra namespaces list -- it doesn't append. In addition omitting the arg doesn't delete existing extra-namespaces; user must explicitly call `paasta secret update `with --extra-namespaces ''` to unset existing ones.  This was the compromise to minimize complexity on the cli side, but happy to try something idfferent if you think it works better!
  - `paasta_secrets_sync --only-extra-namespaces`: instead of deriving target namespaces from instance configs, builds the namespace→allowlist map solely from each secret's `extra_namespaces` field. Intended for services with no PaaSTA instances. 
    - Intended invocation could be to pipe _every_ service (+_shared) to paasta_secrets_sync --only-extra-namespaces, rather than only those with particular instance types as with all our other paasta secret syncs, or if we wanted more efficiency, do some bash filtering to get only servicves w/ at least 1 secret file with an `extra_namespaces` field 🤷 

  **Implementation notes:**

  - `_update_extra_namespaces` patches the `extra_namespaces` field into an already-written secret JSON file. `vault_tools` owns the normal write path for the ciphertext; this function runs after `write_secret` returns. Uses `atomic_file_write` (write-to-temp-then-rename) consistent with `write_json_configuration_file` / `write_yaml_configuration_file` in `utils.py`, tho it wasn't originally intended to work on jsonsecret files.
  - `get_services_to_k8s_namespaces_from_extra_namespaces` returns the same `Dict[service, Dict[namespace, Optional[Set[str]]]]` shape as `get_services_to_k8s_namespaces_to_allowlist`, so `sync_all_secrets` consumes both paths unchanged. Each secret with `extra_namespaces` is added to the allowlist for each declared namespace; secrets without the field are skipped entirely.

Note that this feature would not only satisfy our AIRFLOW plans, but also help a handful of other usecases that currently have to add 'dummy' instances to get a secret synced somewhere - eg temporal secret_placeholder or cassandrar shared secrets\

  🤖 Generated with [Claude Code](https://claude.com/claude-code)