### PR TITLE
PAASTA-17887 - improving PaaSTA deployment error handling

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -3588,8 +3588,9 @@ def write_annotation_for_kubernetes_service(
 
 
 def list_all_paasta_deployments(kube_client: KubeClient) -> Sequence[KubeDeployment]:
-    """Gets deployments in all namespaces by passing the service label selector"""
-    label_selectors = "paasta.yelp.com/service"
+    """Gets deployments in all namespaces and passes the 'managed=true' label selector to
+    ensure only PaaSTA-managed deployments are returned."""
+    label_selectors = "paasta.yelp.com/managed=true"
     return list_deployments_in_all_namespaces(
         kube_client=kube_client, label_selector=label_selectors
     )

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -3880,6 +3880,12 @@ def test_list_all_paasta_deployments(addl_labels, replicas):
     )
 
     assert list_all_paasta_deployments(kube_client=mock_client) == []
+    mock_client.deployments.list_deployment_for_all_namespaces.assert_called_once_with(
+        label_selector="paasta.yelp.com/managed=true"
+    )
+    mock_client.deployments.list_stateful_set_for_all_namespaces.assert_called_once_with(
+        label_selector="paasta.yelp.com/managed=true"
+    )
     mock_items = [
         mock.Mock(
             metadata=mock.Mock(
@@ -3890,6 +3896,7 @@ def test_list_all_paasta_deployments(addl_labels, replicas):
                     "yelp.com/paasta_config_sha": "b12345",
                     "paasta.yelp.com/service": "kurupt",
                     "paasta.yelp.com/instance": "fm",
+                    "paasta.yelp.com/managed": "true",
                     "paasta.yelp.com/git_sha": "a12345",
                     "paasta.yelp.com/config_sha": "b12345",
                     **addl_labels,
@@ -3906,6 +3913,7 @@ def test_list_all_paasta_deployments(addl_labels, replicas):
                     "yelp.com/paasta_config_sha": "b12345",
                     "paasta.yelp.com/service": "kurupt",
                     "paasta.yelp.com/instance": "am",
+                    "paasta.yelp.com/managed": "true",
                     "paasta.yelp.com/git_sha": "a12345",
                     "paasta.yelp.com/config_sha": "b12345",
                     **addl_labels,
@@ -3914,6 +3922,12 @@ def test_list_all_paasta_deployments(addl_labels, replicas):
             )
         ),
     ]
+    mock_client.deployments.list_deployment_for_all_namespaces.assert_called_once_with(
+        label_selector="paasta.yelp.com/managed=true"
+    )
+    mock_client.deployments.list_stateful_set_for_all_namespaces.assert_called_once_with(
+        label_selector="paasta.yelp.com/managed=true"
+    )
 
     # Setting the number of replicas this way since spec
     # is a reserved argument for Mocks


### PR DESCRIPTION
### **Issue**
Improving error handling for PaaSTA. Can fail on deployment missing 'paasta.yelp.com/instance' label. 
### **Changes**
Updated 'list_all_paasta_deployments' to filter by both 'paasta.yelp.com/instance' and 'paasta.yelp.com/service' labels.
Updated the relevant unit test to verify the changes. 
