### PR TITLE
PEREL-5334: Add timeout_server_threshold to smartstack schema

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -1029,7 +1029,7 @@ These keys provide optional overrides for the default alerting behaviour.
           page_nonprod: true
           error_threshold_ratio: 0.02
           minimum_error_rps: 10
-          timeout_server_threshold: 0.8
+          timeout_threshold_ratio: 0.8
           default_endpoint_alerting: true
           endpoints:
             - name: GET /something
@@ -1052,7 +1052,7 @@ These keys provide optional overrides for the default alerting behaviour.
      environments. Defaults to **false**.
    - ``error_threshold_ratio``: Error threshold ratio (0-1) for errors under this namespace. Defaults to **0.01**.
    - ``minimum_error_rps``: Minimum error rate per second for errors under this namespace before an alert can be triggered, minimum is zero. Defaults to **5**.
-   - ``timeout_server_threshold``: Ratio (0-1) of ``timeout_server_ms`` at which to alert on p99 latency. Defaults to **0.8** (80%).
+   - ``timeout_threshold_ratio``: Ratio (0-1) of ``timeout_server_ms`` at which to alert on p99 latency. Defaults to **0.8** (80%).
    - ``default_endpoint_alerting``: Turn on alerts for all endpoints in this namespace. Defaults to **false**.
    - ``endpoint_error_threshold_ratio``: Error threshold ratio (0-1) for errors to any singular endpoint. Defaults to the namespace ``error_threshold_ratio`` if specified, or **0.01**.
    - ``endpoint_minimum_error_rps``: Minimum error rate per second for errors to any singular endpoint before an alert can be triggered for errors to any singular endpoint. Defaults to the namespace ``minimum_error_rps`` if specified, or **5**.

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -1029,6 +1029,7 @@ These keys provide optional overrides for the default alerting behaviour.
           page_nonprod: true
           error_threshold_ratio: 0.02
           minimum_error_rps: 10
+          timeout_server_threshold: 0.8
           default_endpoint_alerting: true
           endpoints:
             - name: GET /something
@@ -1051,6 +1052,7 @@ These keys provide optional overrides for the default alerting behaviour.
      environments. Defaults to **false**.
    - ``error_threshold_ratio``: Error threshold ratio (0-1) for errors under this namespace. Defaults to **0.01**.
    - ``minimum_error_rps``: Minimum error rate per second for errors under this namespace before an alert can be triggered, minimum is zero. Defaults to **5**.
+   - ``timeout_server_threshold``: Ratio (0-1) of ``timeout_server_ms`` at which to alert on p99 latency. Defaults to **0.8** (80%).
    - ``default_endpoint_alerting``: Turn on alerts for all endpoints in this namespace. Defaults to **false**.
    - ``endpoint_error_threshold_ratio``: Error threshold ratio (0-1) for errors to any singular endpoint. Defaults to the namespace ``error_threshold_ratio`` if specified, or **0.01**.
    - ``endpoint_minimum_error_rps``: Minimum error rate per second for errors to any singular endpoint before an alert can be triggered for errors to any singular endpoint. Defaults to the namespace ``minimum_error_rps`` if specified, or **5**.

--- a/paasta_tools/cli/schemas/smartstack_schema.json
+++ b/paasta_tools/cli/schemas/smartstack_schema.json
@@ -272,9 +272,10 @@
                         "type": "number",
                         "minimum": 0
                     },
-                    "latency_threshold_ms": {
+                    "timeout_server_threshold": {
                         "type": "number",
-                        "minimum": 0
+                        "minimum": 0,
+                        "maximum": 1
                     },
                     "default_endpoint_alerting": {
                         "type": "boolean"
@@ -304,9 +305,6 @@
                                 "minimum_error_rps": {
                                     "type": "number",
                                     "minimum": 0
-                                },
-                                "latency_threshold": {
-                                    "type": "string"
                                 },
                                 "team": {
                                     "type": "string"

--- a/paasta_tools/cli/schemas/smartstack_schema.json
+++ b/paasta_tools/cli/schemas/smartstack_schema.json
@@ -272,7 +272,7 @@
                         "type": "number",
                         "minimum": 0
                     },
-                    "timeout_server_threshold": {
+                    "timeout_threshold_ratio": {
                         "type": "number",
                         "minimum": 0,
                         "maximum": 1


### PR DESCRIPTION
## Summary

- Add `timeout_threshold_ratio` (number, 0-1) to smartstack monitoring schema
- Document the field in yelpsoa_configs.rst
- Remove dead fields: `latency_threshold_ms` (monitoring), `latency_threshold` (endpoints)

**Jira:** https://jira.yelpcorp.com/browse/PEREL-5334
**Exporter PR:** https://github.yelpcorp.com/docker-images/yelpsoa-configs-mirror/pull/37

## Plan

The perel shard's latency alert fires when p99 latency exceeds a threshold computed as **80% of `timeout_server_ms`**. This ratio is hardcoded in the yelpsoa-configs-mirror exporter - service owners have no way to tune it without setting an absolute ms value (a field that was never adopted).

Add a new `timeout_threshold_ratio` field (0-1 ratio) to `smartstack.yaml` under `monitoring`. The exporter multiplies this by `timeout_server_ms` to produce the metric value consumed by the alert.

### Example usage

```yaml
# smartstack.yaml
main:
  proxy_port: 20000
  timeout_server_ms: 60000
  monitoring:
    timeout_threshold_ratio: 0.5   # alert at 50% of 60s = 30s
```

If not specified, defaults to `0.8` (current behavior, unchanged).

### Scope of changes

| Repo | File | Change |
|------|------|--------|
| Yelp/paasta | `cli/schemas/smartstack_schema.json` | Add `timeout_threshold_ratio` (number, 0-1). Remove dead fields: `latency_threshold_ms` (monitoring), `latency_threshold` (endpoints). |
| Yelp/paasta | `docs/source/yelpsoa_configs.rst` | Document the new field in the Error Alerting section. |
| docker-images/yelpsoa-configs-mirror | `prometheus_exporter.py` | Read `timeout_threshold_ratio` from config (default 0.8 via `SvcMonitoringDefaults`). Compute `latency_threshold_ms = timeout_threshold_ratio * timeout_server_ms`. |
| docker-images/yelpsoa-configs-mirror | `tests/` | Update tests to exercise the new field. |

### What doesn't change

- Prometheus metric names (`yelpsoa_configs_service_latency_threshold_ms`, `..._endpoint`)
- Alerting rules on perel (already correct)
- Per-endpoint threshold behavior (inherits namespace value)
- `metrics.py` gauge definitions