### PR TITLE
PAASTA-18875: Making max surge configurable

### DIFF
--- a/docs/source/bouncing.rst
+++ b/docs/source/bouncing.rst
@@ -179,3 +179,12 @@ Tron Bouncing
 
 In PaaSTA Tron jobs are simply configured to use new code or config **on the
 next execution of the job**. In progress jobs are not adjusted or killed.
+
+Controlling Surge During Bounces
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, PaaSTA attempts to start as many replicas as were previously running during a bounce at once.
+If your service (among other reasons) is large and/or lives in a small pool, you can tune how many replicas PaaSTA will
+essentially "overprovision" during a bounce with the ``bounce_overprovision_factor`` option
+
+ See the docs on `bounce_overprovision_factor <yelpsoa_configs.html#eks-[clustername].yaml>`_ file.

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -416,6 +416,13 @@ instance MAY have:
       This fraction of boxes must agree that the task is up for the bounce to treat a task as healthy.
       Defaults to 1.0 -- haproxy on all queried boxes must agree that the task is up.
 
+  * ``bounce_overprovision_factor``: controls the maximum number of extra instances allowed above the desired count during a bounce,
+    as a fraction from 0.25 to 1. 0.25 is set as the floor to ensure at least 25% surge capacity is allowed.
+    * **Type:** Number (0.25-1)
+    * **Default:** System default is set to ``1.0``
+
+    Example:: bounce_overprovision_factor : 0.25
+
   * ``bounce_margin_factor``: proportionally increase the number of old instances
     to be drained when the crossover bounce method is used.
     0 < bounce_margin_factor <= 1. Defaults to 1 (no influence).

--- a/paasta_tools/cli/schemas/eks_schema.json
+++ b/paasta_tools/cli/schemas/eks_schema.json
@@ -197,6 +197,13 @@
                 "deploy_group": {
                     "type": "string"
                 },
+                "bounce_overprovision_factor": {
+                    "type": "number",
+                    "minimum": 0.25,
+                    "maximum": 1,
+                    "exclusiveMinimum": false,
+                    "comment": "Fraction of extra instances allowed during a bounce. Defaults to 1.0. Floor set to 0.25"
+                },
                 "autoscaling": {
                     "$ref": "autoscaling_schema.json#autoscaling_params"
                 },

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -983,7 +983,10 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
         strategy_type = KUBE_DEPLOY_STATEGY_MAP[bounce_method]
 
         if strategy_type == "RollingUpdate":
-            max_surge = "100%"
+            # k8s expects an absolute number (an integer) or a integer percentage string (e.g., 55%)
+            # and since we don't allow folks to set an absolute number to surge by, we need to protect against someone being
+            # clever and trying to set a surge of something like ".1234" for 12.34% by rounding the input
+            max_surge = f"{int(round(self.get_bounce_overprovision_factor() * 100, ndigits=2))}%"
             if bounce_method == "crossover":
                 max_unavailable = "{}%".format(
                     int((1 - self.get_bounce_margin_factor()) * 100)

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -95,6 +95,7 @@ class LongRunningServiceConfigDict(InstanceConfigDict, total=False):
     replication_threshold: int
     bounce_start_deadline: float
     bounce_margin_factor: float
+    bounce_overprovision_factor: float
     should_ping_for_unhealthy_pods: bool
     weight: int
     unhealthy_pod_eviction_policy: str
@@ -234,6 +235,12 @@ class LongRunningServiceConfig(InstanceConfig):
     # FIXME(jlynch|2016-08-02, PAASTA-4964): DEPRECATE nerve_ns and remove it
     def get_nerve_namespace(self) -> str:
         return decompose_job_id(self.get_registrations()[0])[1]
+
+    def get_bounce_overprovision_factor(self) -> float:
+        return self.config_dict.get(
+            "bounce_overprovision_factor",
+            load_system_paasta_config().get_bounce_overprovision_factor(),
+        )
 
     def get_registrations(self) -> List[str]:
         for registration in self.get_invalid_registrations():

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1920,6 +1920,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     datastore_credentials_vault_env_overrides: Dict[str, str]
     default_push_groups: List
     default_should_use_uwsgi_exporter: bool
+    default_bounce_overprovision_factor: float
     deploy_blacklist: UnsafeDeployBlacklist
     deployd_metrics_provider: str
     deploy_whitelist: UnsafeDeployWhitelist
@@ -2166,6 +2167,9 @@ class SystemPaastaConfig:
         if hosts.startswith("zk://"):
             return hosts[len("zk://") :]
         return hosts
+
+    def get_bounce_overprovision_factor(self) -> float:
+        return self.config_dict.get("default_bounce_overprovision_factor", 1.0)
 
     def get_system_docker_registry(self) -> str:
         """Get the docker_registry defined in this host's cluster config file.

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -409,6 +409,10 @@ class TestKubernetesDeploymentConfig:
             "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_bounce_margin_factor",
             autospec=True,
             return_value=bounce_margin_factor,
+        ), mock.patch(
+            "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_bounce_overprovision_factor",
+            autospec=True,
+            return_value=1.0,
         ):
             assert (
                 self.deployment.get_deployment_strategy_config()
@@ -5117,6 +5121,10 @@ def test_warning_big_bounce_default_config():
         new=mock_load_system_paasta_config,
         autospec=False,
     ), mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_bounce_overprovision_factor",
+        autospec=True,
+        return_value=1.0,
+    ), mock.patch(
         "paasta_tools.kubernetes_tools.load_service_namespace_config",
         return_value=ServiceNamespaceConfig(),
         autospec=True,
@@ -5162,6 +5170,10 @@ def test_warning_big_bounce_routable_pod():
         "paasta_tools.kubernetes_tools.load_system_paasta_config",
         new=mock_load_system_paasta_config,
         autospec=False,
+    ), mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_bounce_overprovision_factor",
+        autospec=True,
+        return_value=1.0,
     ), mock.patch(
         "paasta_tools.kubernetes_tools.load_service_namespace_config",
         return_value=ServiceNamespaceConfig({"proxy_port": 1}),
@@ -5209,6 +5221,10 @@ def test_warning_big_bounce_common_config():
         "paasta_tools.kubernetes_tools.load_system_paasta_config",
         new=mock_load_system_paasta_config,
         autospec=False,
+    ), mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_bounce_overprovision_factor",
+        autospec=True,
+        return_value=1.0,
     ), mock.patch(
         "paasta_tools.kubernetes_tools.load_service_namespace_config",
         return_value=ServiceNamespaceConfig(),

--- a/tests/test_long_running_service_tools.py
+++ b/tests/test_long_running_service_tools.py
@@ -17,6 +17,7 @@ from pytest import raises
 
 from paasta_tools import long_running_service_tools
 from paasta_tools.utils import InvalidInstanceConfig
+from paasta_tools.utils import SystemPaastaConfig
 
 
 class TestLongRunningServiceConfig:
@@ -472,3 +473,59 @@ def test_get_expected_instance_count_for_namespace():
             cluster="fake_cluster",
             instance_type_class=long_running_service_tools.LongRunningServiceConfig,
         )
+
+
+class TestGetBounceOverprovisionFactor:
+    def test_returns_value_from_config(self):
+        """Uses per-service config when set."""
+        mock_system_config = mock.Mock(spec=SystemPaastaConfig)
+        mock_system_config.get_bounce_overprovision_factor.return_value = 1.0
+        with mock.patch(
+            "paasta_tools.long_running_service_tools.load_system_paasta_config",
+            autospec=True,
+            return_value=mock_system_config,
+        ):
+            service_config = long_running_service_tools.LongRunningServiceConfig(
+                service="test-service",
+                cluster="test-cluster",
+                instance="test-instance",
+                config_dict={"bounce_overprovision_factor": 0.5},
+                branch_dict=None,
+            )
+            assert service_config.get_bounce_overprovision_factor() == 0.5
+
+    def test_falls_back_to_system_default(self):
+        """Falls back to system default when not set per-service."""
+        mock_system_config = mock.Mock(spec=SystemPaastaConfig)
+        mock_system_config.get_bounce_overprovision_factor.return_value = 0.75
+        with mock.patch(
+            "paasta_tools.long_running_service_tools.load_system_paasta_config",
+            autospec=True,
+            return_value=mock_system_config,
+        ):
+            service_config = long_running_service_tools.LongRunningServiceConfig(
+                service="test-service",
+                cluster="test-cluster",
+                instance="test-instance",
+                config_dict={},
+                branch_dict=None,
+            )
+            assert service_config.get_bounce_overprovision_factor() == 0.75
+
+    def test_falls_back_to_100_percent_when_nothing_configured(self):
+        """Falls back to 100% when neither per-service nor system default is set."""
+        mock_system_config = mock.Mock(spec=SystemPaastaConfig)
+        mock_system_config.get_bounce_overprovision_factor.return_value = 1.0
+        with mock.patch(
+            "paasta_tools.long_running_service_tools.load_system_paasta_config",
+            autospec=True,
+            return_value=mock_system_config,
+        ):
+            service_config = long_running_service_tools.LongRunningServiceConfig(
+                service="test-service",
+                cluster="test-cluster",
+                instance="test-instance",
+                config_dict={},
+                branch_dict=None,
+            )
+            assert service_config.get_bounce_overprovision_factor() == 1.0

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -3005,3 +3005,19 @@ class TestGetRollbackTagsForSha:
         }
         results = utils.get_rollback_tags_for_sha(refs, "prod.main", "a" * 40)
         assert results == []
+
+
+class TestGetDefaultBounceOverprovisionFactor:
+    def test_returns_configured_value_with_percent(self):
+        config = SystemPaastaConfig(
+            config={"default_bounce_overprovision_factor": 0.5},
+            directory="/fake/dir",
+        )
+        assert config.get_bounce_overprovision_factor() == 0.5
+
+    def test_returns_default_when_not_configured(self):
+        config = SystemPaastaConfig(
+            config={},
+            directory="/fake/dir",
+        )
+        assert config.get_bounce_overprovision_factor() == 1.0


### PR DESCRIPTION
## Issue
`max_surge` is currently hard-coded at `"100%"` in `get_deployment_strategy_config()`. We want to make it configurable so services can control how aggressively they bounce.

## Changes
- Made bounce overprovision configurable at two levels:
  - **Per-service** — via `bounce_overprovision_factor` in EKS soaconfigs (float, 0.25-1). 0.25 is set as the hard floor to avoid any issues occurring when setting the value to 0%.
  - **System default** — via `default_bounce_overprovision_factor` in `SystemPaastaConfig` (defaults to `1.0`)
- Added `bounce_overprovision_factor` to the EKS schema (`eks_schema.json`) with number validation (`0 < value <= 1`)
- Updated documentation in `docs/source/bouncing.rst` and `docs/source/yelpsoa_configs.rst`
- Added unit tests for `get_bounce_overprovision_factor()` at both per-service and system levels
- Updated existing `test_get_deployment_strategy` and `test_warning_big_bounce_*` tests to mock the new method
- Uses 0-1 float values consistent with existing percent-based config like `bounce_margin_factor`