### PR TITLE
FLINK-5946: add UDF information for streamhouse_queries

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -855,6 +855,7 @@ def _print_flink_status_from_job_manager(
         )
 
         if verbose:
+            output.extend(flink_tools.format_flink_udf_info(flink_instance_config))
             output.extend(
                 flink_tools.format_flink_instance_metadata(instance_details, service)
             )

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -114,6 +114,8 @@ class FlinkInstanceDetails(TypedDict):
 class FlinkDeploymentConfigDict(LongRunningServiceConfigDict, total=False):
     taskmanager: TaskManagerConfig
     spot: bool
+    udf_plugin_name: str
+    udf_plugin_version: str
 
 
 class FlinkDeploymentConfig(LongRunningServiceConfig):
@@ -489,6 +491,15 @@ def format_flink_instance_header(
         output.append(f"    URL: {details['dashboard_url']}/")
 
     return output
+
+
+def format_flink_udf_info(config: FlinkDeploymentConfig) -> List[str]:
+    """Format UDF plugin info if configured."""
+    name = config.config_dict.get("udf_plugin_name")
+    if not name:
+        return []
+    version = config.config_dict.get("udf_plugin_version", "unknown")
+    return [f"    UDF plugin: {name} (version {version})"]
 
 
 def format_flink_instance_metadata(

--- a/tests/test_flink_tools.py
+++ b/tests/test_flink_tools.py
@@ -770,3 +770,32 @@ class TestFormatFlinkJobsTable:
         result = flink_tools.format_flink_jobs_table([job], None, 2)
         output_text = "\n".join(result)
         assert "None" not in output_text
+
+
+class TestFormatFlinkUdfInfo:
+    def _make_config(self, extra_config: dict) -> FlinkDeploymentConfig:
+        config_dict = FlinkDeploymentConfigDict(**extra_config)
+        return FlinkDeploymentConfig(
+            service="test_service",
+            cluster="test_cluster",
+            instance="test_instance",
+            config_dict=config_dict,
+            branch_dict=None,
+            soa_dir="/dev/null",
+        )
+
+    def test_no_udf(self):
+        config = self._make_config({})
+        assert flink_tools.format_flink_udf_info(config) == []
+
+    def test_with_udf(self):
+        config = self._make_config(
+            {"udf_plugin_name": "canary_noop", "udf_plugin_version": "1.0.1"}
+        )
+        result = flink_tools.format_flink_udf_info(config)
+        assert result == ["    UDF plugin: canary_noop (version 1.0.1)"]
+
+    def test_udf_name_only(self):
+        config = self._make_config({"udf_plugin_name": "my_udf"})
+        result = flink_tools.format_flink_udf_info(config)
+        assert result == ["    UDF plugin: my_udf (version unknown)"]


### PR DESCRIPTION
FLINK-5946 HACK-4947
With -v or higher, the information about the UDF (streamhouse_plugins user defined function) will be included on a per-cluster level in paasta status.

Testing was done locally by running local paasta status
