### PR TITLE
fix: shell cli autocomplete

### DIFF
--- a/paasta_tools/cli/cli.py
+++ b/paasta_tools/cli/cli.py
@@ -218,9 +218,16 @@ def parse_args(argv):
     :return: an argparse.Namespace object mapping parameter names to the inputs
              from sys.argv
     """
+    # NOTE: in "real" use, these env vars are set by
+    #paasta_tabcomplete.sh (which we plop into 
+    # usr/share/bash-completion/completions/ as our completion script)
     if "_ARGCOMPLETE" in os.environ:
+        # NOTE: COMP_LINE will be the full command so far
         comp_line = os.environ.get("COMP_LINE", "")
         comp_words = comp_line.split()
+        
+        # ...but we want to grab the subcommand since the
+        # shell can handle tab-completing `paasta` :p
         if len(comp_words) >= 2 and comp_words[1] in PAASTA_SUBCOMMANDS:
             parser = get_argparser(commands=[comp_words[1]])
         else:

--- a/paasta_tools/cli/cli.py
+++ b/paasta_tools/cli/cli.py
@@ -226,6 +226,7 @@ def parse_args(argv):
         else:
             parser = get_argparser(commands=[])
         argcomplete.autocomplete(parser)
+        return parser.parse_args(argv), parser
 
     parser = get_argparser(commands=[])
 

--- a/paasta_tools/cli/cli.py
+++ b/paasta_tools/cli/cli.py
@@ -219,13 +219,13 @@ def parse_args(argv):
              from sys.argv
     """
     # NOTE: in "real" use, these env vars are set by
-    #paasta_tabcomplete.sh (which we plop into 
+    # paasta_tabcomplete.sh (which we plop into
     # usr/share/bash-completion/completions/ as our completion script)
     if "_ARGCOMPLETE" in os.environ:
         # NOTE: COMP_LINE will be the full command so far
         comp_line = os.environ.get("COMP_LINE", "")
         comp_words = comp_line.split()
-        
+
         # ...but we want to grab the subcommand since the
         # shell can handle tab-completing `paasta` :p
         if len(comp_words) >= 2 and comp_words[1] in PAASTA_SUBCOMMANDS:

--- a/paasta_tools/cli/cli.py
+++ b/paasta_tools/cli/cli.py
@@ -218,14 +218,21 @@ def parse_args(argv):
     :return: an argparse.Namespace object mapping parameter names to the inputs
              from sys.argv
     """
+    if "_ARGCOMPLETE" in os.environ:
+        comp_line = os.environ.get("COMP_LINE", "")
+        comp_words = comp_line.split()
+        if len(comp_words) >= 2 and comp_words[1] in PAASTA_SUBCOMMANDS:
+            parser = get_argparser(commands=[comp_words[1]])
+        else:
+            parser = get_argparser(commands=[])
+        argcomplete.autocomplete(parser)
+
     parser = get_argparser(commands=[])
-    argcomplete.autocomplete(parser)
 
     args, _ = parser.parse_known_args(argv)
     if args.command:
         parser = get_argparser(commands=[args.command])
 
-    argcomplete.autocomplete(parser)
     return parser.parse_args(argv), parser
 
 

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -571,7 +571,7 @@ def run_on_master(
 
 
 def lazy_choices_completer(list_func):
-    def inner(prefix):
+    def inner(prefix, **kwargs):
         options = list_func()
         return [o for o in options if o.startswith(prefix)]
 

--- a/paasta_tools/cli/utils.py
+++ b/paasta_tools/cli/utils.py
@@ -571,8 +571,8 @@ def run_on_master(
 
 
 def lazy_choices_completer(list_func):
-    def inner(prefix, **kwargs):
-        options = list_func(**kwargs)
+    def inner(prefix):
+        options = list_func()
         return [o for o in options if o.startswith(prefix)]
 
     return inner


### PR DESCRIPTION
## Issue
Currently the paasta CLI autocomplete is broken and we want to be able to tab complete services, clusters, etc.

## Changes
- Fix `list_func` doesn't take in kwargs
- Parser is built + provides autocomplete depending on the args

## Test
Works with `bash` and `zsh`