### PR TITLE
feat: remove smartstack annotation if not smartstack

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2343,10 +2343,16 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             if force_no_routable_ip
             else self.has_routable_ip(service_namespace_config, system_paasta_config)
         )
-        annotations: KubePodAnnotations = {
-            "smartstack_registrations": json.dumps(self.get_registrations()),
-            "paasta.yelp.com/routable_ip": has_routable_ip,
-        }
+        annotations: KubePodAnnotations = (
+            {
+                "smartstack_registrations": json.dumps(self.get_registrations()),
+                "paasta.yelp.com/routable_ip": has_routable_ip,
+            }
+            if service_namespace_config.is_in_smartstack()
+            else {
+                "paasta.yelp.com/routable_ip": has_routable_ip,
+            }
+        )
 
         # The HPAMetrics collector needs these annotations to tell it to pull
         # metrics from these pods
@@ -2853,10 +2859,8 @@ def get_kubernetes_services_running_here(
     services = []
     pods = get_k8s_pods()
     for pod in pods["items"]:
-        if (
-            pod["status"]["phase"] != "Running"
-            or "smartstack_registrations" not in pod["metadata"].get("annotations", {})
-            or (exclude_terminating and pod["metadata"].get("deletionTimestamp"))
+        if pod["status"]["phase"] != "Running" or (
+            exclude_terminating and pod["metadata"].get("deletionTimestamp")
         ):
             continue
         try:
@@ -2878,7 +2882,9 @@ def get_kubernetes_services_running_here(
                     port=port,
                     pod_ip=pod["status"]["podIP"],
                     registrations=json.loads(
-                        pod["metadata"]["annotations"]["smartstack_registrations"]
+                        pod["metadata"]["annotations"].get(
+                            "smartstack_registrations", "[]"
+                        )
                     ),
                     weight=weight,
                 )

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2347,11 +2347,6 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             "paasta.yelp.com/routable_ip": has_routable_ip,
         }
 
-        if service_namespace_config.is_in_smartstack():
-            annotations["smartstack_registrations"] = json.dumps(
-                self.get_registrations()
-            )
-
         # The HPAMetrics collector needs these annotations to tell it to pull
         # metrics from these pods
         # TODO: see if we can remove this as we're no longer using sfx data to scale
@@ -2476,6 +2471,9 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         }
         if service_namespace_config.is_in_smartstack():
             labels["paasta.yelp.com/weight"] = str(self.get_weight())
+            annotations["smartstack_registrations"] = json.dumps(
+                self.get_registrations()
+            )
 
         # Allow the Prometheus Operator's Pod Service Monitor for specified
         # shard to find this pod
@@ -2882,9 +2880,7 @@ def get_kubernetes_services_running_here(
                     port=port,
                     pod_ip=pod["status"]["podIP"],
                     registrations=json.loads(
-                        pod["metadata"]["annotations"].get(
-                            "smartstack_registrations", "[]"
-                        )
+                        pod["metadata"]["annotations"]["smartstack_registrations"]
                     ),
                     weight=weight,
                 )

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2343,16 +2343,14 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             if force_no_routable_ip
             else self.has_routable_ip(service_namespace_config, system_paasta_config)
         )
-        annotations: KubePodAnnotations = (
-            {
-                "smartstack_registrations": json.dumps(self.get_registrations()),
-                "paasta.yelp.com/routable_ip": has_routable_ip,
-            }
-            if service_namespace_config.is_in_smartstack()
-            else {
-                "paasta.yelp.com/routable_ip": has_routable_ip,
-            }
-        )
+        annotations: KubePodAnnotations = {
+            "paasta.yelp.com/routable_ip": has_routable_ip,
+        }
+
+        if service_namespace_config.is_in_smartstack():
+            annotations["smartstack_registrations"] = json.dumps(
+                self.get_registrations()
+            )
 
         # The HPAMetrics collector needs these annotations to tell it to pull
         # metrics from these pods
@@ -2859,8 +2857,10 @@ def get_kubernetes_services_running_here(
     services = []
     pods = get_k8s_pods()
     for pod in pods["items"]:
-        if pod["status"]["phase"] != "Running" or (
-            exclude_terminating and pod["metadata"].get("deletionTimestamp")
+        if (
+            pod["status"]["phase"] != "Running"
+            or "smartstack_registrations" not in pod["metadata"].get("annotations", {})
+            or (exclude_terminating and pod["metadata"].get("deletionTimestamp"))
         ):
             continue
         try:

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -3572,6 +3572,7 @@ def test_get_kubernetes_services_running_here():
                         },
                         "annotations": {
                             "iam.amazonaws.com/role": "",
+                            "smartstack_registrations": "[]",
                         },
                     },
                     "spec": spec,
@@ -3589,6 +3590,7 @@ def test_get_kubernetes_services_running_here():
                         },
                         "annotations": {
                             "iam.amazonaws.com/role": "",
+                            "smartstack_registrations": "[]",
                         },
                     },
                     "spec": spec,
@@ -3606,6 +3608,7 @@ def test_get_kubernetes_services_running_here():
                         },
                         "annotations": {
                             "iam.amazonaws.com/role": "",
+                            "smartstack_registrations": "[]",
                         },
                     },
                     "spec": spec,
@@ -3638,29 +3641,12 @@ def test_get_kubernetes_services_running_here():
                 registrations=[],
                 weight=10,
             ),
-            KubernetesServiceRegistration(
-                name="kurupt",
-                instance="beats",
-                port=8888,
-                pod_ip="10.1.1.1",
-                registrations=[],
-                weight=10,
-            ),
         ]
 
         # mock a terminating pod
         mock_pod_results["items"][0]["metadata"]["deletionTimestamp"] = "now"
         mock_requests_get.return_value.json.return_value = mock_pod_results
-        assert get_kubernetes_services_running_here(exclude_terminating=True) == [
-            KubernetesServiceRegistration(
-                name="kurupt",
-                instance="beats",
-                port=8888,
-                pod_ip="10.1.1.1",
-                registrations=[],
-                weight=10,
-            ),
-        ]
+        assert get_kubernetes_services_running_here(exclude_terminating=True) == []
 
         # if the kubelet is down we don't want to reconfigure nerve until it comes back
         # and we can be sure what is running or not

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1881,8 +1881,6 @@ class TestKubernetesDeploymentConfig:
             "paasta.yelp.com/managed": "true",
             "paasta.yelp.com/deploy_group": "brentford.fm",
         }
-        if in_smtstk:
-            expected_labels["paasta.yelp.com/weight"] = "10"
 
         if autoscaling_metric_provider in (
             METRICS_PROVIDER_PISCINA,
@@ -1901,11 +1899,19 @@ class TestKubernetesDeploymentConfig:
         ):
             routable_ip = "true"
 
-        expected_annotations = {
-            "smartstack_registrations": '["kurupt.fm"]',
-            "paasta.yelp.com/routable_ip": routable_ip,
-            "iam.amazonaws.com/role": "",
-        }
+        if in_smtstk:
+            expected_labels["paasta.yelp.com/weight"] = "10"
+            expected_annotations = {
+                "smartstack_registrations": '["kurupt.fm"]',
+                "paasta.yelp.com/routable_ip": routable_ip,
+                "iam.amazonaws.com/role": "",
+            }
+        else:
+            expected_annotations = {
+                "paasta.yelp.com/routable_ip": routable_ip,
+                "iam.amazonaws.com/role": "",
+            }
+
         if autoscaling_metric_provider == METRICS_PROVIDER_UWSGI:
             expected_annotations["autoscaling"] = "uwsgi"
 
@@ -3565,7 +3571,6 @@ def test_get_kubernetes_services_running_here():
                             "paasta.yelp.com/instance": "fm",
                         },
                         "annotations": {
-                            "smartstack_registrations": "[]",
                             "iam.amazonaws.com/role": "",
                         },
                     },
@@ -3583,7 +3588,6 @@ def test_get_kubernetes_services_running_here():
                             "paasta.yelp.com/instance": "garage",
                         },
                         "annotations": {
-                            "smartstack_registrations": "[]",
                             "iam.amazonaws.com/role": "",
                         },
                     },
@@ -3601,7 +3605,6 @@ def test_get_kubernetes_services_running_here():
                             "paasta.yelp.com/instance": "grindah",
                         },
                         "annotations": {
-                            "smartstack_registrations": "[]",
                             "iam.amazonaws.com/role": "",
                         },
                     },
@@ -3634,13 +3637,30 @@ def test_get_kubernetes_services_running_here():
                 pod_ip="10.1.1.3",
                 registrations=[],
                 weight=10,
-            )
+            ),
+            KubernetesServiceRegistration(
+                name="kurupt",
+                instance="beats",
+                port=8888,
+                pod_ip="10.1.1.1",
+                registrations=[],
+                weight=10,
+            ),
         ]
 
         # mock a terminating pod
         mock_pod_results["items"][0]["metadata"]["deletionTimestamp"] = "now"
         mock_requests_get.return_value.json.return_value = mock_pod_results
-        assert get_kubernetes_services_running_here(exclude_terminating=True) == []
+        assert get_kubernetes_services_running_here(exclude_terminating=True) == [
+            KubernetesServiceRegistration(
+                name="kurupt",
+                instance="beats",
+                port=8888,
+                pod_ip="10.1.1.1",
+                registrations=[],
+                weight=10,
+            ),
+        ]
 
         # if the kubelet is down we don't want to reconfigure nerve until it comes back
         # and we can be sure what is running or not
@@ -5105,7 +5125,7 @@ def test_warning_big_bounce_default_config():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "configeed84480"
+            == "config8c16e42b"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 
@@ -5198,7 +5218,7 @@ def test_warning_big_bounce_common_config():
             job_config.format_kubernetes_app().spec.template.metadata.labels[
                 "paasta.yelp.com/config_sha"
             ]
-            == "config0e657f9b"
+            == "config800d4a76"
         ), "If this fails, just change the constant in this test, but be aware that deploying this change will cause every service to bounce!"
 
 

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -3572,7 +3572,7 @@ def test_get_kubernetes_services_running_here():
                         },
                         "annotations": {
                             "iam.amazonaws.com/role": "",
-                            "smartstack_registrations": "[]",
+                            "smartstack_registrations": '["compute-infra-test-service.main"]',
                         },
                     },
                     "spec": spec,
@@ -3590,7 +3590,7 @@ def test_get_kubernetes_services_running_here():
                         },
                         "annotations": {
                             "iam.amazonaws.com/role": "",
-                            "smartstack_registrations": "[]",
+                            "smartstack_registrations": '["compute-infra-test-service.main"]',
                         },
                     },
                     "spec": spec,
@@ -3608,7 +3608,7 @@ def test_get_kubernetes_services_running_here():
                         },
                         "annotations": {
                             "iam.amazonaws.com/role": "",
-                            "smartstack_registrations": "[]",
+                            "smartstack_registrations": '["compute-infra-test-service.main"]',
                         },
                     },
                     "spec": spec,
@@ -3638,7 +3638,7 @@ def test_get_kubernetes_services_running_here():
                 instance="fm",
                 port=8888,
                 pod_ip="10.1.1.3",
-                registrations=[],
+                registrations=["compute-infra-test-service.main"],
                 weight=10,
             ),
         ]


### PR DESCRIPTION
## Issue
Currently, even if a service isn't registering in smartstack, a "smartstack_registrations" annotation will still be assigned to pods. It would be cleaner to omit it when we don't need it.

## Changes
- Removed "smartstack_registration" depending on whether it's in the smartstack or not.

Note: Since smart_stack registration is now an optional schema, this will trigger a **big bounce**