### PR TITLE
Add SL2 Grafana dashboard link to paasta status output

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -1031,9 +1031,9 @@ def print_kubernetes_status_v2(
     instance_state = get_instance_state(status)
     dashboard_url = get_sl2_dashboard(cluster, service, instance)
     output.append(
-        f"    {PaastaColors.yellow('y/sl2')}       {PaastaColors.blue(dashboard_url)}"
+        f"    {PaastaColors.yellow('y/sl2:')}      {PaastaColors.blue(dashboard_url)}"
     )
-    output.append(f"    State: {instance_state}")
+    output.append(f"    State:      {instance_state}")
     output.append("    Running versions:")
     if not verbose:
         output.append(
@@ -1537,7 +1537,7 @@ def print_kubernetes_status(
     )
     dashboard_url = get_sl2_dashboard(cluster, service, instance)
     output.append(
-        f"    {PaastaColors.yellow('y/sl2')}       {PaastaColors.blue(dashboard_url)}"
+        f"    {PaastaColors.yellow('y/sl2:')}      {PaastaColors.blue(dashboard_url)}"
     )
     output.append(f"    State:      {bouncing_status} - Desired state: {desired_state}")
 

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -327,18 +327,9 @@ def paasta_status_on_api_endpoint(
     is_eks: bool = False,
     all_namespaces: bool = False,
 ) -> int:
-    ecosystem = system_paasta_config.get_ecosystem_for_cluster(cluster)
-    dashboard_url = (
-        f"https://grafana.yelpcorp.com/d/d304815a-aea2-4de9-8e67-d37645967801/service-load"
-        f"?var-ServiceName={service}"
-        f"&var-Ecosystem={ecosystem}"
-        f"&var-SuperRegion={cluster}"
-        f"&var-Paasta_Instance={instance}"
-    )
     output = [
         "",
         f"\n{service}.{PaastaColors.cyan(instance)} in {cluster}{' (EKS)' if is_eks else ''}",
-        f"    Grafana:    {PaastaColors.blue(dashboard_url)}",
     ]
     client = get_paasta_oapi_client(
         cluster=get_paasta_oapi_api_clustername(cluster=cluster, is_eks=is_eks),
@@ -373,6 +364,7 @@ def paasta_status_on_api_endpoint(
     # TODO: Remove this when all clusters are returning status.version
     elif status.git_sha != "":
         output.append(f"    Git sha:    {status.git_sha} (desired)")
+
     instance_types = find_instance_types(status)
     if not instance_types:
         output.append(
@@ -382,6 +374,16 @@ def paasta_status_on_api_endpoint(
             )
         )
         return 0
+    if any(t in ("kubernetes", "kubernetes_v2", "eks") for t in instance_types):
+        ecosystem = system_paasta_config.get_ecosystem_for_cluster(cluster)
+        dashboard_url = (
+            f"https://grafana.yelpcorp.com/d/d304815a-aea2-4de9-8e67-d37645967801/service-load"
+            f"?var-ServiceName={service}"
+            f"&var-Ecosystem={ecosystem}"
+            f"&var-SuperRegion={cluster}"
+            f"&var-Paasta_Instance={instance}"
+        )
+        output.append(f"    SL2:        {PaastaColors.blue(dashboard_url)}")
 
     ret_code = 0
     for instance_type in instance_types:

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -327,9 +327,18 @@ def paasta_status_on_api_endpoint(
     is_eks: bool = False,
     all_namespaces: bool = False,
 ) -> int:
+    ecosystem = system_paasta_config.get_ecosystem_for_cluster(cluster)
+    dashboard_url = (
+        f"https://grafana.yelpcorp.com/d/d304815a-aea2-4de9-8e67-d37645967801/service-load"
+        f"?var-ServiceName={service}"
+        f"&var-Ecosystem={ecosystem}"
+        f"&var-SuperRegion={cluster}"
+        f"&var-Paasta_Instance={instance}"
+    )
     output = [
         "",
         f"\n{service}.{PaastaColors.cyan(instance)} in {cluster}{' (EKS)' if is_eks else ''}",
+        f"    Grafana:  {PaastaColors.blue(dashboard_url)}",
     ]
     client = get_paasta_oapi_client(
         cluster=get_paasta_oapi_api_clustername(cluster=cluster, is_eks=is_eks),

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -126,6 +126,7 @@ InstanceStatusWriter = Callable[
             str,
             "cluster",  # noqa: F821  # flake8 false-positive, these are not var references
         ),
+        Arg(str, "ecosystem"),  # noqa: F821  # flake8 false-positive
         Arg(str, "service"),  # noqa: F821  # flake8 false-positive
         Arg(str, "instance"),  # noqa: F821  # flake8 false-positive
         Arg(List[str], "output"),  # noqa: F821  # flake8 false-positive
@@ -374,24 +375,15 @@ def paasta_status_on_api_endpoint(
             )
         )
         return 0
-    if any(t in ("kubernetes", "kubernetes_v2", "eks") for t in instance_types):
-        ecosystem = system_paasta_config.get_ecosystem_for_cluster(cluster)
-        dashboard_url = (
-            f"https://grafana.yelpcorp.com/d/d304815a-aea2-4de9-8e67-d37645967801/service-load"
-            f"?var-ServiceName={service}"
-            f"&var-Ecosystem={ecosystem}"
-            f"&var-SuperRegion={cluster}"
-            f"&var-Paasta_Instance={instance}"
-        )
-        output.append(f"    SL2:        {PaastaColors.blue(dashboard_url)}")
 
+    ecosystem = system_paasta_config.get_ecosystem_for_cluster(cluster)
     ret_code = 0
     for instance_type in instance_types:
         # check the actual status value and call the corresponding status writer
         service_status_value = getattr(status, instance_type)
         writer_callable = INSTANCE_TYPE_WRITERS.get(instance_type)
         ret = writer_callable(
-            cluster, service, instance, output, service_status_value, verbose
+            cluster, ecosystem, service, instance, output, service_status_value, verbose
         )
         if ret != 0:
             output.append(
@@ -421,6 +413,7 @@ def find_instance_types(status: Any) -> List[str]:
 
 def print_adhoc_status(
     cluster: str,
+    ecosystem: str,
     service: str,
     instance: str,
     output: List[str],
@@ -944,6 +937,7 @@ def _print_flink_status_from_job_manager(
 
 def print_flink_status(
     cluster: str,
+    ecosystem: str,
     service: str,
     instance: str,
     output: List[str],
@@ -982,6 +976,7 @@ def print_flink_status(
 
 def print_flinkeks_status(
     cluster: str,
+    ecosystem: str,
     service: str,
     instance: str,
     output: List[str],
@@ -1021,6 +1016,7 @@ def print_flinkeks_status(
 
 def print_kubernetes_status_v2(
     cluster: str,
+    ecosystem: str,
     service: str,
     instance: str,
     output: List[str],
@@ -1028,6 +1024,14 @@ def print_kubernetes_status_v2(
     verbose: int = 0,
 ) -> int:
     instance_state = get_instance_state(status)
+    dashboard_url = (
+        f"https://grafana.yelpcorp.com/d/d304815a-aea2-4de9-8e67-d37645967801/service-load"
+        f"?var-ServiceName={service}"
+        f"&var-Ecosystem={ecosystem}"
+        f"&var-SuperRegion={cluster}"
+        f"&var-Paasta_Instance={instance}"
+    )
+    output.append(f"    SL2:        {PaastaColors.blue(dashboard_url)}")
     output.append(f"    State: {instance_state}")
     output.append("    Running versions:")
     if not verbose:
@@ -1518,6 +1522,7 @@ def get_autoscaling_table(
 
 def print_kubernetes_status(
     cluster: str,
+    ecosystem: str,
     service: str,
     instance: str,
     output: List[str],
@@ -1530,6 +1535,14 @@ def print_kubernetes_status(
     desired_state = desired_state_human(
         kubernetes_status.desired_state, kubernetes_status.expected_instance_count
     )
+    dashboard_url = (
+        f"https://grafana.yelpcorp.com/d/d304815a-aea2-4de9-8e67-d37645967801/service-load"
+        f"?var-ServiceName={service}"
+        f"&var-Ecosystem={ecosystem}"
+        f"&var-SuperRegion={cluster}"
+        f"&var-Paasta_Instance={instance}"
+    )
+    output.append(f"    SL2:        {PaastaColors.blue(dashboard_url)}")
     output.append(f"    State:      {bouncing_status} - Desired state: {desired_state}")
 
     status = KubernetesDeployStatus.fromstring(kubernetes_status.deploy_status)
@@ -1629,6 +1642,7 @@ def print_kubernetes_status(
 
 def print_tron_status(
     cluster: str,
+    ecosystem: str,
     service: str,
     instance: str,
     output: List[str],
@@ -1656,6 +1670,7 @@ def print_tron_status(
 
 def print_cassandra_status(
     cluster: str,
+    ecosystem: str,
     service: str,
     instance: str,
     output: List[str],
@@ -1807,6 +1822,7 @@ def node_property_to_str(prop: Dict[str, Any], verbose: int) -> str:
 
 def print_kafka_status(
     cluster: str,
+    ecosystem: str,
     service: str,
     instance: str,
     output: List[str],

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -126,7 +126,6 @@ InstanceStatusWriter = Callable[
             str,
             "cluster",  # noqa: F821  # flake8 false-positive, these are not var references
         ),
-        Arg(str, "ecosystem"),  # noqa: F821  # flake8 false-positive
         Arg(str, "service"),  # noqa: F821  # flake8 false-positive
         Arg(str, "instance"),  # noqa: F821  # flake8 false-positive
         Arg(List[str], "output"),  # noqa: F821  # flake8 false-positive
@@ -376,14 +375,13 @@ def paasta_status_on_api_endpoint(
         )
         return 0
 
-    ecosystem = system_paasta_config.get_ecosystem_for_cluster(cluster)
     ret_code = 0
     for instance_type in instance_types:
         # check the actual status value and call the corresponding status writer
         service_status_value = getattr(status, instance_type)
         writer_callable = INSTANCE_TYPE_WRITERS.get(instance_type)
         ret = writer_callable(
-            cluster, ecosystem, service, instance, output, service_status_value, verbose
+            cluster, service, instance, output, service_status_value, verbose
         )
         if ret != 0:
             output.append(
@@ -413,7 +411,6 @@ def find_instance_types(status: Any) -> List[str]:
 
 def print_adhoc_status(
     cluster: str,
-    ecosystem: str,
     service: str,
     instance: str,
     output: List[str],
@@ -937,7 +934,6 @@ def _print_flink_status_from_job_manager(
 
 def print_flink_status(
     cluster: str,
-    ecosystem: str,
     service: str,
     instance: str,
     output: List[str],
@@ -976,7 +972,6 @@ def print_flink_status(
 
 def print_flinkeks_status(
     cluster: str,
-    ecosystem: str,
     service: str,
     instance: str,
     output: List[str],
@@ -1014,9 +1009,19 @@ def print_flinkeks_status(
     )
 
 
+def get_sl2_dashboard(cluster: str, service: str, instance: str) -> str:
+    ecosystem: str = load_system_paasta_config().get_ecosystem_for_cluster(cluster)
+    return (
+        f"https://grafana.yelpcorp.com/d/d304815a-aea2-4de9-8e67-d37645967801/service-load"
+        f"?var-ServiceName={service}"
+        f"&var-Ecosystem={ecosystem}"
+        f"&var-SuperRegion={cluster}"
+        f"&var-Paasta_Instance={instance}"
+    )
+
+
 def print_kubernetes_status_v2(
     cluster: str,
-    ecosystem: str,
     service: str,
     instance: str,
     output: List[str],
@@ -1024,14 +1029,10 @@ def print_kubernetes_status_v2(
     verbose: int = 0,
 ) -> int:
     instance_state = get_instance_state(status)
-    dashboard_url = (
-        f"https://grafana.yelpcorp.com/d/d304815a-aea2-4de9-8e67-d37645967801/service-load"
-        f"?var-ServiceName={service}"
-        f"&var-Ecosystem={ecosystem}"
-        f"&var-SuperRegion={cluster}"
-        f"&var-Paasta_Instance={instance}"
+    dashboard_url = get_sl2_dashboard(cluster, service, instance)
+    output.append(
+        f"    {PaastaColors.yellow('y/sl2')}       {PaastaColors.blue(dashboard_url)}"
     )
-    output.append(f"    SL2:        {PaastaColors.blue(dashboard_url)}")
     output.append(f"    State: {instance_state}")
     output.append("    Running versions:")
     if not verbose:
@@ -1522,7 +1523,6 @@ def get_autoscaling_table(
 
 def print_kubernetes_status(
     cluster: str,
-    ecosystem: str,
     service: str,
     instance: str,
     output: List[str],
@@ -1535,14 +1535,10 @@ def print_kubernetes_status(
     desired_state = desired_state_human(
         kubernetes_status.desired_state, kubernetes_status.expected_instance_count
     )
-    dashboard_url = (
-        f"https://grafana.yelpcorp.com/d/d304815a-aea2-4de9-8e67-d37645967801/service-load"
-        f"?var-ServiceName={service}"
-        f"&var-Ecosystem={ecosystem}"
-        f"&var-SuperRegion={cluster}"
-        f"&var-Paasta_Instance={instance}"
+    dashboard_url = get_sl2_dashboard(cluster, service, instance)
+    output.append(
+        f"    {PaastaColors.yellow('y/sl2')}       {PaastaColors.blue(dashboard_url)}"
     )
-    output.append(f"    SL2:        {PaastaColors.blue(dashboard_url)}")
     output.append(f"    State:      {bouncing_status} - Desired state: {desired_state}")
 
     status = KubernetesDeployStatus.fromstring(kubernetes_status.deploy_status)
@@ -1642,7 +1638,6 @@ def print_kubernetes_status(
 
 def print_tron_status(
     cluster: str,
-    ecosystem: str,
     service: str,
     instance: str,
     output: List[str],
@@ -1670,7 +1665,6 @@ def print_tron_status(
 
 def print_cassandra_status(
     cluster: str,
-    ecosystem: str,
     service: str,
     instance: str,
     output: List[str],
@@ -1822,7 +1816,6 @@ def node_property_to_str(prop: Dict[str, Any], verbose: int) -> str:
 
 def print_kafka_status(
     cluster: str,
-    ecosystem: str,
     service: str,
     instance: str,
     output: List[str],

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -338,7 +338,7 @@ def paasta_status_on_api_endpoint(
     output = [
         "",
         f"\n{service}.{PaastaColors.cyan(instance)} in {cluster}{' (EKS)' if is_eks else ''}",
-        f"    Grafana:  {PaastaColors.blue(dashboard_url)}",
+        f"    Grafana:    {PaastaColors.blue(dashboard_url)}",
     ]
     client = get_paasta_oapi_client(
         cluster=get_paasta_oapi_api_clustername(cluster=cluster, is_eks=is_eks),

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -37,7 +37,6 @@ from paasta_tools.cli.cmds.status import desired_state_human
 from paasta_tools.cli.cmds.status import format_kubernetes_pod_table
 from paasta_tools.cli.cmds.status import format_kubernetes_replicaset_table
 from paasta_tools.cli.cmds.status import get_instance_state
-from paasta_tools.cli.cmds.status import get_sl2_dashboard
 from paasta_tools.cli.cmds.status import get_smartstack_status_human
 from paasta_tools.cli.cmds.status import get_versions_table
 from paasta_tools.cli.cmds.status import haproxy_backend_report
@@ -1643,9 +1642,13 @@ def mock_flink_status() -> Mapping[str, Any]:
     )
 
 
+@mock.patch("paasta_tools.cli.cmds.status.get_sl2_dashboard", autospec=True)
 @mock.patch("paasta_tools.cli.cmds.status.get_paasta_oapi_client", autospec=True)
 def test_paasta_status_on_api_endpoint_kubernetes_v2(
-    mock_get_paasta_oapi_client, system_paasta_config, mock_kubernetes_status_v2
+    mock_get_paasta_oapi_client,
+    mock_get_sl2_dashboard,
+    system_paasta_config,
+    mock_kubernetes_status_v2,
 ):
     fake_status_obj = paastamodels.InstanceStatus(
         git_sha="fake_git_sha",
@@ -1746,7 +1749,8 @@ def mock_kubernetes_status_v2():
 
 
 class TestPrintKubernetesStatusV2:
-    def test_error(self, mock_kubernetes_status_v2):
+    @mock.patch("paasta_tools.cli.cmds.status.get_sl2_dashboard", autospec=True)
+    def test_error(self, mock_get_sl2_dashboard, mock_kubernetes_status_v2):
         mock_kubernetes_status_v2.error_message = "Something bad happened!"
         output = []
         return_code = print_kubernetes_status_v2(
@@ -1760,7 +1764,10 @@ class TestPrintKubernetesStatusV2:
         assert return_code == 1
         assert "Something bad happened!" in output[-1]
 
-    def test_successful_return_value(self, mock_kubernetes_status_v2):
+    @mock.patch("paasta_tools.cli.cmds.status.get_sl2_dashboard", autospec=True)
+    def test_successful_return_value(
+        self, mock_get_sl2_dashboard, mock_kubernetes_status_v2
+    ):
         return_code = print_kubernetes_status_v2(
             cluster="cluster",
             service="service",
@@ -1771,6 +1778,7 @@ class TestPrintKubernetesStatusV2:
         )
         assert return_code == 0
 
+    @mock.patch("paasta_tools.cli.cmds.status.get_sl2_dashboard", autospec=True)
     @mock.patch(
         "paasta_tools.cli.cmds.status.get_instance_state",
         autospec=True,
@@ -1783,6 +1791,7 @@ class TestPrintKubernetesStatusV2:
         self,
         mock_get_versions_table,
         mock_get_instance_state,
+        mock_get_sl2_dashboard,
         mock_kubernetes_status_v2,
     ):
         output = []
@@ -2160,7 +2169,8 @@ class TestGetVersionsTable:
 
 
 class TestPrintKubernetesStatus:
-    def test_error(self, mock_kubernetes_status):
+    @mock.patch("paasta_tools.cli.cmds.status.get_sl2_dashboard", autospec=True)
+    def test_error(self, mock_get_sl2_dashboard, mock_kubernetes_status):
         mock_kubernetes_status.error_message = "Things went wrong"
         output = []
         return_value = print_kubernetes_status(
@@ -2174,7 +2184,10 @@ class TestPrintKubernetesStatus:
         assert return_value == 1
         assert PaastaColors.red("Things went wrong") in output[-1]
 
-    def test_successful_return_value(self, mock_kubernetes_status):
+    @mock.patch("paasta_tools.cli.cmds.status.get_sl2_dashboard", autospec=True)
+    def test_successful_return_value(
+        self, mock_get_sl2_dashboard, mock_kubernetes_status
+    ):
         return_value = print_kubernetes_status(
             cluster="fake_cluster",
             service="fake_service",
@@ -2184,6 +2197,7 @@ class TestPrintKubernetesStatus:
         )
         assert return_value == 0
 
+    @patch("paasta_tools.cli.cmds.status.get_sl2_dashboard", autospec=True)
     @patch("paasta_tools.cli.cmds.status.get_smartstack_status_human", autospec=True)
     @patch("paasta_tools.cli.cmds.status.get_envoy_status_human", autospec=True)
     @patch("paasta_tools.cli.cmds.status.humanize.naturaltime", autospec=True)
@@ -2202,6 +2216,7 @@ class TestPrintKubernetesStatus:
         mock_naturaltime,
         mock_get_envoy_status_human,
         mock_get_smartstack_status_human,
+        mock_get_sl2_dashboard,
         mock_kubernetes_status,
     ):
         mock_bouncing_status.return_value = "Bouncing (crossover)"
@@ -2260,7 +2275,7 @@ class TestPrintKubernetesStatus:
             kubernetes_status=mock_kubernetes_status,
         )
 
-        dashboard_url = get_sl2_dashboard(
+        dashboard_url = mock_get_sl2_dashboard(
             cluster="fake_cluster", service="fake_service", instance="fake_instance"
         )
         expected_output = [

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -1797,7 +1797,7 @@ class TestPrintKubernetesStatusV2:
             verbose=0,
         )
         joined_output = "\n".join(output)
-        assert f"State: {mock_get_instance_state.return_value}" in joined_output
+        assert f"State:      {mock_get_instance_state.return_value}" in joined_output
         mock_get_versions_table.assert_called_once_with(
             mock.ANY, "service", "instance", "cluster", 0
         )
@@ -2264,7 +2264,7 @@ class TestPrintKubernetesStatus:
             cluster="fake_cluster", service="fake_service", instance="fake_instance"
         )
         expected_output = [
-            f"    {PaastaColors.yellow('y/sl2')}       {PaastaColors.blue(dashboard_url)}",
+            f"    {PaastaColors.yellow('y/sl2:')}      {PaastaColors.blue(dashboard_url)}",
             f"    State:      {mock_bouncing_status.return_value} - Desired state: {mock_desired_state.return_value}",
             f"    Kubernetes:   {PaastaColors.green('Healthy')} - up with {PaastaColors.green('(2/2)')} instances ({PaastaColors.red('1')} evicted). Status: {mock_kubernetes_app_deploy_status_human.return_value}",
         ]

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -37,6 +37,7 @@ from paasta_tools.cli.cmds.status import desired_state_human
 from paasta_tools.cli.cmds.status import format_kubernetes_pod_table
 from paasta_tools.cli.cmds.status import format_kubernetes_replicaset_table
 from paasta_tools.cli.cmds.status import get_instance_state
+from paasta_tools.cli.cmds.status import get_sl2_dashboard
 from paasta_tools.cli.cmds.status import get_smartstack_status_human
 from paasta_tools.cli.cmds.status import get_versions_table
 from paasta_tools.cli.cmds.status import haproxy_backend_report
@@ -1705,7 +1706,6 @@ def test_format_kubernetes_replicaset_table_in_non_verbose(mock_kubernetes_statu
         mock_kubernetes_status.error_message = ""
         status.print_kubernetes_status(
             cluster="fake_cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=[],
@@ -1751,7 +1751,6 @@ class TestPrintKubernetesStatusV2:
         output = []
         return_code = print_kubernetes_status_v2(
             cluster="cluster",
-            ecosystem="fake_ecosystem",
             service="service",
             instance="instance",
             output=output,
@@ -1764,7 +1763,6 @@ class TestPrintKubernetesStatusV2:
     def test_successful_return_value(self, mock_kubernetes_status_v2):
         return_code = print_kubernetes_status_v2(
             cluster="cluster",
-            ecosystem="fake_ecosystem",
             service="service",
             instance="instance",
             output=[],
@@ -1792,7 +1790,6 @@ class TestPrintKubernetesStatusV2:
         mock_get_versions_table.return_value = mock_versions_table
         print_kubernetes_status_v2(
             cluster="cluster",
-            ecosystem="fake_ecosystem",
             service="service",
             instance="instance",
             output=output,
@@ -2168,7 +2165,6 @@ class TestPrintKubernetesStatus:
         output = []
         return_value = print_kubernetes_status(
             cluster="fake_Cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2181,7 +2177,6 @@ class TestPrintKubernetesStatus:
     def test_successful_return_value(self, mock_kubernetes_status):
         return_value = print_kubernetes_status(
             cluster="fake_cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=[],
@@ -2259,22 +2254,17 @@ class TestPrintKubernetesStatus:
         output = []
         print_kubernetes_status(
             cluster="fake_cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
             kubernetes_status=mock_kubernetes_status,
         )
 
-        dashboard_url = (
-            "https://grafana.yelpcorp.com/d/d304815a-aea2-4de9-8e67-d37645967801/service-load"
-            "?var-ServiceName=fake_service"
-            "&var-Ecosystem=fake_ecosystem"
-            "&var-SuperRegion=fake_cluster"
-            "&var-Paasta_Instance=fake_instance"
+        dashboard_url = get_sl2_dashboard(
+            cluster="fake_cluster", service="fake_service", instance="fake_instance"
         )
         expected_output = [
-            f"    SL2:        {PaastaColors.blue(dashboard_url)}",
+            f"    {PaastaColors.yellow('y/sl2')}       {PaastaColors.blue(dashboard_url)}",
             f"    State:      {mock_bouncing_status.return_value} - Desired state: {mock_desired_state.return_value}",
             f"    Kubernetes:   {PaastaColors.green('Healthy')} - up with {PaastaColors.green('(2/2)')} instances ({PaastaColors.red('1')} evicted). Status: {mock_kubernetes_app_deploy_status_human.return_value}",
         ]
@@ -2298,7 +2288,6 @@ class TestPrintCassandraStatus:
         output = []
         return_value = print_cassandra_status(
             cluster="fake_cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2326,7 +2315,6 @@ class TestPrintCassandraStatus:
         output = []
         return_value = print_cassandra_status(
             cluster="fake_cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2376,7 +2364,6 @@ class TestPrintCassandraStatus:
         output = []
         return_value = print_cassandra_status(
             cluster="fake_cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2410,7 +2397,6 @@ class TestPrintKafkaStatus:
         output = []
         return_value = print_kafka_status(
             cluster="fake_Cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2424,7 +2410,6 @@ class TestPrintKafkaStatus:
     def test_successful_return_value(self, mock_kafka_status):
         return_value = print_kafka_status(
             cluster="fake_cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=[],
@@ -2443,7 +2428,6 @@ class TestPrintKafkaStatus:
         output = []
         print_kafka_status(
             cluster="fake_cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2494,7 +2478,6 @@ class TestPrintFlinkStatus:
         output = []
         return_value = print_flink_status(
             cluster="fake_cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2527,7 +2510,6 @@ class TestPrintFlinkStatus:
         output = []
         return_value = print_flink_status(
             cluster="fake_cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2562,7 +2544,6 @@ class TestPrintFlinkStatus:
         output = []
         return_value = print_flink_status(
             cluster="fake_cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2593,7 +2574,6 @@ class TestPrintFlinkStatus:
         output = []
         return_value = print_flink_status(
             cluster="fake_cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2623,7 +2603,6 @@ class TestPrintFlinkStatus:
         output = []
         return_value = print_flink_status(
             cluster="fake_cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2656,7 +2635,6 @@ class TestPrintFlinkStatus:
         output = []
         return_value = print_flink_status(
             cluster="fake_cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2692,7 +2670,6 @@ class TestPrintFlinkStatus:
 
         return_value = print_flink_status(
             cluster="fake_cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=[],
@@ -2754,7 +2731,6 @@ class TestPrintFlinkStatus:
         output = []
         return_value = print_flink_status(
             cluster="fake_cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2805,7 +2781,6 @@ class TestPrintFlinkStatus:
         output = []
         return_value = print_flink_status(
             cluster="fake_cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2845,7 +2820,6 @@ class TestPrintFlinkStatus:
         output = []
         print_flink_status(
             cluster="fake_cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2896,7 +2870,6 @@ class TestPrintFlinkStatus:
         mock_flink_status["status"]["state"] = "Stoppingjobmanager"
         print_flink_status(
             cluster="fake_cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2950,7 +2923,6 @@ class TestPrintFlinkStatus:
         ][2:]
         print_flink_status(
             cluster="fake_cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2999,7 +2971,6 @@ class TestPrintFlinkStatus:
         output = []
         print_flink_status(
             cluster="fake_cluster",
-            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -1695,6 +1695,8 @@ def test_format_kubernetes_replicaset_table_in_non_verbose(mock_kubernetes_statu
         "paasta_tools.cli.cmds.status.format_kubernetes_replicaset_table", autospec=True
     ) as mock_format_kubernetes_replicaset_table, mock.patch(
         "paasta_tools.cli.cmds.status.bouncing_status_human", autospec=True
+    ), mock.patch(
+        "paasta_tools.cli.cmds.status.get_sl2_dashboard", autospec=True
     ):
         mock_kubernetes_status.replicasets = [
             paastamodels.KubernetesReplicaSet(

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -1705,6 +1705,7 @@ def test_format_kubernetes_replicaset_table_in_non_verbose(mock_kubernetes_statu
         mock_kubernetes_status.error_message = ""
         status.print_kubernetes_status(
             cluster="fake_cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=[],
@@ -1750,6 +1751,7 @@ class TestPrintKubernetesStatusV2:
         output = []
         return_code = print_kubernetes_status_v2(
             cluster="cluster",
+            ecosystem="fake_ecosystem",
             service="service",
             instance="instance",
             output=output,
@@ -1762,6 +1764,7 @@ class TestPrintKubernetesStatusV2:
     def test_successful_return_value(self, mock_kubernetes_status_v2):
         return_code = print_kubernetes_status_v2(
             cluster="cluster",
+            ecosystem="fake_ecosystem",
             service="service",
             instance="instance",
             output=[],
@@ -1789,6 +1792,7 @@ class TestPrintKubernetesStatusV2:
         mock_get_versions_table.return_value = mock_versions_table
         print_kubernetes_status_v2(
             cluster="cluster",
+            ecosystem="fake_ecosystem",
             service="service",
             instance="instance",
             output=output,
@@ -2164,6 +2168,7 @@ class TestPrintKubernetesStatus:
         output = []
         return_value = print_kubernetes_status(
             cluster="fake_Cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2176,6 +2181,7 @@ class TestPrintKubernetesStatus:
     def test_successful_return_value(self, mock_kubernetes_status):
         return_value = print_kubernetes_status(
             cluster="fake_cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=[],
@@ -2253,13 +2259,22 @@ class TestPrintKubernetesStatus:
         output = []
         print_kubernetes_status(
             cluster="fake_cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
             kubernetes_status=mock_kubernetes_status,
         )
 
+        dashboard_url = (
+            "https://grafana.yelpcorp.com/d/d304815a-aea2-4de9-8e67-d37645967801/service-load"
+            "?var-ServiceName=fake_service"
+            "&var-Ecosystem=fake_ecosystem"
+            "&var-SuperRegion=fake_cluster"
+            "&var-Paasta_Instance=fake_instance"
+        )
         expected_output = [
+            f"    SL2:        {PaastaColors.blue(dashboard_url)}",
             f"    State:      {mock_bouncing_status.return_value} - Desired state: {mock_desired_state.return_value}",
             f"    Kubernetes:   {PaastaColors.green('Healthy')} - up with {PaastaColors.green('(2/2)')} instances ({PaastaColors.red('1')} evicted). Status: {mock_kubernetes_app_deploy_status_human.return_value}",
         ]
@@ -2283,6 +2298,7 @@ class TestPrintCassandraStatus:
         output = []
         return_value = print_cassandra_status(
             cluster="fake_cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2310,6 +2326,7 @@ class TestPrintCassandraStatus:
         output = []
         return_value = print_cassandra_status(
             cluster="fake_cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2359,6 +2376,7 @@ class TestPrintCassandraStatus:
         output = []
         return_value = print_cassandra_status(
             cluster="fake_cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2392,6 +2410,7 @@ class TestPrintKafkaStatus:
         output = []
         return_value = print_kafka_status(
             cluster="fake_Cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2405,6 +2424,7 @@ class TestPrintKafkaStatus:
     def test_successful_return_value(self, mock_kafka_status):
         return_value = print_kafka_status(
             cluster="fake_cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=[],
@@ -2423,6 +2443,7 @@ class TestPrintKafkaStatus:
         output = []
         print_kafka_status(
             cluster="fake_cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2473,6 +2494,7 @@ class TestPrintFlinkStatus:
         output = []
         return_value = print_flink_status(
             cluster="fake_cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2505,6 +2527,7 @@ class TestPrintFlinkStatus:
         output = []
         return_value = print_flink_status(
             cluster="fake_cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2539,6 +2562,7 @@ class TestPrintFlinkStatus:
         output = []
         return_value = print_flink_status(
             cluster="fake_cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2569,6 +2593,7 @@ class TestPrintFlinkStatus:
         output = []
         return_value = print_flink_status(
             cluster="fake_cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2598,6 +2623,7 @@ class TestPrintFlinkStatus:
         output = []
         return_value = print_flink_status(
             cluster="fake_cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2630,6 +2656,7 @@ class TestPrintFlinkStatus:
         output = []
         return_value = print_flink_status(
             cluster="fake_cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2665,6 +2692,7 @@ class TestPrintFlinkStatus:
 
         return_value = print_flink_status(
             cluster="fake_cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=[],
@@ -2726,6 +2754,7 @@ class TestPrintFlinkStatus:
         output = []
         return_value = print_flink_status(
             cluster="fake_cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2776,6 +2805,7 @@ class TestPrintFlinkStatus:
         output = []
         return_value = print_flink_status(
             cluster="fake_cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2815,6 +2845,7 @@ class TestPrintFlinkStatus:
         output = []
         print_flink_status(
             cluster="fake_cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2865,6 +2896,7 @@ class TestPrintFlinkStatus:
         mock_flink_status["status"]["state"] = "Stoppingjobmanager"
         print_flink_status(
             cluster="fake_cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2918,6 +2950,7 @@ class TestPrintFlinkStatus:
         ][2:]
         print_flink_status(
             cluster="fake_cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,
@@ -2966,6 +2999,7 @@ class TestPrintFlinkStatus:
         output = []
         print_flink_status(
             cluster="fake_cluster",
+            ecosystem="fake_ecosystem",
             service="fake_service",
             instance="fake_instance",
             output=output,


### PR DESCRIPTION
Shows a direct link to the service-load Grafana dashboard for each instance, pre-filtered by service, ecosystem, cluster, and instance.

<img width="1512" height="138" alt="Screenshot 2026-05-11 at 14 23 21" src="https://github.com/user-attachments/assets/6560878e-b0b7-4bf4-90b4-9b143f9cc699" />


Kinda long but hopefully we can change it with y links at some point. 

Also, it accurately uses _cluster_ for the `SuperRegion` parameter
