### PR TITLE
Silence python_jsonschema_objects warnings + upgrade monk

### DIFF
--- a/paasta_tools/cli/cli.py
+++ b/paasta_tools/cli/cli.py
@@ -238,6 +238,17 @@ def main(argv=None):
     """
     logging.basicConfig()
     warnings.filterwarnings("ignore", category=DeprecationWarning)
+    # this is unfortunate, but python-jsonschema-objects does not support
+    # draft-06 schemas (although, they still work since we're not doing
+    # anything fancy) and its not really worth updating all the schemas that
+    # we currently consume to use an older/supported version since there's
+    # nothing stopping folks from adding new schemas with an unsuppoerted
+    # version
+    warnings.filterwarnings(
+        "ignore",
+        message="Schema version.*not recognized",
+        module="python_jsonschema_objects",
+    )
 
     # if we are an external command, we need to exec out early.
     # The reason we exec out early is so we don't bother trying to parse

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -12,7 +12,7 @@ inflection==0.3.1                   # slo-transcoder dependency
 iso8601==2.1.0                      # yelp-ips dependency
 logreader==1.3.0
 markdown==2.4                       # slo-transcoder dependency
-monk==1.3.0                         # yelp-clog dependency
+monk==3.2.2                         # yelp-clog dependency
 mrjob==0.7.4                        # scribereader dependency
 named-decorator==0.1.4              # yelp-profiling dependency
 ndg-httpsclient==0.4.3              # vault-tools dependency


### PR DESCRIPTION
This gets rid of some annoying spam when using the CLI:
```
/nail/home/luisp/pg/Yelp/paasta/.tox/py310-linux/lib/python3.10/site-packages/python_jsonschema_objects/__init__.py:49: UserWarning: Schema version http://json-schema.org/draft-06/schema# not recognized. Some keywords and features may not be supported.
  warnings.warn(
/nail/home/luisp/pg/Yelp/paasta/.tox/py310-linux/lib/python3.10/site-packages/monk/util.py:9: UserWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html. The pkg_resources package is slated for removal as early as 2025-11-30. Refrain from using this package or pin to Setuptools<81.
  import pkg_resources
```

The former is dealt with a silence (see my mini-essay in the code) and the latter is dealt with by upgrading `monk` - while the version bump looks pretty large, the major bumps here were really just done as part of dropping support for older Python versions