### PR TITLE
Remove dependencies on public ubuntu repos (archive.ubuntu.com, …

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,8 @@ jobs:
           - general_itests
     env:
       DOCKER_REGISTRY: ""
+      BASE_IMAGE: ubuntu:jammy
+      EXTRA_PPA: ppa:deadsnakes/ppa
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -35,6 +37,8 @@ jobs:
     runs-on: ubuntu-22.04
     env:
       DOCKER_REGISTRY: ""
+      BASE_IMAGE: ubuntu:jammy
+      EXTRA_PPA: ppa:deadsnakes/ppa
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -17,6 +17,8 @@ jobs:
           - general_itests
     env:
       DOCKER_REGISTRY: ""
+      BASE_IMAGE: ubuntu:jammy
+      EXTRA_PPA: ppa:deadsnakes/ppa
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2

--- a/general_itests/fake_simple_service/Dockerfile
+++ b/general_itests/fake_simple_service/Dockerfile
@@ -12,5 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:jammy
+ARG BASE_IMAGE=docker-dev.yelpcorp.com/jammy_yelp
+FROM ${BASE_IMAGE}

--- a/general_itests/fake_simple_service/Makefile
+++ b/general_itests/fake_simple_service/Makefile
@@ -15,12 +15,12 @@
 DOCKER_TAG ?= fake_simple_service-$(USER)-dev
 
 ifeq ($(findstring .yelpcorp.com,$(shell hostname -f)), .yelpcorp.com)
-	DOCKER_REGISTRY ?= docker-dev.yelpcorp.com/
+	BASE_IMAGE_BUILD_ARG ?=
 else
-	DOCKER_REGISTRY ?= ""
+	BASE_IMAGE_BUILD_ARG ?= --build-arg BASE_IMAGE=ubuntu:jammy
 endif
 
 .PHONY: cook-image
 
 cook-image:
-	docker build --build-arg DOCKER_REGISTRY=$(DOCKER_REGISTRY) -t $(DOCKER_TAG) .
+	docker build $(BASE_IMAGE_BUILD_ARG) -t $(DOCKER_TAG) .

--- a/k8s_itests/docker-compose.yml
+++ b/k8s_itests/docker-compose.yml
@@ -8,6 +8,9 @@ services:
     build:
       context: ../
       dockerfile: ./yelp_package/dockerfiles/itest/k8s/Dockerfile
+      args:
+        BASE_IMAGE: ${BASE_IMAGE:-docker-dev.yelpcorp.com/jammy_yelp}
+        EXTRA_PPA: ${EXTRA_PPA:-}
     network_mode: host
     environment:
       KIND_CLUSTER: ${KIND_CLUSTER}
@@ -34,6 +37,9 @@ services:
     build:
       context: ../
       dockerfile: ./yelp_package/dockerfiles/itest/api/Dockerfile
+      args:
+        BASE_IMAGE: ${BASE_IMAGE:-docker-dev.yelpcorp.com/jammy_yelp}
+        EXTRA_PPA: ${EXTRA_PPA:-}
     command: bash -c 'mkdir -p /work/k8s_itests/deployments/.tmp && python -m paasta_tools.contrib.render_template -s /work/k8s_itests/deployments/paasta/ -d /work/k8s_itests/deployments/.tmp && pip install -e /work && exec paasta-api -D -c ${KIND_CLUSTER} ${PAASTA_API_PORT}'
     network_mode: host
     environment:

--- a/tox.ini
+++ b/tox.ini
@@ -111,6 +111,8 @@ passenv =
     DOCKER_HOST
     DOCKER_CERT_PATH
     INDEX_URL_BUILD_ARG
+    BASE_IMAGE
+    EXTRA_PPA
 changedir=k8s_itests/
 commands =
     # Requires system Docker Compose V2 (`docker compose` CLI) to be installed and available in PATH.
@@ -120,7 +122,7 @@ commands =
     {toxinidir}/k8s_itests/scripts/setup.sh
     # Run paasta-tools k8s_itests in docker
     docker compose down
-    docker compose --verbose build --parallel --build-arg DOCKER_REGISTRY={env:DOCKER_REGISTRY:docker-dev.yelpcorp.com/} --build-arg {env:INDEX_URL_BUILD_ARG:UNUSED}=https://pypi.org/simple
+    docker compose --verbose build --parallel --build-arg BASE_IMAGE={env:BASE_IMAGE:docker-dev.yelpcorp.com/jammy_yelp} --build-arg EXTRA_PPA={env:EXTRA_PPA:} --build-arg {env:INDEX_URL_BUILD_ARG:UNUSED}=https://pypi.org/simple
     docker compose up \
         --abort-on-container-exit
 

--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -35,8 +35,8 @@ endif
 build_%_docker:
 	[ -d ../dist ] || mkdir ../dist
 	docker pull "docker.io/yelp/paastatools_$*_container" || true
-	cd dockerfiles/$*/ && docker build --build-arg DOCKER_REGISTRY=$(DOCKER_REGISTRY) \
-	$(if $(filter-out $(PAASTA_ENV),YELP), --build-arg PIP_INDEX_URL=https://pypi.org/simple,) \
+	cd dockerfiles/$*/ && docker build \
+	$(if $(filter-out $(PAASTA_ENV),YELP), --build-arg BASE_IMAGE=ubuntu:$* --build-arg PIP_INDEX_URL=https://pypi.org/simple --build-arg EXTRA_PPA=ppa:deadsnakes/ppa,) \
 		-t "docker.io/yelp/paastatools_$*_container" .
 
 .SECONDEXPANSION:

--- a/yelp_package/dockerfiles/focal/Dockerfile
+++ b/yelp_package/dockerfiles/focal/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:focal
+ARG BASE_IMAGE=docker-dev.yelpcorp.com/focal_yelp
+FROM ${BASE_IMAGE}
 
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/focal/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL

--- a/yelp_package/dockerfiles/gitremote/Dockerfile
+++ b/yelp_package/dockerfiles/gitremote/Dockerfile
@@ -1,5 +1,5 @@
-ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:jammy
+ARG BASE_IMAGE=docker-dev.yelpcorp.com/jammy_yelp
+FROM ${BASE_IMAGE}
 
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y \

--- a/yelp_package/dockerfiles/itest/api/Dockerfile
+++ b/yelp_package/dockerfiles/itest/api/Dockerfile
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:jammy
+ARG BASE_IMAGE=docker-dev.yelpcorp.com/jammy_yelp
+FROM ${BASE_IMAGE}
 
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/jammy/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL
+ARG EXTRA_PPA=
 
 RUN apt-get update -yq && \
     apt-get install -yq \
-        # needed to add a ppa
         software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa
+    if [ -n "${EXTRA_PPA}" ]; then add-apt-repository "${EXTRA_PPA}"; fi
 
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/yelp_package/dockerfiles/itest/hacheck/Dockerfile
+++ b/yelp_package/dockerfiles/itest/hacheck/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:bionic
+ARG BASE_IMAGE=docker-dev.yelpcorp.com/bionic_yelp
+FROM ${BASE_IMAGE}
 
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/bionic/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL

--- a/yelp_package/dockerfiles/itest/httpdrain/Dockerfile
+++ b/yelp_package/dockerfiles/itest/httpdrain/Dockerfile
@@ -1,5 +1,5 @@
-ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:jammy
+ARG BASE_IMAGE=docker-dev.yelpcorp.com/jammy_yelp
+FROM ${BASE_IMAGE}
 
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/jammy/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL

--- a/yelp_package/dockerfiles/itest/k8s/Dockerfile
+++ b/yelp_package/dockerfiles/itest/k8s/Dockerfile
@@ -12,17 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:jammy
+ARG BASE_IMAGE=docker-dev.yelpcorp.com/jammy_yelp
+FROM ${BASE_IMAGE}
 
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/jammy/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL
+ARG EXTRA_PPA=
 
 RUN apt-get update -yq && \
     apt-get install -yq \
-        # needed to add a ppa
         software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa
+    if [ -n "${EXTRA_PPA}" ]; then add-apt-repository "${EXTRA_PPA}"; fi
 
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/yelp_package/dockerfiles/itest/zookeeper/Dockerfile
+++ b/yelp_package/dockerfiles/itest/zookeeper/Dockerfile
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:jammy
+ARG BASE_IMAGE=docker-dev.yelpcorp.com/jammy_yelp
+FROM ${BASE_IMAGE}
 
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/yelp_package/dockerfiles/jammy/Dockerfile
+++ b/yelp_package/dockerfiles/jammy/Dockerfile
@@ -12,17 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:jammy
+ARG BASE_IMAGE=docker-dev.yelpcorp.com/jammy_yelp
+FROM ${BASE_IMAGE}
 
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/jammy/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL
+ARG EXTRA_PPA=
 RUN rm /etc/dpkg/dpkg.cfg.d/excludes
 RUN apt-get update && apt-get install -yq gnupg2
 
 RUN apt-get update > /dev/null && \
     apt-get install -y --no-install-recommends software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa
+    if [ -n "${EXTRA_PPA}" ]; then add-apt-repository "${EXTRA_PPA}"; fi
 
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \

--- a/yelp_package/dockerfiles/noble/Dockerfile
+++ b/yelp_package/dockerfiles/noble/Dockerfile
@@ -12,17 +12,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-ARG DOCKER_REGISTRY=docker-dev.yelpcorp.com/
-FROM ${DOCKER_REGISTRY}ubuntu:noble
+ARG BASE_IMAGE=docker-dev.yelpcorp.com/noble_yelp
+FROM ${BASE_IMAGE}
 
 ARG PIP_INDEX_URL=https://pypi.yelpcorp.com/simple
 ENV PIP_INDEX_URL=$PIP_INDEX_URL
+ARG EXTRA_PPA=
 RUN rm /etc/dpkg/dpkg.cfg.d/excludes
 RUN apt-get update && apt-get install -yq gnupg2
 
 RUN apt-get update > /dev/null && \
     apt-get install -y --no-install-recommends software-properties-common && \
-    add-apt-repository ppa:deadsnakes/ppa
+    if [ -n "${EXTRA_PPA}" ]; then add-apt-repository "${EXTRA_PPA}"; fi
 
 RUN apt-get update > /dev/null && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \


### PR DESCRIPTION
…ppa.launchpadcontent.net) to fix internal builds during the DDoS against Canonical.


As an aside, it looks like `yelp_package/dockerfiles/itest/hacheck/Dockerfile` might be dead code.