### PR TITLE
PEREL-5347: Add timeout alerting enablement keys to smartstack schema

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -1053,6 +1053,9 @@ These keys provide optional overrides for the default alerting behaviour.
    - ``error_threshold_ratio``: Error threshold ratio (0-1) for errors under this namespace. Defaults to **0.01**.
    - ``minimum_error_rps``: Minimum error rate per second for errors under this namespace before an alert can be triggered, minimum is zero. Defaults to **5**.
    - ``timeout_threshold_ratio``: Ratio (0-1) of ``timeout_server_ms`` at which to alert on p99 latency. Defaults to **0.8** (80%).
+   - ``timeout_alerting``: Enable latency/timeout alerting for this namespace. When true, alerts fire to the configured ``slack_channel`` when p99 latency exceeds the threshold. Defaults to **false**.
+   - ``timeout_page``: Page on latency threshold breach. Only applies when ``timeout_alerting`` is true. Defaults to **false**.
+   - ``timeout_ticket``: Create a Jira ticket on latency threshold breach. Only applies when ``timeout_alerting`` is true. Defaults to **false**.
    - ``default_endpoint_alerting``: Turn on alerts for all endpoints in this namespace. Defaults to **false**.
    - ``endpoint_error_threshold_ratio``: Error threshold ratio (0-1) for errors to any singular endpoint. Defaults to the namespace ``error_threshold_ratio`` if specified, or **0.01**.
    - ``endpoint_minimum_error_rps``: Minimum error rate per second for errors to any singular endpoint before an alert can be triggered for errors to any singular endpoint. Defaults to the namespace ``minimum_error_rps`` if specified, or **5**.

--- a/paasta_tools/cli/schemas/smartstack_schema.json
+++ b/paasta_tools/cli/schemas/smartstack_schema.json
@@ -277,6 +277,15 @@
                         "minimum": 0,
                         "maximum": 1
                     },
+                    "timeout_alerting": {
+                        "type": "boolean"
+                    },
+                    "timeout_page": {
+                        "type": "boolean"
+                    },
+                    "timeout_ticket": {
+                        "type": "boolean"
+                    },
                     "default_endpoint_alerting": {
                         "type": "boolean"
                     },


### PR DESCRIPTION
**Jira:** https://jira.yelpcorp.com/browse/PEREL-5347

## Summary

Add `timeout_alerting`, `timeout_page`, `timeout_ticket` boolean fields to the smartstack monitoring schema and documentation.

## Plan

These are opt-in enablement keys for the latency/timeout alerting feature. They gate whether a service namespace receives latency alerts and control escalation behavior.

| Key | Type | Default | Purpose |
|-----|------|---------|---------|
| timeout_alerting | boolean | false | Master switch - enables latency alerting (sends to slack_channel) |
| timeout_page | boolean | false | Escalate to paging on latency breach |
| timeout_ticket | boolean | false | Create Jira ticket on latency breach |

Related PRs:
- Exporter: https://github.yelpcorp.com/docker-images/yelpsoa-configs-mirror/pull/38 (reads these fields, exports as labels)
- Alerting rule: https://github.yelpcorp.com/misc/eks-k8s-configs/pull/9628 (filters on timeout_alerting=true)