### PR TITLE
Fix local-run secrets retrieval for EKS clusters

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -912,8 +912,12 @@ def run_docker_container(
         # if secrets_for_owner_team enabled in yelpsoa for service
         if is_secrets_for_teams_enabled(service, soa_dir):
             try:
+                cluster = instance_config.cluster
+                kube_context = (
+                    cluster if cluster.startswith("eks-") else f"eks-{cluster}"
+                )
                 kube_client = KubeClient(
-                    config_file=KUBE_CONFIG_USER_PATH, context=instance_config.cluster
+                    config_file=KUBE_CONFIG_USER_PATH, context=kube_context
                 )
                 secret_environment = get_kubernetes_secret_env_variables(
                     kube_client, environment, service, instance_config.get_namespace()

--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -913,6 +913,10 @@ def run_docker_container(
         if is_secrets_for_teams_enabled(service, soa_dir):
             try:
                 cluster = instance_config.cluster
+                # Clusters that have both an EKS and non-EKS pair use
+                # eks-prefixed context names (e.g. eks-pnw-devc). Clusters
+                # like eksstage or spark clusters don't, but no one
+                # local-runs on those today.
                 kube_context = (
                     cluster if cluster.startswith("eks-") else f"eks-{cluster}"
                 )


### PR DESCRIPTION
## Problem or Feature 

The kube context for EKS clusters is `eks-{cluster}`, but `instance_config.cluster` only contains the base name (e.g. `pnw-devc`). This caused 404s when fetching secrets_for_teams secrets via local-run.

## Testing Done

- Tested with an eks workload (eks-pnw-devc)
- Tested with a tron workload (tron-pnw-devc)
- Both successfully retrieve secrets via `local-run --decrypt-secrets`