### PR TITLE
Add best-effort Jenkins link to paasta status -v output

### DIFF
--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -2147,6 +2147,14 @@ def apply_args_filters(
     return clusters_services_instances
 
 
+def print_jenkins_link(service: str, verbose: int) -> None:
+    if verbose >= 1:
+        jenkins_url = (
+            f"https://jenkins-paasta-k8s.yelpcorp.com/job/services-{service}-paasta/"
+        )
+        print(f"\nJenkins: {PaastaColors.blue(jenkins_url)}")
+
+
 def paasta_status(args) -> int:
     """Print the status of a Yelp service running on PaaSTA.
     :param args: argparse.Namespace obj created from sys.args by cli"""
@@ -2157,6 +2165,11 @@ def paasta_status(args) -> int:
     printer = CancellablePrinter()
     tasks = []
     clusters_services_instances = apply_args_filters(args)
+
+    services = set().union(*clusters_services_instances.values())
+    for svc in services:
+        print_jenkins_link(svc, args.verbose)
+
     for cluster, service_instances in clusters_services_instances.items():
         for service, instances in service_instances.items():
             all_flink = all((i in FLINK_DEPLOYMENT_CONFIGS) for i in instances.values())

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -2147,14 +2147,6 @@ def apply_args_filters(
     return clusters_services_instances
 
 
-def print_jenkins_link(service: str, verbose: int) -> None:
-    if verbose >= 1:
-        jenkins_url = (
-            f"https://jenkins-paasta-k8s.yelpcorp.com/job/services-{service}-paasta/"
-        )
-        print(f"\nJenkins: {PaastaColors.blue(jenkins_url)}")
-
-
 def paasta_status(args) -> int:
     """Print the status of a Yelp service running on PaaSTA.
     :param args: argparse.Namespace obj created from sys.args by cli"""
@@ -2166,9 +2158,9 @@ def paasta_status(args) -> int:
     tasks = []
     clusters_services_instances = apply_args_filters(args)
 
-    services = set().union(*clusters_services_instances.values())
-    for svc in services:
-        print_jenkins_link(svc, args.verbose)
+    if args.verbose and clusters_services_instances:
+        jenkins_url = f"http://y/jenkins?filter={args.service}"
+        print(f"\nDeployment Pipeline(s): {PaastaColors.blue(jenkins_url)}")
 
     for cluster, service_instances in clusters_services_instances.items():
         for service, instances in service_instances.items():

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -213,6 +213,7 @@ def test_status_pending_pipeline_build_message(
     args.clusters = None
     args.instances = None
     args.owner = None
+    args.verbose = 0
     args.soa_dir = utils.DEFAULT_SOA_DIR
     args.registration = None
     args.service_instance = None
@@ -819,6 +820,7 @@ def test_status_with_owner(
     args.clusters = None
     args.deploy_group = None
     args.owner = "faketeam"
+    args.verbose = 0
     args.soa_dir = "/fake/soa/dir"
     args.registration = None
     args.service_instance = None


### PR DESCRIPTION
Prints a link to the service's Jenkins job page once per service when verbose mode is enabled.

Had to add `verbose` to some tests for the tests to pass

<img width="954" height="204" alt="Screenshot 2026-05-08 at 16 14 39" src="https://github.com/user-attachments/assets/db8818cb-494e-42dc-8454-9319c6d01938" />
