### PR TITLE
Start tagging `paasta rollback`'d commits

### DIFF
--- a/paasta_tools/cli/cli.py
+++ b/paasta_tools/cli/cli.py
@@ -102,6 +102,7 @@ def add_subparser(command, subparsers):
 PAASTA_SUBCOMMANDS = {
     "autoscale": "autoscale",
     "check": "check",
+    "check-rollback-status": "check_rollback_status",
     "cook-image": "cook_image",
     "get-docker-image": "get_docker_image",
     "get-image-version": "get_image_version",

--- a/paasta_tools/cli/cmds/check_rollback_status.py
+++ b/paasta_tools/cli/cmds/check_rollback_status.py
@@ -1,0 +1,80 @@
+import argparse
+import sys
+
+from paasta_tools.cli.utils import NoSuchService
+from paasta_tools.cli.utils import lazy_choices_completer
+from paasta_tools.cli.utils import list_deploy_groups
+from paasta_tools.cli.utils import validate_service_name
+from paasta_tools.remote_git import LSRemoteException
+from paasta_tools.remote_git import list_remote_refs
+from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import get_git_url
+from paasta_tools.utils import get_rollback_tags_for_sha
+from paasta_tools.utils import list_services
+
+
+def add_subparser(subparsers: argparse._SubParsersAction) -> None:
+    parser = subparsers.add_parser(
+        "check-rollback-status",
+        help="Check if a commit was previously rolled back for a deploy group",
+        description=(
+            "Checks whether a given commit has been marked as rolled back "
+            "for a deploy group. Exit code 0 means the commit is safe to "
+            "deploy, exit code 1 means it was previously rolled back."
+        ),
+    )
+    parser.add_argument(
+        "-s",
+        "--service",
+        help="Name of the service to check",
+        required=True,
+        type=lambda x: x.rstrip("/"),
+    ).completer = lazy_choices_completer(list_services)
+    parser.add_argument(
+        "-l",
+        "--deploy-group",
+        help="Deploy group to check for rollback tags",
+        required=True,
+    ).completer = lazy_choices_completer(list_deploy_groups)
+    parser.add_argument(
+        "-k",
+        "--commit",
+        help="Git SHA to check",
+        required=True,
+    )
+    parser.add_argument(
+        "-d",
+        "--soa-dir",
+        help="A directory from which soa-configs should be read from",
+        default=DEFAULT_SOA_DIR,
+    )
+    parser.set_defaults(command=paasta_check_rollback_status)
+
+
+def paasta_check_rollback_status(args: argparse.Namespace) -> int:
+    service = args.service
+    deploy_group = args.deploy_group
+    commit = args.commit
+    soa_dir = args.soa_dir
+
+    try:
+        validate_service_name(service, soa_dir)
+    except NoSuchService as e:
+        print(f"ERROR: {e}", file=sys.stderr)
+        return 2
+
+    try:
+        refs = list_remote_refs(get_git_url(service=service, soa_dir=soa_dir))
+    except LSRemoteException as e:
+        print(f"ERROR: Could not fetch remote refs: {e}", file=sys.stderr)
+        return 2
+
+    rollback_tags = get_rollback_tags_for_sha(refs, deploy_group, commit)
+    if rollback_tags:
+        print(f"ROLLED BACK: Commit {commit} was rolled back for {deploy_group}")
+        for _, tstamp in rollback_tags:
+            print(f"  Rolled back at: {tstamp}")
+        return 1
+
+    print(f"OK: Commit {commit} has not been rolled back for {deploy_group}")
+    return 0

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -89,6 +89,7 @@ from paasta_tools.utils import format_tag
 from paasta_tools.utils import get_files_of_type_in_dir
 from paasta_tools.utils import get_git_url
 from paasta_tools.utils import get_paasta_tag_from_deploy_group
+from paasta_tools.utils import get_rollback_tags_for_sha
 from paasta_tools.utils import get_username
 from paasta_tools.utils import ldap_user_search
 from paasta_tools.utils import list_services
@@ -502,6 +503,30 @@ def paasta_mark_for_deployment(args: argparse.Namespace) -> int:
             raise ValueError(
                 f"Failed to find image in the registry for the following version {deployment_version}"
             )
+
+    try:
+        # XXX: manual m-f-d is pretty rare so this should be fine
+        # ...but we might need to detect manual m-f-d in the future
+        # and ask for explicit confirmation (note: "manual" is important
+        # here - we don't want to break the Jenkins case :p)
+        refs = remote_git.list_remote_refs(args.git_url)
+        rollback_tags = get_rollback_tags_for_sha(refs, deploy_group, commit)
+        if rollback_tags:
+            print(
+                PaastaColors.yellow(
+                    f"WARNING: Commit {commit} was previously rolled back for {deploy_group}."
+                )
+            )
+            for _, tstamp in rollback_tags:
+                print(PaastaColors.yellow(f"  Rolled back at: {tstamp}"))
+            print(
+                PaastaColors.red(
+                    "This commit may cause the same issues that triggered the original rollback. "
+                    "Proceed with caution!"
+                )
+            )
+    except remote_git.LSRemoteException:
+        log.debug("Could not check for rollback tags; skipping warning", exc_info=True)
 
     deploy_info = get_deploy_info(service=service, soa_dir=args.soa_dir)
     if not can_user_deploy_service(deploy_info, service):
@@ -1135,6 +1160,19 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         if self.mark_for_deployment_return_code != 0:
             self.trigger("mfd_failed")
         else:
+            if (
+                remote_git.create_rollback_tag(
+                    git_url=self.git_url,
+                    deploy_group=self.deploy_group,
+                    bad_sha=self.commit,
+                    image_version=self.image_version,
+                )
+                != 0
+            ):
+                self.update_slack_thread(
+                    f"WARNING: Failed to create rollback tag for `{self.commit[:8]}`. "
+                    "Jenkins will automatically re-deploy this commit in the near future!"
+                )
             self.update_slack_thread(
                 f"Marked `{self.old_git_sha[:8]}` for {self.deploy_group}."
                 + (

--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -31,6 +31,7 @@ from paasta_tools.cli.utils import list_deploy_groups
 from paasta_tools.cli.utils import validate_full_git_sha
 from paasta_tools.cli.utils import validate_given_deploy_groups
 from paasta_tools.deployment_utils import get_currently_deployed_version
+from paasta_tools.remote_git import create_rollback_tag
 from paasta_tools.remote_git import list_remote_refs
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import DeploymentVersion
@@ -180,9 +181,14 @@ def get_versions_for_service(
             deploy_group = regex_match["deploy_group"]
             tstamp = regex_match["tstamp"]
             image_version = regex_match["image_version"]
+            tag_type = regex_match["tag"]
         except KeyError:
             pass
         else:
+            if tag_type != "deploy":
+                # i.e., we don't care about noise like rollback tags :)
+                continue
+
             # Now we filter and dedup by picking the most recent sha for a deploy group
             # Note that all strings are greater than ''
             if deploy_group in deploy_groups:
@@ -312,6 +318,7 @@ def paasta_rollback(args: argparse.Namespace) -> int:
     # TODO: Add similar check for when image_version is empty and no-commit redeploys is enforced for requested deploy_group
 
     returncode = 0
+    performed_rollback = False
 
     for deploy_group in deploy_groups:
         rolled_back_from = get_currently_deployed_version(service, deploy_group)
@@ -326,6 +333,7 @@ def paasta_rollback(args: argparse.Namespace) -> int:
         # we could also gate this by the return code from m-f-d, but we probably care more about someone wanting to
         # rollback than we care about if the underlying machinery was successfully able to complete the request
         if rolled_back_from != new_version:
+            performed_rollback = True
             audit_action_details = {
                 "rolled_back_from": str(rolled_back_from),
                 "rolled_back_to": str(new_version),
@@ -335,8 +343,31 @@ def paasta_rollback(args: argparse.Namespace) -> int:
             _log_audit(
                 action="rollback", action_details=audit_action_details, service=service
             )
+            if (
+                create_rollback_tag(
+                    git_url=git_url,
+                    deploy_group=deploy_group,
+                    bad_sha=rolled_back_from.sha,
+                    image_version=rolled_back_from.image_version,
+                )
+                != 0
+            ):
+                print(
+                    PaastaColors.yellow(
+                        f"WARNING: Failed to create rollback tag for {rolled_back_from.sha}. "
+                        "Jenkins will automatically re-deploy this commit in the near future!"
+                    )
+                )
+        else:
+            print(
+                PaastaColors.red(
+                    f"WARNING: {new_version.sha} is the currently deployed SHA for {deploy_group}! "
+                    f"You have not rolled back in {deploy_group}!"
+                )
+            )
+            returncode = 1
 
-    if returncode == 0:
+    if performed_rollback:
         print(
             PaastaColors.yellow(
                 f"WARNING: You MUST manually revert changes in Git! Use 'git revert {rolled_back_from.sha}', and go through the normal push process. "

--- a/paasta_tools/remote_git.py
+++ b/paasta_tools/remote_git.py
@@ -11,13 +11,19 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import logging
 import re
+from typing import Optional
 
 import dulwich.client
 import dulwich.errors
 
 from paasta_tools.utils import _run
+from paasta_tools.utils import format_tag
+from paasta_tools.utils import get_paasta_tag_from_deploy_group
 from paasta_tools.utils import timeout
+
+log = logging.getLogger(__name__)
 
 
 def _make_determine_wants_func(ref_mutator):
@@ -125,3 +131,30 @@ def get_authors(git_url, from_sha, to_sha):
     else:
         # TODO: PAASTA-16927: support getting authors for services on GHE
         return 1, f"Fetching authors not supported for {git_server}"
+
+
+def create_rollback_tag(
+    git_url: str,
+    deploy_group: str,
+    bad_sha: str,
+    image_version: Optional[str] = None,
+) -> int:
+    """Create a rollback tag pointing at the bad SHA for a deploy group.
+
+    This marks a commit as having been rolled back, so that Jenkins
+    can avoid re-deploying it.
+    """
+    tag = get_paasta_tag_from_deploy_group(
+        identifier=deploy_group, desired_state="rollback", image_version=image_version
+    )
+    remote_tag = format_tag(tag)
+    ref_mutator = make_force_push_mutate_refs_func(targets=[remote_tag], sha=bad_sha)
+    try:
+        create_remote_refs(git_url=git_url, ref_mutator=ref_mutator, force=True)
+    except Exception as e:
+        log.warning(
+            f"Failed to create rollback tag for {bad_sha} in {deploy_group}: {e}"
+        )
+        return 1
+    log.info(f"Created rollback tag for {bad_sha} in {deploy_group}")
+    return 0

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -109,6 +109,8 @@ ANY_CLUSTER = "N/A"
 ANY_INSTANCE = "N/A"
 DEFAULT_LOGLEVEL = "event"
 no_escape = re.compile(r"\x1B\[[0-9;]*[mK]")
+# NOTE: renaming these named groups will require refactoring users of this regex
+ROLLBACK_TAG_PATTERN = r"^refs/tags/paasta-{deploy_group}(?:\+(?P<image_version>.*)){{0,1}}-(?P<dtime>\d{{8}}T\d{{6}})-rollback$"
 
 # instead of the convention of using underscores in this scribe channel name,
 # the audit log uses dashes to prevent collisions with a service that might be
@@ -3723,6 +3725,35 @@ def get_latest_deployment_tag(
                 most_recent_sha = sha
                 most_recent_image_version = gd["image_version"]
     return most_recent_ref, most_recent_sha, most_recent_image_version
+
+
+def get_rollback_tags_for_sha(
+    refs: Dict[str, str], deploy_group: str, sha: str
+) -> List[Tuple[str, str]]:
+    """Gets all rollback tags for a given SHA in a deploy group.
+
+    :param refs: A dictionary mapping git refs to shas
+    :param deploy_group: The deployment group to look for tags for
+    :param sha: The git SHA to check for rollback tags
+
+    :returns: A list of (ref_name, timestamp) tuples for matching rollback
+              tags, sorted by timestamp descending (most recent first)
+
+              NOTE: timestamp is technically not necessary since it's
+              embedded in the tag name - but it does save some processing
+              later on :p
+    """
+    pattern = re.compile(
+        ROLLBACK_TAG_PATTERN.format(deploy_group=re.escape(deploy_group))
+    )
+    results: List[Tuple[str, str]] = []
+    for ref_name, ref_sha in refs.items():
+        if ref_sha != sha:
+            continue
+        if match := pattern.match(ref_name):
+            results.append((ref_name, match.group("dtime")))
+    results.sort(key=lambda x: x[1], reverse=True)
+    return results
 
 
 def build_image_identifier(

--- a/tests/cli/test_cmds_check_rollback_status.py
+++ b/tests/cli/test_cmds_check_rollback_status.py
@@ -1,0 +1,135 @@
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+from paasta_tools.cli.cmds.check_rollback_status import paasta_check_rollback_status
+from paasta_tools.cli.utils import NoSuchService
+from paasta_tools.remote_git import LSRemoteException
+
+FAKE_SHA = "abc123" * 7
+
+
+@pytest.fixture
+def fake_args():
+    return SimpleNamespace(
+        service="test_service",
+        deploy_group="prod.main",
+        commit=FAKE_SHA,
+        soa_dir="/nail/etc/services",
+    )
+
+
+def test_no_rollback_tags(fake_args, capsys):
+    with patch(
+        "paasta_tools.cli.cmds.check_rollback_status.validate_service_name",
+        autospec=True,
+    ), patch(
+        "paasta_tools.cli.cmds.check_rollback_status.get_git_url",
+        autospec=True,
+        return_value="git@git.yelpcorp.com:services/test_service",
+    ), patch(
+        "paasta_tools.cli.cmds.check_rollback_status.list_remote_refs",
+        autospec=True,
+        return_value={
+            "refs/tags/paasta-prod.main-20260420T120000-deploy": FAKE_SHA,
+        },
+    ):
+        assert paasta_check_rollback_status(fake_args) == 0
+        captured = capsys.readouterr()
+        assert "OK" in captured.out
+
+
+def test_rollback_tag_exists(fake_args, capsys):
+    with patch(
+        "paasta_tools.cli.cmds.check_rollback_status.validate_service_name",
+        autospec=True,
+    ), patch(
+        "paasta_tools.cli.cmds.check_rollback_status.get_git_url",
+        autospec=True,
+        return_value="git@git.yelpcorp.com:services/test_service",
+    ), patch(
+        "paasta_tools.cli.cmds.check_rollback_status.list_remote_refs",
+        autospec=True,
+        return_value={
+            "refs/tags/paasta-prod.main-20260420T120000-deploy": "other_sha" * 5,
+            "refs/tags/paasta-prod.main-20260420T130000-rollback": FAKE_SHA,
+        },
+    ):
+        assert paasta_check_rollback_status(fake_args) == 1
+        captured = capsys.readouterr()
+        assert "ROLLED BACK" in captured.out
+        assert "20260420T130000" in captured.out
+
+
+def test_git_error(fake_args):
+    with patch(
+        "paasta_tools.cli.cmds.check_rollback_status.validate_service_name",
+        autospec=True,
+    ), patch(
+        "paasta_tools.cli.cmds.check_rollback_status.get_git_url",
+        autospec=True,
+        return_value="git@git.yelpcorp.com:services/test_service",
+    ), patch(
+        "paasta_tools.cli.cmds.check_rollback_status.list_remote_refs",
+        autospec=True,
+        side_effect=LSRemoteException("connection refused"),
+    ):
+        assert paasta_check_rollback_status(fake_args) == 2
+
+
+def test_nonexistent_service(fake_args):
+    fake_args.service = "nonexistent_service"
+
+    with patch(
+        "paasta_tools.cli.cmds.check_rollback_status.validate_service_name",
+        autospec=True,
+        side_effect=NoSuchService("nonexistent_service"),
+    ), patch(
+        "paasta_tools.cli.cmds.check_rollback_status.get_git_url",
+        autospec=True,
+    ) as mock_get_git_url, patch(
+        "paasta_tools.cli.cmds.check_rollback_status.list_remote_refs",
+        autospec=True,
+    ) as mock_list_remote_refs:
+        assert paasta_check_rollback_status(fake_args) == 2
+        assert not mock_get_git_url.called
+        assert not mock_list_remote_refs.called
+
+
+def test_ignores_rollback_tags_for_other_deploy_groups(fake_args):
+    with patch(
+        "paasta_tools.cli.cmds.check_rollback_status.validate_service_name",
+        autospec=True,
+    ), patch(
+        "paasta_tools.cli.cmds.check_rollback_status.get_git_url",
+        autospec=True,
+        return_value="git@git.yelpcorp.com:services/test_service",
+    ), patch(
+        "paasta_tools.cli.cmds.check_rollback_status.list_remote_refs",
+        autospec=True,
+        return_value={
+            "refs/tags/paasta-staging.main-20260420T130000-rollback": FAKE_SHA,
+        },
+    ):
+        assert paasta_check_rollback_status(fake_args) == 0
+
+
+def test_image_version_in_tag(fake_args, capsys):
+    with patch(
+        "paasta_tools.cli.cmds.check_rollback_status.validate_service_name",
+        autospec=True,
+    ), patch(
+        "paasta_tools.cli.cmds.check_rollback_status.get_git_url",
+        autospec=True,
+        return_value="git@git.yelpcorp.com:services/test_service",
+    ), patch(
+        "paasta_tools.cli.cmds.check_rollback_status.list_remote_refs",
+        autospec=True,
+        return_value={
+            "refs/tags/paasta-prod.main+v1.2.3-20260420T130000-rollback": FAKE_SHA,
+        },
+    ):
+        assert paasta_check_rollback_status(fake_args) == 1
+        captured = capsys.readouterr()
+        assert "ROLLED BACK" in captured.out

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -201,7 +201,11 @@ def test_paasta_mark_for_deployment_when_verify_image_fails(
     "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
 )
 @patch("paasta_tools.metrics.metrics_lib.get_metrics_interface", autospec=True)
+@patch("paasta_tools.remote_git.list_remote_refs", autospec=True)
+@patch("paasta_tools.remote_git.create_rollback_tag", autospec=True)
 def test_paasta_mark_for_deployment_with_good_rollback(
+    mock_create_rollback_tag,
+    mock_list_remote_refs,
     mock_get_metrics,
     mock_load_system_paasta_config,
     mock_list_deploy_groups,

--- a/tests/cli/test_cmds_rollback.py
+++ b/tests/cli/test_cmds_rollback.py
@@ -26,6 +26,7 @@ from paasta_tools.utils import DeploymentVersion
 from paasta_tools.utils import RollbackTypes
 
 
+@patch("paasta_tools.cli.cmds.rollback.create_rollback_tag", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_version", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback._log_audit", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.list_deploy_groups", autospec=True)
@@ -43,6 +44,7 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
     mock_list_deploy_groups,
     mock_log_audit,
     mock_get_currently_deployed_version,
+    mock_create_rollback_tag,
 ):
     fake_args, _ = parse_args(
         ["rollback", "-s", "fakeservice", "-k", "abcd" * 10, "-l", "fake_deploy_group1"]
@@ -94,6 +96,7 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
         assert call_kwargs["service"] == fake_args.service
 
 
+@patch("paasta_tools.cli.cmds.rollback.create_rollback_tag", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_version", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback._log_audit", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.list_deploy_groups", autospec=True)
@@ -111,6 +114,7 @@ def test_paasta_rollback_mark_for_deployment_with_image(
     mock_list_deploy_groups,
     mock_log_audit,
     mock_get_currently_deployed_version,
+    mock_create_rollback_tag,
 ):
     fake_args, _ = parse_args(
         [
@@ -178,6 +182,7 @@ def test_paasta_rollback_mark_for_deployment_with_image(
         assert call_kwargs["service"] == fake_args.service
 
 
+@patch("paasta_tools.cli.cmds.rollback.create_rollback_tag", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_version", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback._log_audit", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.list_deploy_groups", autospec=True)
@@ -195,6 +200,7 @@ def test_paasta_rollback_with_force(
     mock_list_deploy_groups,
     mock_log_audit,
     mock_get_currently_deployed_version,
+    mock_create_rollback_tag,
 ):
     fake_args, _ = parse_args(
         [
@@ -319,6 +325,7 @@ def test_paasta_rollback_mark_for_deployment_no_deploy_group_arg(
         assert call_kwargs["service"] == fake_args.service
 
 
+@patch("paasta_tools.cli.cmds.rollback.create_rollback_tag", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_version", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback._log_audit", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.list_deploy_groups", autospec=True)
@@ -336,6 +343,7 @@ def test_paasta_rollback_mark_for_deployment_all_deploy_groups_arg(
     mock_list_deploy_groups,
     mock_log_audit,
     mock_get_currently_deployed_version,
+    mock_create_rollback_tag,
 ):
     fake_args, _ = parse_args(
         ["rollback", "-s", "fakeservice", "-k", "abcd" * 10, "-a"]
@@ -476,6 +484,7 @@ def test_paasta_rollback_git_sha_was_not_marked_before(
     assert not mock_log_audit.called
 
 
+@patch("paasta_tools.cli.cmds.rollback.create_rollback_tag", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_version", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback._log_audit", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.list_deploy_groups", autospec=True)
@@ -493,6 +502,7 @@ def test_paasta_rollback_mark_for_deployment_multiple_deploy_group_args(
     mock_list_deploy_groups,
     mock_log_audit,
     mock_get_currently_deployed_version,
+    mock_create_rollback_tag,
 ):
     fake_args, _ = parse_args(
         [
@@ -719,3 +729,130 @@ def test_list_previously_deployed_shas_no_deploy_groups():
 
 def test_get_versions_for_service_no_service_name():
     assert get_versions_for_service(None, None, "/fake/soa/dir") == {}
+
+
+def test_get_versions_for_service_excludes_rollback_tags():
+    fake_refs = {
+        "refs/tags/paasta-test.deploy.group-20260420T120000-deploy": "deploy_sha",
+        "refs/tags/paasta-test.deploy.group-20260420T130000-rollback": "rollback_sha",
+    }
+    fake_deploy_groups = ["test.deploy.group"]
+
+    with patch(
+        "paasta_tools.cli.cmds.rollback.list_remote_refs",
+        autospec=True,
+        return_value=fake_refs,
+    ), patch(
+        "paasta_tools.cli.cmds.rollback.list_deploy_groups",
+        autospec=True,
+        return_value=fake_deploy_groups,
+    ), patch(
+        "paasta_tools.cli.cmds.rollback.get_git_url",
+        autospec=True,
+        return_value="git://git.repo",
+    ):
+        versions = get_versions_for_service(
+            "fake_service", {"test.deploy.group"}, "/fake/soa/dir"
+        )
+        shas = {v.sha for v in versions}
+        assert "deploy_sha" in shas
+        assert "rollback_sha" not in shas
+
+
+def test_create_rollback_tag_called_after_rollback():
+    fake_args, _ = parse_args(
+        ["rollback", "-s", "fakeservice", "-k", "abcd" * 10, "-l", "fake_deploy_group1"]
+    )
+    old_version = DeploymentVersion(sha="1234" * 10, image_version=None)
+
+    with patch(
+        "paasta_tools.cli.cmds.rollback.can_user_deploy_service", autospec=True
+    ), patch(
+        "paasta_tools.cli.cmds.rollback.get_versions_for_service",
+        autospec=True,
+        return_value={
+            DeploymentVersion(sha=fake_args.commit, image_version=None): (
+                "20170403T025512",
+                fake_args.deploy_groups,
+            ),
+        },
+    ), patch(
+        "paasta_tools.cli.cmds.rollback.mark_for_deployment",
+        autospec=True,
+        return_value=0,
+    ), patch(
+        "paasta_tools.cli.cmds.rollback.get_git_url",
+        autospec=True,
+        return_value="git://git.repo",
+    ), patch(
+        "paasta_tools.cli.cmds.rollback.figure_out_service_name",
+        autospec=True,
+        return_value=fake_args.service,
+    ), patch(
+        "paasta_tools.cli.cmds.rollback.list_deploy_groups",
+        autospec=True,
+        return_value=[fake_args.deploy_groups],
+    ), patch(
+        "paasta_tools.cli.cmds.rollback._log_audit", autospec=True
+    ), patch(
+        "paasta_tools.cli.cmds.rollback.get_currently_deployed_version",
+        autospec=True,
+        return_value=old_version,
+    ), patch(
+        "paasta_tools.cli.cmds.rollback.create_rollback_tag", autospec=True
+    ) as mock_create_rollback_tag:
+        assert paasta_rollback(fake_args) == 0
+
+        mock_create_rollback_tag.assert_called_once_with(
+            git_url="git://git.repo",
+            deploy_group=fake_args.deploy_groups,
+            bad_sha=old_version.sha,
+            image_version=old_version.image_version,
+        )
+
+
+def test_create_rollback_tag_not_called_when_same_version():
+    commit = "abcd" * 10
+    fake_args, _ = parse_args(
+        ["rollback", "-s", "fakeservice", "-k", commit, "-l", "fake_deploy_group1"]
+    )
+
+    with patch(
+        "paasta_tools.cli.cmds.rollback.can_user_deploy_service", autospec=True
+    ), patch(
+        "paasta_tools.cli.cmds.rollback.get_versions_for_service",
+        autospec=True,
+        return_value={
+            DeploymentVersion(sha=commit, image_version=None): (
+                "20170403T025512",
+                fake_args.deploy_groups,
+            ),
+        },
+    ), patch(
+        "paasta_tools.cli.cmds.rollback.mark_for_deployment",
+        autospec=True,
+        return_value=0,
+    ), patch(
+        "paasta_tools.cli.cmds.rollback.get_git_url",
+        autospec=True,
+        return_value="git://git.repo",
+    ), patch(
+        "paasta_tools.cli.cmds.rollback.figure_out_service_name",
+        autospec=True,
+        return_value=fake_args.service,
+    ), patch(
+        "paasta_tools.cli.cmds.rollback.list_deploy_groups",
+        autospec=True,
+        return_value=[fake_args.deploy_groups],
+    ), patch(
+        "paasta_tools.cli.cmds.rollback._log_audit", autospec=True
+    ), patch(
+        "paasta_tools.cli.cmds.rollback.get_currently_deployed_version",
+        autospec=True,
+        return_value=DeploymentVersion(sha=commit, image_version=None),
+    ), patch(
+        "paasta_tools.cli.cmds.rollback.create_rollback_tag", autospec=True
+    ) as mock_create_rollback_tag:
+        paasta_rollback(fake_args)
+
+        assert not mock_create_rollback_tag.called

--- a/tests/test_remote_git.py
+++ b/tests/test_remote_git.py
@@ -144,3 +144,30 @@ def test_get_authors_works_with_good_url(mock_run):
         command="ssh git@git.yelpcorp.com authors-of-changeset yelp-main a b",
         timeout=5.0,
     )
+
+
+def test_create_rollback_tag_success():
+    with mock.patch(
+        "paasta_tools.remote_git.create_remote_refs", autospec=True
+    ) as mock_create_remote_refs:
+        result = remote_git.create_rollback_tag(
+            git_url="git@git.yelpcorp.com:services/myservice",
+            deploy_group="prod.main",
+            bad_sha="a" * 40,
+        )
+        assert result == 0
+        mock_create_remote_refs.assert_called_once()
+
+
+def test_create_rollback_tag_failure():
+    with mock.patch(
+        "paasta_tools.remote_git.create_remote_refs",
+        autospec=True,
+        side_effect=Exception("connection refused"),
+    ):
+        result = remote_git.create_rollback_tag(
+            git_url="git@git.yelpcorp.com:services/myservice",
+            deploy_group="prod.main",
+            bad_sha="a" * 40,
+        )
+        assert result == 1

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2969,3 +2969,39 @@ def test_validate_pool_error(cluster, pool, system_paasta_config):
 )
 def test_get_git_sha_from_dockerurl(docker_url, long, expected):
     assert utils.get_git_sha_from_dockerurl(docker_url, long) == expected
+
+
+class TestGetRollbackTagsForSha:
+    def test_finds_rollback_tags(self):
+        bad_sha = "a" * 40
+        refs = {
+            "refs/tags/paasta-prod.main-20260420T120000-rollback": bad_sha,
+            "refs/tags/paasta-prod.main-20260420T130000-rollback": bad_sha,
+        }
+        results = utils.get_rollback_tags_for_sha(refs, "prod.main", bad_sha)
+        assert len(results) == 2
+        assert results[0][1] == "20260420T130000"
+        assert results[1][1] == "20260420T120000"
+
+    def test_ignores_other_deploy_groups(self):
+        bad_sha = "a" * 40
+        refs = {
+            "refs/tags/paasta-staging.main-20260420T120000-rollback": bad_sha,
+        }
+        results = utils.get_rollback_tags_for_sha(refs, "prod.main", bad_sha)
+        assert results == []
+
+    def test_ignores_deploy_tags(self):
+        sha = "a" * 40
+        refs = {
+            "refs/tags/paasta-prod.main-20260420T120000-deploy": sha,
+        }
+        results = utils.get_rollback_tags_for_sha(refs, "prod.main", sha)
+        assert results == []
+
+    def test_no_rollback_tags(self):
+        refs = {
+            "refs/tags/paasta-prod.main-20260420T120000-rollback": "b" * 40,
+        }
+        results = utils.get_rollback_tags_for_sha(refs, "prod.main", "a" * 40)
+        assert results == []


### PR DESCRIPTION
plus add a CLI util to check if a commit has been rolled back.

We can then use this information/utility to prevent ourselves from rolling forward on a commit that we already rolled back automatically.

I have a Jenkins PR internally that will use this to ask for explicit confirmation on non-timer-triggered builds (and just abort timer-triggered builds).

NOTE: this looks like a large PR, but there's more tests than anything else :p

I've tested this locally (note: i've cleaned up my rollback tags from git):
```
>> paasta rollback -s katamari_test_service -l dev.load_generator -k e9fab4959a2ad582cb8b85bf643600ac9fbeb9a4                                           
[service katamari_test_service] Marked e9fab4959a2ad582cb8b85bf643600ac9fbeb9a4 for deployment in deploy group dev.load_generator
WARNING: e9fab4959a2ad582cb8b85bf643600ac9fbeb9a4 is the currently deployed SHA for dev.load_generator! You have not rolled back in dev.load_generator!

> paasta rollback -s katamari_test_service -l dev.load_generator -k c4e16a52a1c3789ba13b2513631b52a262baea87                                          
[service katamari_test_service] Notifying soa-configs primary to generate a deployment for katamari_test_service
[service katamari_test_service] Marked c4e16a52a1c3789ba13b2513631b52a262baea87 for deployment in deploy group dev.load_generator
WARNING: You MUST manually revert changes in Git! Use 'git revert e9fab4959a2ad582cb8b85bf643600ac9fbeb9a4', and go through the normal push process.
WARNING: Failing to do so means that Jenkins will redeploy the latest code on the next scheduled build!

> paasta check-rollback-status -s katamari_test_service -l dev.load_generator -k e9fab4959a2ad582cb8b85bf643600ac9fbeb9a4 
ROLLED BACK: Commit e9fab4959a2ad582cb8b85bf643600ac9fbeb9a4 was rolled back for dev.load_generator
  Rolled back at: 20260505T212202

> paasta check-rollback-status -s katamari_test_service -l dev.load_generator -k c4e16a52a1c3789ba13b2513631b52a262baea87
OK: Commit c4e16a52a1c3789ba13b2513631b52a262baea87 has not been rolled back for dev.load_generator
```

NOTE 2: atm, this only adds special handling for manual rollbacks
...but that seems fine since that's been the most problematic so
far (and I can see folks wanting Jenkins to keep trying to re-deploy
SLO-rolled-back commits again on nightly builds) - but that's easy
enough to change if we do want to also not try to roll-forward there
as well