### PR TITLE
Add PaaSTA Playground Claude Skill

### DIFF
--- a/.claude/skills/paasta-playground/SKILL.md
+++ b/.claude/skills/paasta-playground/SKILL.md
@@ -454,22 +454,3 @@ The docker image must be pullable from the Kind cluster. For testing PaaSTA logi
 make clean-playground    # removes etc_paasta_playground/ and soa_config_playground/
 make k8s_clean           # deletes the Kind cluster entirely
 ```
-
-## VS Code Integration
-
-The repo includes VS Code debug configurations in `.vscode/launch.json`:
-
-| Configuration | What it does |
-|---|---|
-| `paasta API playground` | Starts API with debugger attached |
-| `paasta playground` | Runs `paasta status` with API as preLaunchTask |
-| `paasta status playground` | CLI status command (API must already be running) |
-| `Run setup k8s job in playground` | Deploys workloads to Kind cluster |
-| `Generate deployments.json in playground` | Regenerates deployments.json |
-| `Run cleanup k8s jobs in playground` | Removes stale K8s resources |
-
-The `Run API Playground` VS Code task (`.vscode/tasks.json`) runs `make playground-api`
-as a background task — used as `preLaunchTask` by the "paasta playground" config.
-
-All VS Code configs set the correct env vars (`KUBECONFIG`, `PAASTA_SYSTEM_CONFIG_DIR`,
-`PAASTA_TEST_CLUSTER`, `PAASTA_API_SOA_DIR`) so you don't need to configure them manually.

--- a/.claude/skills/paasta-playground/SKILL.md
+++ b/.claude/skills/paasta-playground/SKILL.md
@@ -305,10 +305,11 @@ This exercises the polling loop that checks `bounce_status`:
 
 ```bash
 # API must be running for this to work
+# First deploy a new version via setup_kubernetes_job, then run m-f-d with --wait-for-deployment
 .tox/py310-linux/bin/python -m paasta_tools.cli.cli mark-for-deployment \
   --service compute-infra-test-service \
   --deploy-group prod.main \
-  --commit $(jq -r '.v2.deployments["prod.main"].git_sha' soa_config_playground/compute-infra-test-service/deployments.json) \
+  --commit <new-sha> \
   --wait-for-deployment \
   -d ./soa_config_playground/
 ```
@@ -393,7 +394,6 @@ curl -s "$API_URL/v1/version"
 |-------|-------|-----|
 | `ImportError: cannot import name 'client' from 'kubernetes'` | Local `paasta_tools/kubernetes/` shadows pip `kubernetes` package | Always use `python -m` invocation, never direct script paths |
 | API returns 404 for bounce_status | API not reading playground soa_dir | Ensure `PAASTA_API_SOA_DIR=./soa_config_playground` is set (handled by `tox -e playground-api`) |
-| `get_currently_deployed_version` returns None in playground | The call at line 489 of `mark_for_deployment.py` doesn't pass `soa_dir` — reads from `DEFAULT_SOA_DIR` | Known pre-existing issue; for testing the version-match path, patch the function to pass `soa_dir` |
 | Pods stuck in Pending | Kind cluster lacks resources or not running | `make k8s_fake_cluster` to recreate; check `kubectl describe pod` for scheduling errors |
 | `Back-off pulling image` / `ImagePullBackOff` | Registry credentials expired (they rotate) | Re-run `k8s_itests/scripts/set-paasta-registry-credentials.sh $USER-k8s-test` (interactive auth required). Script is idempotent. |
 | API connection refused | API not started or crashed | Run `make playground-api` and wait for `[INFO] Booting worker` |

--- a/.claude/skills/paasta-playground/SKILL.md
+++ b/.claude/skills/paasta-playground/SKILL.md
@@ -2,11 +2,12 @@
 name: paasta-playground
 description: >-
   How to test PaaSTA code changes against a local Kind Kubernetes cluster using the
-  playground environment. Use this skill whenever: testing CLI commands locally, verifying
-  API changes end-to-end, debugging PaaSTA behavior against real pods, running
-  mark-for-deployment status, logs or other CLI commands locally, or the user mentions "playground", "kind cluster",
-  "local testing", or "test against real k8s". Also use when the user wants to validate
-  code changes beyond unit tests — the playground bridges unit tests and production.
+  playground environment. The playground bridges unit tests and production.
+when_to_use: >-
+  Testing CLI commands locally, verifying API changes end-to-end, debugging PaaSTA
+  behavior against real pods, running mark-for-deployment/status/logs locally, or the
+  user mentions "playground", "kind cluster", "local testing", or "test against real k8s".
+  Also use when the user wants to validate code changes beyond unit tests.
 ---
 
 # PaaSTA Playground Testing

--- a/.claude/skills/paasta-playground/SKILL.md
+++ b/.claude/skills/paasta-playground/SKILL.md
@@ -1,0 +1,475 @@
+---
+name: paasta-playground
+description: >-
+  How to test PaaSTA code changes against a local Kind Kubernetes cluster using the
+  playground environment. Use this skill whenever: testing CLI commands locally, verifying
+  API changes end-to-end, debugging PaaSTA behavior against real pods, running
+  mark-for-deployment status, logs or other CLI commands locally, or the user mentions "playground", "kind cluster",
+  "local testing", or "test against real k8s". Also use when the user wants to validate
+  code changes beyond unit tests — the playground bridges unit tests and production.
+---
+
+# PaaSTA Playground Testing
+
+The playground is a local environment that runs PaaSTA against a real Kind Kubernetes
+cluster on the devbox. It lets you test CLI commands, API endpoints, and deployment
+logic against actual running pods — catching issues that unit tests with mocks miss.
+
+## If the Playground Is Not Set Up
+
+Run `.claude/skills/paasta-playground/scripts/playground-status.sh` to check what's
+ready vs what's missing. If the cluster or configs don't exist:
+
+1. **Cluster missing** — the user must run `! make k8s_fake_cluster` themselves (the
+   `!` prefix runs the command in the current session). This requires interactive
+   keyboard input for browser-based authentication to get docker registry credentials.
+   You cannot run this non-interactively.
+
+2. **tox virtualenv missing** — `make dev` can be run non-interactively, but takes
+   several minutes. Run it in background or ask the user to run `! make dev`.
+
+3. **Configs missing** (`etc_paasta_playground/`, `soa_config_playground/`) — run
+   `make generate_deployments_for_service` (non-interactive, safe to run directly).
+
+4. **Workloads not deployed** — run `make setup-kubernetes-job` (non-interactive).
+
+5. **API not running** — start with `make playground-api` in a separate terminal, or
+   ask the user to run it. The API must stay running for CLI commands that call it.
+
+6. **Registry credentials expired** (pods stuck in `ImagePullBackOff` or
+   `Back-off pulling image`) — credentials rotate and eventually expire. The user must
+   re-run `! k8s_itests/scripts/set-paasta-registry-credentials.sh $USER-k8s-test`
+   (requires interactive auth). The script is idempotent — safe to re-run anytime.
+   It overwrites the existing credentials on all nodes and restarts containerd/kubelet.
+
+## Architecture
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  Kind Cluster (kind-$USER-k8s-test)                              │
+│    └── namespace: paastasvc-<service>  (one per service)         │
+│         └── <service>-<instance> pods                            │
+├──────────────────────────────────────────────────────────────────┤
+│  PaaSTA API (localhost:<dynamic-port>)                            │
+│    reads: soa_config_playground/, etc_paasta_playground/          │
+│    talks to: Kind cluster via k8s_itests/kubeconfig              │
+├──────────────────────────────────────────────────────────────────┤
+│  PaaSTA CLI                                                      │
+│    env: PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_playground/         │
+│    flag: -d ./soa_config_playground/                              │
+│    talks to: PaaSTA API (endpoint from api_endpoints.json)       │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+The playground can run any PaaSTA service — not just the default
+`compute-infra-test-service`. Add a directory under `soa_config_playground/` with the
+standard PaaSTA config files and it will be picked up by `setup_kubernetes_job`.
+
+**Key directories:**
+- `etc_paasta_playground/` — system config: `api_endpoints.json` (API URL per cluster),
+  `clusters.json`, `volumes.json`, `docker_registry.json`
+- `soa_config_playground/` — service configs: `deploy.yaml`, `kubernetes-*.yaml`,
+  `deployments.json`, `service.yaml`
+- `k8s_itests/kubeconfig` — kubeconfig for the Kind cluster
+
+**Namespace convention:** PaaSTA namespaces are `paastasvc-<service>`. Underscores in
+service names become double hyphens (e.g., `my_service` → `paastasvc-my--service`).
+
+**API port:** Determined dynamically by `pick_random_port("paasta-dev-api")` — a
+deterministic hash per user (range 33000-58000). The port is written to
+`etc_paasta_playground/api_endpoints.json` on API startup. Check it there if in doubt.
+
+## Prerequisites
+
+```bash
+make dev                # builds .tox/py310-linux virtualenv (one-time)
+make k8s_fake_cluster   # creates the Kind cluster (one-time, persists across sessions)
+```
+
+**Interactive terminal required:** `make k8s_fake_cluster` triggers browser-based
+authentication to get registry credentials for pulling images. Run it in a terminal
+where you can interact with the auth flow (`! make k8s_fake_cluster` in Claude Code).
+
+See `references/cli-reference.md` → "Kind Cluster Management" for cluster sizing,
+scaling, and registry credential details.
+
+Verify the cluster exists:
+```bash
+KUBECONFIG=./k8s_itests/kubeconfig kubectl get nodes
+```
+
+## Setup Workflow
+
+Run these in order. Each step depends on the previous:
+
+### 1. Generate playground configs
+
+```bash
+make generate_deployments_for_service
+```
+
+This does three things:
+1. Runs `create_paasta_playground.py` which starts a local zookeeper container and
+   creates `etc_paasta_playground/` and `soa_config_playground/` from templates in
+   `k8s_itests/deployments/paasta/`
+2. Runs `generate_deployments_for_service` which reads git deploy tags for the test
+   service and materializes them into `soa_config_playground/<service>/deployments.json`
+
+The `deployments.json` file maps deploy groups to docker image + git SHA — this is
+what `setup_kubernetes_job` reads to know which version to deploy.
+
+### 2. Deploy workloads to the cluster
+
+```bash
+make setup-kubernetes-job
+```
+
+Reads `soa_config_playground/` and `deployments.json`, then creates/updates the
+Kubernetes Deployment objects for all services configured in the playground.
+
+**Important:** `setup_kubernetes_job` only creates or updates Kubernetes Deployments.
+It does NOT remove stale ones. If you:
+- Remove an instance from config
+- Rename an instance
+- Remove a service entirely
+
+You must also run cleanup to reconcile:
+
+```bash
+make cleanup-kubernetes-jobs
+```
+
+`cleanup_kubernetes_jobs` lists all PaaSTA-managed Deployments/StatefulSets in the
+cluster, compares them against what's defined in `soa_config_playground/`, and
+`deep_delete`s anything that shouldn't exist. The Makefile passes `--force` to skip
+the kill-threshold safety check.
+
+**Full deploy cycle (mimics production reconciliation):**
+```bash
+make setup-kubernetes-job && make cleanup-kubernetes-jobs
+```
+
+Verify pods are running:
+```bash
+KUBECONFIG=./k8s_itests/kubeconfig kubectl get pods -n paastasvc-<service>
+```
+
+### 3. Start the PaaSTA API
+
+```bash
+make playground-api
+```
+
+Runs the API via `tox -e playground-api`. Leave this running in a separate terminal/tmux.
+The API reads from `soa_config_playground/` (via `PAASTA_API_SOA_DIR` env var in tox.ini)
+and talks to the Kind cluster.
+
+Wait for the line: `[INFO] Booting worker with pid: ...` before testing CLI commands.
+
+The API serves the same endpoints as production — `bounce_status`, `instance/status`,
+etc. This is what `--wait-for-deployment` polls to determine if a bounce is complete.
+
+## Running CLI Commands Against the Playground
+
+See `references/cli-reference.md` for the full flag table, which commands work in the
+playground, and known flag inconsistencies between commands.
+
+Every CLI command needs these environment variables and flags:
+
+```bash
+export PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_playground/
+export KUBECONFIG=./k8s_itests/kubeconfig
+
+# Then run any CLI command with -d for soa_dir:
+.tox/py310-linux/bin/python -m paasta_tools.cli.cli <command> \
+  -s <service> \
+  -c kind-$USER-k8s-test \
+  -d ./soa_config_playground/
+```
+
+Always use `python -m` to invoke — never run scripts directly. The local
+`paasta_tools/kubernetes/` package shadows the pip `kubernetes` package if you
+use direct script invocation.
+
+> **kubectl namespaces:** When running `kubectl` commands, translate service names to
+> namespace format: `paastasvc-<service>` with underscores replaced by double hyphens.
+> Example: `my_service` → `-n paastasvc-my--service`
+
+
+### Common playground commands
+
+**Status** (requires API running):
+```bash
+.tox/py310-linux/bin/python -m paasta_tools.cli.cli status \
+  -s <service> \
+  -c kind-$USER-k8s-test \
+  -d ./soa_config_playground/
+```
+
+Expected output shows: Version (desired), State (Running/Bouncing), Kubernetes health
+(Healthy with N/N instances), ReplicaSet details.
+
+**Mark-for-deployment:**
+```bash
+.tox/py310-linux/bin/python -m paasta_tools.cli.cli mark-for-deployment \
+  --service <service> \
+  --deploy-group <deploy-group> \
+  --commit <sha> \
+  -d ./soa_config_playground/
+```
+
+**Run PaaSTA modules directly** (setup_kubernetes_job, cleanup, etc.):
+```bash
+.tox/py310-linux/bin/python -m paasta_tools.setup_kubernetes_job \
+  -d ./soa_config_playground -c kind-$USER-k8s-test \
+  <service>.<instance>
+```
+
+## Quick-Start Script
+
+Source the helper to set environment variables:
+```bash
+source <(.claude/skills/paasta-playground/scripts/playground-env.sh)
+```
+
+Check what's running vs what needs setup:
+```bash
+.claude/skills/paasta-playground/scripts/playground-status.sh
+```
+
+## How the Playground Maps to Production
+
+In production, a PaaSTA deploy flows through these stages:
+
+1. **CI pipeline** runs `mark-for-deployment` which creates a git tag
+   (`paasta-$deploy_group-$date-deploy`) and triggers deployment processing
+2. **`generate_deployments_for_service`** reads all git tags for the service and
+   materializes them into `deployments.json`
+3. **`setup_kubernetes_job`** (runs periodically on each cluster) reads `deployments.json`
+   + kubernetes config, creates/updates the K8s Deployment object
+4. **Kubernetes controllers** create a new ReplicaSet, schedule pods, and (based on
+   bounce strategy) drain old pods once new ones are healthy. The default `crossover`
+   strategy maps to K8s `RollingUpdate` — new pods must be ready before old ones are removed
+5. **`cleanup_kubernetes_jobs`** (runs periodically) compares running apps against config
+   and `deep_delete`s any Deployment/StatefulSet that shouldn't exist
+6. **`--wait-for-deployment`** (if set in `deploy.yaml` or CLI flag) polls the API's
+   `bounce_status` endpoint checking: only the target version is running, deploy status
+   is Running/Deploying/Waiting, and replicas meet the bounce margin
+
+The playground lets you trigger each stage independently:
+
+| Production | Playground |
+|---|---|
+| `mark-for-deployment` → `generate_deployments_for_service` | Edit `deployments.json` directly, or `make generate_deployments_for_service` |
+| `setup_kubernetes_job` (periodic) creates/updates K8s Deployment | `make setup-kubernetes-job` (manual) |
+| `cleanup_kubernetes_jobs` (periodic) removes stale K8s Deployments | `make cleanup-kubernetes-jobs` (manual) |
+| K8s controllers handle the bounce (RollingUpdate/Recreate) | Same — Kind cluster runs real controllers |
+| PaaSTA API serves bounce_status, instance status | `make playground-api` |
+| CLI reads system config from `PAASTA_SYSTEM_CONFIG_DIR` | `PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_playground/` |
+| soa-configs from `DEFAULT_SOA_DIR` | `-d ./soa_config_playground/` |
+| `wait_for_deployment: true` in `deploy.yaml` blocks pipeline | `--wait-for-deployment` CLI flag |
+
+The key advantage: in production these run continuously and automatically. In the
+playground you run them manually, which lets you observe intermediate states and test
+specific code paths in isolation.
+
+## Testing Scenarios
+
+Examples below use `compute-infra-test-service` (the default playground service) but
+the same patterns apply to any service you configure.
+
+### Testing mark-for-deployment (same-version re-run)
+
+This exercises the early-exit logic when a pipeline re-runs with the same commit:
+
+```bash
+# Check current deployed version
+jq '.v2.deployments["prod.main"]' soa_config_playground/compute-infra-test-service/deployments.json
+
+# Run m-f-d with the SAME sha — triggers version-match detection
+.tox/py310-linux/bin/python -m paasta_tools.cli.cli mark-for-deployment \
+  --service compute-infra-test-service \
+  --deploy-group prod.main \
+  --commit $(jq -r '.v2.deployments["prod.main"].git_sha' soa_config_playground/compute-infra-test-service/deployments.json) \
+  -d ./soa_config_playground/
+
+# Exit code 0 = instances healthy, safe to proceed
+# Exit code 1 = instances unhealthy, blocks pipeline
+echo "Exit code: $?"
+```
+
+### Testing mark-for-deployment with --wait-for-deployment
+
+This exercises the polling loop that checks `bounce_status`:
+
+```bash
+# API must be running for this to work
+.tox/py310-linux/bin/python -m paasta_tools.cli.cli mark-for-deployment \
+  --service compute-infra-test-service \
+  --deploy-group prod.main \
+  --commit $(jq -r '.v2.deployments["prod.main"].git_sha' soa_config_playground/compute-infra-test-service/deployments.json) \
+  --wait-for-deployment \
+  -d ./soa_config_playground/
+```
+
+### Simulating a full deploy (new version)
+
+**Important:** `make setup-kubernetes-job` depends on `generate_deployments_for_service`,
+which regenerates `deployments.json` from git tags — overwriting any manual edits.
+If you've manually edited `deployments.json`, run `setup_kubernetes_job` directly:
+
+```bash
+# 1. Edit deployments.json — change git_sha and docker_image tag
+#    This simulates what generate_deployments_for_service produces after m-f-d
+vim soa_config_playground/compute-infra-test-service/deployments.json
+
+# 2. Run setup_kubernetes_job DIRECTLY (bypasses Make dependency that would overwrite your edit)
+export KUBECONFIG=./k8s_itests/kubeconfig
+export PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_playground/
+.tox/py310-linux/bin/python -m paasta_tools.setup_kubernetes_job \
+  -d ./soa_config_playground -c kind-$USER-k8s-test \
+  compute-infra-test-service.autoscaling
+
+# 3. Run cleanup directly
+.tox/py310-linux/bin/python -m paasta_tools.cleanup_kubernetes_jobs \
+  -d ./soa_config_playground -c kind-$USER-k8s-test --force
+
+# 4. Check status (same endpoint wait-for-deployment polls)
+.tox/py310-linux/bin/python -m paasta_tools.cli.cli status \
+  -s compute-infra-test-service -c kind-$USER-k8s-test \
+  -d ./soa_config_playground/
+```
+
+**When to use `make` vs direct invocation:**
+- `make setup-kubernetes-job` — safe when you haven't manually edited `deployments.json`
+  (it regenerates from git tags first, then deploys)
+- Direct `python -m paasta_tools.setup_kubernetes_job` — use when you've manually
+  edited `deployments.json` or `kubernetes-*.yaml` and don't want it overwritten
+
+### Simulating a config-only change (yelpsoa-configs update)
+
+When kubernetes-*.yaml changes without a new docker image (scaling, resources, env):
+
+```bash
+# 1. Edit the config
+vim soa_config_playground/compute-infra-test-service/kubernetes-kind-$USER-k8s-test.yaml
+
+# 2. Run setup + cleanup directly (avoids generate_deployments overwriting deployments.json)
+export KUBECONFIG=./k8s_itests/kubeconfig
+export PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_playground/
+.tox/py310-linux/bin/python -m paasta_tools.setup_kubernetes_job \
+  -d ./soa_config_playground -c kind-$USER-k8s-test \
+  compute-infra-test-service.autoscaling
+.tox/py310-linux/bin/python -m paasta_tools.cleanup_kubernetes_jobs \
+  -d ./soa_config_playground -c kind-$USER-k8s-test --force
+
+# 3. Watch the bounce happen (K8s RollingUpdate by default)
+KUBECONFIG=./k8s_itests/kubeconfig kubectl get pods -n paastasvc-compute-infra-test-service -w
+```
+
+### Testing API endpoints directly
+
+The API routes use `{service}/{instance}` — no cluster in the path (each cluster has
+its own API instance):
+
+```bash
+# Get the API URL from config
+API_URL=$(jq -r '.api_endpoints["kind-'$USER'-k8s-test"]' etc_paasta_playground/api_endpoints.json)
+
+# bounce_status — what wait-for-deployment polls
+curl -s "$API_URL/v1/services/<service>/<instance>/bounce_status" | python -m json.tool
+
+# instance status
+curl -s "$API_URL/v1/services/<service>/<instance>/status" | python -m json.tool
+
+# API version
+curl -s "$API_URL/v1/version"
+```
+
+## Known Gotchas
+
+| Issue | Cause | Fix |
+|-------|-------|-----|
+| `ImportError: cannot import name 'client' from 'kubernetes'` | Local `paasta_tools/kubernetes/` shadows pip `kubernetes` package | Always use `python -m` invocation, never direct script paths |
+| API returns 404 for bounce_status | API not reading playground soa_dir | Ensure `PAASTA_API_SOA_DIR=./soa_config_playground` is set (handled by `tox -e playground-api`) |
+| `get_currently_deployed_version` returns None in playground | The call at line 489 of `mark_for_deployment.py` doesn't pass `soa_dir` — reads from `DEFAULT_SOA_DIR` | Known pre-existing issue; for testing the version-match path, patch the function to pass `soa_dir` |
+| Pods stuck in Pending | Kind cluster lacks resources or not running | `make k8s_fake_cluster` to recreate; check `kubectl describe pod` for scheduling errors |
+| `Back-off pulling image` / `ImagePullBackOff` | Registry credentials expired (they rotate) | Re-run `k8s_itests/scripts/set-paasta-registry-credentials.sh $USER-k8s-test` (interactive auth required). Script is idempotent. |
+| API connection refused | API not started or crashed | Run `make playground-api` and wait for `[INFO] Booting worker` |
+| `No such cluster` errors | Cluster name mismatch | Must be `kind-$USER-k8s-test` (check `etc_paasta_playground/clusters.json`) |
+| Manual edits to `deployments.json` lost | `make setup-kubernetes-job` depends on `generate_deployments_for_service` which regenerates from git tags | Run `setup_kubernetes_job` directly via `python -m` instead of `make` |
+| Old pods still running after removing an instance | `setup_kubernetes_job` only creates/updates, never deletes | Run `cleanup_kubernetes_jobs` directly to remove stale Deployments |
+| `cleanup_kubernetes_jobs` refuses to kill | Kill threshold exceeded (>50% of apps would be deleted) | The Makefile passes `--force`; if running manually, add `--force` |
+| Zookeeper container not running | `create_paasta_playground.py` starts it but it may stop | `docker ps \| grep zookeeper`; re-run `make generate_deployments_for_service` |
+| Bounce strategy confusion | `crossover` = K8s `RollingUpdate` (new ready before old removed); `downthenup` = K8s `Recreate` (kill all old first); `brutal` = `RollingUpdate` with maxUnavailable=100% | Check `bounce_method` in kubernetes config; default is `crossover` |
+
+## Adding Custom Services to the Playground
+
+The playground isn't limited to `compute-infra-test-service`. To run any service:
+
+```bash
+# 1. Create the service config directory
+mkdir -p soa_config_playground/my-service
+
+# 2. Add required config files:
+#    - kubernetes-kind-$USER-k8s-test.yaml (instance definitions)
+#    - deploy.yaml (pipeline config, can be minimal)
+#    - deployments.json (version mapping)
+
+# Example minimal kubernetes config:
+cat > soa_config_playground/my-service/kubernetes-kind-$USER-k8s-test.yaml << 'EOF'
+main:
+  cpus: 0.1
+  mem: 128
+  instances: 2
+  deploy_group: prod.main
+EOF
+
+cat > soa_config_playground/my-service/deploy.yaml << 'EOF'
+---
+pipeline:
+- step: prod.main
+EOF
+
+# 3. Create deployments.json pointing to a valid docker image:
+cat > soa_config_playground/my-service/deployments.json << EOF
+{"v2": {"deployments": {"prod.main": {"docker_image": "services-my-service:paasta-<sha>", "git_sha": "<sha>", "image_version": null}}, "controls": {"my-service:kind-$USER-k8s-test.main": {"desired_state": "start", "force_bounce": null}}}}
+EOF
+
+# 4. Deploy it
+export KUBECONFIG=./k8s_itests/kubeconfig
+export PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_playground/
+.tox/py310-linux/bin/python -m paasta_tools.setup_kubernetes_job \
+  -d ./soa_config_playground -c kind-$USER-k8s-test \
+  my-service.main
+```
+
+The docker image must be pullable from the Kind cluster. For testing PaaSTA logic
+(not the service itself), you can reuse the existing test image from
+`compute-infra-test-service`'s `deployments.json`.
+
+## Cleanup
+
+```bash
+make clean-playground    # removes etc_paasta_playground/ and soa_config_playground/
+make k8s_clean           # deletes the Kind cluster entirely
+```
+
+## VS Code Integration
+
+The repo includes VS Code debug configurations in `.vscode/launch.json`:
+
+| Configuration | What it does |
+|---|---|
+| `paasta API playground` | Starts API with debugger attached |
+| `paasta playground` | Runs `paasta status` with API as preLaunchTask |
+| `paasta status playground` | CLI status command (API must already be running) |
+| `Run setup k8s job in playground` | Deploys workloads to Kind cluster |
+| `Generate deployments.json in playground` | Regenerates deployments.json |
+| `Run cleanup k8s jobs in playground` | Removes stale K8s resources |
+
+The `Run API Playground` VS Code task (`.vscode/tasks.json`) runs `make playground-api`
+as a background task — used as `preLaunchTask` by the "paasta playground" config.
+
+All VS Code configs set the correct env vars (`KUBECONFIG`, `PAASTA_SYSTEM_CONFIG_DIR`,
+`PAASTA_TEST_CLUSTER`, `PAASTA_API_SOA_DIR`) so you don't need to configure them manually.

--- a/.claude/skills/paasta-playground/references/cli-reference.md
+++ b/.claude/skills/paasta-playground/references/cli-reference.md
@@ -1,0 +1,445 @@
+# CLI Commands in the Playground
+
+All commands require:
+```bash
+export PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_playground/
+export KUBECONFIG=./k8s_itests/kubeconfig
+```
+
+Invoke pattern:
+```bash
+.tox/py310-linux/bin/python -m paasta_tools.cli.cli <command> [flags]
+```
+
+## Command Reference
+
+### status
+
+Shows deployment state, pod health, ReplicaSets, and autoscaling info.
+
+```bash
+.tox/py310-linux/bin/python -m paasta_tools.cli.cli status \
+  -s <service> -c kind-$USER-k8s-test -d ./soa_config_playground/
+
+# Verbose (per-pod detail):
+  -v
+
+# Extra verbose (container stdout/stderr tail):
+  -vv
+```
+
+**Requires:** API running (`make playground-api`)
+
+**Output includes:** Version (desired), State (Running/Bouncing), Kubernetes health
+(Healthy with N/N instances), ReplicaSet details, pod-level errors, autoscaling status.
+
+---
+
+### mark-for-deployment
+
+Marks a git SHA for deployment to a deploy group. In the playground, this writes a
+git tag but the version-match logic and wait-for-deployment polling are the primary
+test targets.
+
+```bash
+.tox/py310-linux/bin/python -m paasta_tools.cli.cli mark-for-deployment \
+  -s <service> \
+  -l <deploy-group> \
+  -c <40-char-sha> \
+  -d ./soa_config_playground/
+```
+
+**Important:** `-c` here means **commit**, not cluster. This differs from most other
+PaaSTA commands where `-c` means cluster.
+
+**Flags:**
+| Flag | Purpose |
+|------|---------|
+| `-s, --service` | Service name (required) |
+| `-l, --deploy-group` | Deploy group to mark (required) |
+| `-c, -k, --commit` | Git SHA to deploy (required) |
+| `--wait-for-deployment` | Poll bounce_status until deploy completes or times out |
+| `-t, --timeout <seconds>` | How long to wait (default: 1800) |
+| `--auto-rollback` | Rollback if timeout is reached |
+| `--polling-interval` | Seconds between bounce_status checks |
+| `--diagnosis-interval` | Seconds between deploy diagnosis runs |
+
+**Exit codes:**
+- `0` — deploy successful (or version already healthy)
+- `1` — deploy failed or instances unhealthy
+
+**Note:** The same-version re-run path checks if the target SHA matches what's already
+deployed. If it does, it checks instance health and returns 0 (healthy) or 1 (unhealthy).
+
+---
+
+### wait-for-deployment
+
+Standalone version of the `--wait-for-deployment` polling loop. Useful for testing
+the polling/diagnosis logic independently.
+
+```bash
+.tox/py310-linux/bin/python -m paasta_tools.cli.cli wait-for-deployment \
+  -s <service> \
+  -l <deploy-group> \
+  -c <commit> \
+  -d ./soa_config_playground/
+```
+
+**Flags:**
+| Flag | Purpose |
+|------|---------|
+| `-t <seconds>` | Timeout (default: 1800) |
+| `--polling-interval <seconds>` | How often to check bounce_status |
+| `--diagnosis-interval <seconds>` | How often to run deploy diagnosis |
+| `--time-before-first-diagnosis <seconds>` | Wait before first diagnosis |
+
+**Requires:** API running
+
+---
+
+### get-latest-deployment
+
+Returns the currently deployed git SHA for a deploy group.
+
+```bash
+.tox/py310-linux/bin/python -m paasta_tools.cli.cli get-latest-deployment \
+  -s <service> -l <deploy-group> -d ./soa_config_playground/
+```
+
+**Output:** 40-character git SHA (or empty if not deployed)
+
+---
+
+### info
+
+Shows service metadata from soa-configs (no API call required).
+
+```bash
+.tox/py310-linux/bin/python -m paasta_tools.cli.cli info \
+  -s <service> -d ./soa_config_playground/
+```
+
+**Output:** Service name, description, owner, runbook, git repo, clusters deployed to.
+
+---
+
+### get-docker-image
+
+Returns the docker image URL for a deploy group.
+
+```bash
+.tox/py310-linux/bin/python -m paasta_tools.cli.cli get-docker-image \
+  -s <service> -i <instance> -l <deploy-group> -d ./soa_config_playground/
+```
+
+**Note:** Uses `-l` for deploy group — does NOT take `-c` for cluster.
+
+---
+
+### list-clusters
+
+Lists clusters configured in the playground.
+
+```bash
+.tox/py310-linux/bin/python -m paasta_tools.cli.cli list-clusters \
+  -d ./soa_config_playground/
+```
+
+**Output:** `kind-$USER-k8s-test`
+
+---
+
+### validate
+
+Validates service config files against JSON schemas. Catches config errors before deploying.
+
+```bash
+.tox/py310-linux/bin/python -m paasta_tools.cli.cli validate \
+  -s <service> -y ./soa_config_playground/
+```
+
+**Important:** Uses `-y` for soa_dir, NOT `-d`.
+
+---
+
+### autoscale
+
+View or override autoscaling settings.
+
+```bash
+# View current state:
+.tox/py310-linux/bin/python -m paasta_tools.cli.cli autoscale \
+  -s <service> -i <instance> -c kind-$USER-k8s-test -d ./soa_config_playground/
+
+# Set instance count (bypass autoscaler):
+  --set <N>
+
+# Set temporary floor:
+  --set-min <N> --for 3h
+```
+
+**Requires:** API running
+
+---
+
+## Direct Module Invocation (Operator Modules)
+
+These bypass the CLI and run PaaSTA backend modules directly. In production, these run
+periodically on each cluster. In the playground, you invoke them manually to trigger
+specific reconciliation steps.
+
+### setup_kubernetes_job
+
+Creates/updates Kubernetes Deployment objects from config. This is the primary
+"deploy" action — it reads `deployments.json` + kubernetes config and creates or
+updates the K8s Deployment object with the target image and settings.
+
+```bash
+.tox/py310-linux/bin/python -m paasta_tools.setup_kubernetes_job \
+  -d ./soa_config_playground -c kind-$USER-k8s-test \
+  <service>.<instance>
+```
+
+Multiple service.instance pairs can be passed as positional args (at least one is
+required).
+
+**Flags:**
+| Flag | Purpose |
+|------|---------|
+| `-d, --soa-dir` | soa_config directory |
+| `-c, --cluster` | Cluster name |
+| `-v, --verbose` | Debug logging |
+
+---
+
+### cleanup_kubernetes_jobs
+
+Compares running Deployments/StatefulSets against what's configured in soa_dir and
+`deep_delete`s anything that shouldn't exist. This is the counterpart to
+`setup_kubernetes_job` — together they form the full reconciliation loop.
+
+```bash
+.tox/py310-linux/bin/python -m paasta_tools.cleanup_kubernetes_jobs \
+  -d ./soa_config_playground -c kind-$USER-k8s-test --force
+```
+
+`--force` skips the kill-threshold safety check (needed in playground since we have
+few services and the ratio math would otherwise block deletion of >50% of apps).
+
+---
+
+### setup_kubernetes_crd
+
+Creates/updates Custom Resource Definitions (CRDs) for a service. CRDs are the
+schema definitions that allow custom resources (Flink jobs, Cassandra clusters, etc.)
+to exist in the cluster.
+
+```bash
+.tox/py310-linux/bin/python -m paasta_tools.setup_kubernetes_crd \
+  -d ./soa_config_playground -c kind-$USER-k8s-test \
+  <service>
+```
+
+**Flags:**
+| Flag | Purpose |
+|------|---------|
+| `-d, --soa-dir` | soa_config directory |
+| `-c, --cluster` | Cluster name |
+| `-v, --verbose` | Debug logging |
+| positional | Service name(s) to set up CRDs for |
+
+---
+
+### setup_kubernetes_cr
+
+Creates/updates Custom Resources (CRs) — the actual instances of custom resource
+types (Flink jobs, Cassandra clusters, etc.). Reads CRD definitions from
+system_paasta_config and applies configured CRs to the cluster.
+
+```bash
+.tox/py310-linux/bin/python -m paasta_tools.setup_kubernetes_cr \
+  -d ./soa_config_playground -c kind-$USER-k8s-test
+```
+
+**Flags:**
+| Flag | Purpose |
+|------|---------|
+| `-d, --soa-dir` | soa_config directory |
+| `-c, --cluster` | Cluster name |
+| `-s, --service` | Limit to a specific service |
+| `-i, --instance` | Limit to a specific instance |
+| `-D, --dry-run` | Print K8s manifests to stdout without applying |
+| `-v, --verbose` | Debug logging |
+
+---
+
+### setup_kubernetes_internal_crd
+
+Creates/updates PaaSTA's own internal CRDs (not service-specific). These are the
+CRD schemas that PaaSTA itself needs to operate (e.g., autoscaling state, deploy
+locks).
+
+```bash
+.tox/py310-linux/bin/python -m paasta_tools.setup_kubernetes_internal_crd -v
+```
+
+No flags required beyond `-v` — reads from the PaaSTA package itself.
+
+---
+
+### generate_deployments_for_service
+
+Reads git deploy tags and materializes `deployments.json`. This maps deploy groups
+to docker image + git SHA — the source of truth for what version should be running.
+
+```bash
+.tox/py310-linux/bin/python -m paasta_tools.generate_deployments_for_service \
+  -s <service> -d ./soa_config_playground/
+```
+
+**Warning:** This overwrites any manual edits to `deployments.json`.
+
+---
+
+## Secrets
+
+### paasta secret
+
+Manages encrypted service secrets. In the playground, the `run` subcommand is most
+useful — it decrypts secrets and runs a command with them as environment variables.
+
+```bash
+# Run a command with decrypted secrets:
+.tox/py310-linux/bin/python -m paasta_tools.cli.cli secret run \
+  -s <service> -i <instance> -c kind-$USER-k8s-test \
+  -d ./soa_config_playground/ \
+  -- env
+
+# Add a new secret:
+.tox/py310-linux/bin/python -m paasta_tools.cli.cli secret add \
+  -s <service> -c kind-$USER-k8s-test \
+  -d ./soa_config_playground/
+
+# Decrypt and view a secret:
+.tox/py310-linux/bin/python -m paasta_tools.cli.cli secret decrypt \
+  -s <service> -c kind-$USER-k8s-test \
+  -d ./soa_config_playground/
+```
+
+**Requires interactive terminal:** The `add` and `update` subcommands prompt for the
+secret value via stdin. Run these with `! <command>` in Claude Code, or in a separate
+terminal.
+
+### paasta-secrets-sync (Makefile target)
+
+Syncs encrypted secrets from Vault into Kubernetes Secrets for all services in the
+playground. This is needed if your service reads secrets from environment variables.
+
+```bash
+make paasta-secrets-sync
+```
+
+**Requires interactive terminal (first run):** Generates a `.vault-token` via
+`vault login -method=ldap` which prompts for credentials. The token is cached in
+`.vault-token` and reused on subsequent runs until it expires.
+
+The target depends on `setup-kubernetes-job` (ensures the cluster has workloads to
+sync secrets to).
+
+---
+
+## Kind Cluster Management
+
+### Creating the cluster
+
+```bash
+make k8s_fake_cluster
+```
+
+**Requires interactive terminal:** The cluster creation process calls
+`set-paasta-registry-credentials.sh` which authenticates against the docker registry.
+This triggers a browser-based login flow that requires keyboard interaction.
+Run this with `! make k8s_fake_cluster` in Claude Code, or in a separate terminal.
+
+### Cluster sizing
+
+The default cluster config (`k8s_itests/deployments/kind/cluster-devbox.yaml`)
+creates 1 control-plane + 6 workers. Kind nodes are lightweight containers (podman),
+so the resource cost is minimal.
+
+If pods are stuck in `Pending` due to resource pressure, check scheduling:
+```bash
+KUBECONFIG=./k8s_itests/kubeconfig kubectl describe pod <pod> -n paastasvc-<service> | grep -A5 Events
+```
+
+### Scaling the cluster (adding/removing nodes)
+
+Kind does not support adding nodes to a running cluster. To change node count:
+
+1. Edit `k8s_itests/deployments/kind/cluster-devbox.yaml` — add or remove `role: worker`
+   entries
+2. Recreate the cluster:
+   ```bash
+   make k8s_clean && make k8s_fake_cluster
+   ```
+3. Re-deploy workloads:
+   ```bash
+   make generate_deployments_for_service && make setup-kubernetes-job
+   ```
+
+### Registry credentials on new clusters
+
+Kind nodes need credentials to pull images from the internal docker registry.
+The `make k8s_fake_cluster` target handles this automatically by running
+`k8s_itests/scripts/set-paasta-registry-credentials.sh`.
+
+If you recreate the cluster or images fail to pull with "Back-off pulling image",
+re-run the credentials script:
+
+```bash
+k8s_itests/scripts/set-paasta-registry-credentials.sh $USER-k8s-test
+```
+
+**Requires interactive terminal:** Uses docker credential helpers which trigger
+browser-based auth. Run with `! <command>` or in a separate terminal.
+
+The script iterates over all Kind nodes and:
+1. Generates a registry auth token via docker credential helpers
+2. Writes containerd registry host config to each node
+3. Restarts containerd and kubelet on each node
+
+### Destroying the cluster
+
+```bash
+make k8s_clean
+```
+
+This deletes the Kind cluster entirely. You'll need `make k8s_fake_cluster` to
+recreate it.
+
+---
+
+## Commands That Don't Work in the Playground
+
+| Command | Why |
+|---------|-----|
+| `list-deploy-queue` | Calls API endpoint `/deploy_queue` whose handler was removed with deployd (defunct) |
+| `logs` | Reads from production log infrastructure (scribereader/vector-logs) |
+| `local-run` | Builds/pulls docker images from registry (not a playground use case) |
+| `rollback` | Creates git tags on remote; playground has no git server |
+| `start` / `stop` | Push git tags to remote; use config edits + setup_kubernetes_job instead |
+| `restart` | Same as start/stop — relies on git tag infrastructure |
+| `mesh-status` | Requires SmartStack/Envoy proxy (not in Kind cluster) |
+
+---
+
+## Flag Inconsistencies
+
+Some commands use different flags for the same concept:
+
+| Concept | Most commands | Exception |
+|---------|--------------|-----------|
+| soa_dir | `-d` | `validate` uses `-y` |
+| cluster | `-c` means cluster | `mark-for-deployment` and `wait-for-deployment`: `-c` means **commit** |
+| instance | `-i` | `mark-for-deployment` doesn't take instance (operates on deploy group) |

--- a/.claude/skills/paasta-playground/scripts/playground-env.sh
+++ b/.claude/skills/paasta-playground/scripts/playground-env.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Prints environment variables needed to run PaaSTA CLI commands against the playground.
+# Usage: source <(.claude/skills/paasta-playground/scripts/playground-env.sh)
+#    or: eval $(.claude/skills/paasta-playground/scripts/playground-env.sh)
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+
+echo "export PAASTA_SYSTEM_CONFIG_DIR=${REPO_ROOT}/etc_paasta_playground/"
+echo "export KUBECONFIG=${REPO_ROOT}/k8s_itests/kubeconfig"
+echo "export PAASTA_TEST_CLUSTER=kind-${USER}-k8s-test"
+
+if [ -f "${REPO_ROOT}/etc_paasta_playground/api_endpoints.json" ]; then
+    API_PORT=$(python3 -c "import json; print(json.load(open('${REPO_ROOT}/etc_paasta_playground/api_endpoints.json'))['api_endpoints']['kind-${USER}-k8s-test'].split(':')[-1])" 2>/dev/null)
+    if [ -n "$API_PORT" ]; then
+        echo "# API endpoint: http://localhost:${API_PORT}"
+    fi
+fi
+
+echo "# Run CLI: .tox/py310-linux/bin/python -m paasta_tools.cli.cli <cmd> -s compute-infra-test-service -c kind-${USER}-k8s-test -d ${REPO_ROOT}/soa_config_playground/"

--- a/.claude/skills/paasta-playground/scripts/playground-status.sh
+++ b/.claude/skills/paasta-playground/scripts/playground-status.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Checks the current state of the PaaSTA playground and reports what's ready vs what needs setup.
+# Usage: .claude/skills/paasta-playground/scripts/playground-status.sh
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../../.." && pwd)"
+KUBECONFIG="${REPO_ROOT}/k8s_itests/kubeconfig"
+CLUSTER="kind-${USER}-k8s-test"
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+ok() { echo -e "  ${GREEN}✓${NC} $1"; }
+fail() { echo -e "  ${RED}✗${NC} $1"; }
+warn() { echo -e "  ${YELLOW}!${NC} $1"; }
+
+echo "PaaSTA Playground Status"
+echo "========================"
+echo ""
+
+# Check tox env
+echo "Build environment:"
+if [ -d "${REPO_ROOT}/.tox/py310-linux" ]; then
+    ok "tox virtualenv exists (.tox/py310-linux/)"
+else
+    fail "tox virtualenv missing — run: make dev"
+fi
+echo ""
+
+# Check Kind cluster
+echo "Kind cluster (${CLUSTER}):"
+if KUBECONFIG="${KUBECONFIG}" kubectl cluster-info --context "${CLUSTER}" &>/dev/null 2>&1; then
+    ok "cluster is running"
+    NODE_COUNT=$(KUBECONFIG="${KUBECONFIG}" kubectl get nodes --no-headers 2>/dev/null | wc -l)
+    ok "${NODE_COUNT} node(s) available"
+else
+    fail "cluster not running — run: make k8s_fake_cluster"
+fi
+echo ""
+
+# Check playground configs
+echo "Playground configs:"
+if [ -d "${REPO_ROOT}/etc_paasta_playground" ]; then
+    ok "etc_paasta_playground/ exists"
+    if [ -f "${REPO_ROOT}/etc_paasta_playground/api_endpoints.json" ]; then
+        API_URL=$(python3 -c "import json; print(json.load(open('${REPO_ROOT}/etc_paasta_playground/api_endpoints.json'))['api_endpoints'].get('${CLUSTER}', 'not configured'))" 2>/dev/null || echo "parse error")
+        ok "api_endpoints.json → ${API_URL}"
+    fi
+else
+    fail "etc_paasta_playground/ missing — run: make generate_deployments_for_service"
+fi
+
+if [ -d "${REPO_ROOT}/soa_config_playground" ]; then
+    ok "soa_config_playground/ exists"
+    if [ -f "${REPO_ROOT}/soa_config_playground/compute-infra-test-service/deployments.json" ]; then
+        GIT_SHA=$(python3 -c "import json; d=json.load(open('${REPO_ROOT}/soa_config_playground/compute-infra-test-service/deployments.json')); print(d.get('v2',{}).get('deployments',{}).get('prod.main',{}).get('git_sha','unknown'))" 2>/dev/null || echo "parse error")
+        ok "deployments.json present (prod.main sha: ${GIT_SHA:0:8})"
+    else
+        fail "deployments.json missing — run: make generate_deployments_for_service"
+    fi
+else
+    fail "soa_config_playground/ missing — run: make generate_deployments_for_service"
+fi
+echo ""
+
+# Check pods
+echo "Workloads:"
+if KUBECONFIG="${KUBECONFIG}" kubectl get ns paastasvc-compute-infra-test-service &>/dev/null 2>&1; then
+    POD_STATUS=$(KUBECONFIG="${KUBECONFIG}" kubectl get pods -n paastasvc-compute-infra-test-service --no-headers 2>/dev/null)
+    RUNNING=$(echo "$POD_STATUS" | grep -c "Running" || echo "0")
+    TOTAL=$(echo "$POD_STATUS" | wc -l)
+    if [ "$RUNNING" -gt 0 ]; then
+        ok "${RUNNING}/${TOTAL} pod(s) Running in paastasvc-compute-infra-test-service"
+    else
+        warn "0 running pods (${TOTAL} total) — run: make setup-kubernetes-job"
+    fi
+else
+    fail "namespace 'paastasvc-compute-infra-test-service' not found — run: make setup-kubernetes-job"
+fi
+echo ""
+
+# Check API
+echo "PaaSTA API:"
+if [ -f "${REPO_ROOT}/etc_paasta_playground/api_endpoints.json" ]; then
+    API_URL=$(python3 -c "import json; print(json.load(open('${REPO_ROOT}/etc_paasta_playground/api_endpoints.json'))['api_endpoints']['${CLUSTER}'])" 2>/dev/null)
+    if [ -n "$API_URL" ] && curl -s --max-time 2 "${API_URL}/v1/version" &>/dev/null; then
+        ok "API responding at ${API_URL}"
+    else
+        fail "API not responding at ${API_URL:-unknown} — run: make playground-api (in another terminal)"
+    fi
+else
+    fail "api_endpoints.json missing — run: make generate_deployments_for_service first"
+fi
+echo ""
+
+# Check zookeeper
+echo "Zookeeper:"
+ZK_CONTAINER="${USER}-paasta-zookeeper"
+if docker ps --format '{{.Names}}' 2>/dev/null | grep -q "^${ZK_CONTAINER}$"; then
+    ok "container '${ZK_CONTAINER}' running"
+else
+    warn "container '${ZK_CONTAINER}' not running — will be started by make generate_deployments_for_service"
+fi
+echo ""

--- a/k8s_itests/deployments/kind/cluster-devbox.yaml
+++ b/k8s_itests/deployments/kind/cluster-devbox.yaml
@@ -4,16 +4,23 @@ apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
   - role: worker
-    labels:
+    labels: &worker-labels
       yelp.com/pool: default
-    # this mount is needed for services which rely on /nail/etc/{ecosystem,runtime}
-    extraMounts:
+    extraMounts: &worker-mounts
       - hostPath: /nail/etc
         containerPath: /nail/etc
   - role: worker
-    labels:
-      yelp.com/pool: default
-    # this mount is needed for services which rely on /nail/etc/{ecosystem,runtime}
-    extraMounts:
-      - hostPath: /nail/etc
-        containerPath: /nail/etc
+    labels: *worker-labels
+    extraMounts: *worker-mounts
+  - role: worker
+    labels: *worker-labels
+    extraMounts: *worker-mounts
+  - role: worker
+    labels: *worker-labels
+    extraMounts: *worker-mounts
+  - role: worker
+    labels: *worker-labels
+    extraMounts: *worker-mounts
+  - role: worker
+    labels: *worker-labels
+    extraMounts: *worker-mounts

--- a/k8s_itests/deployments/kind/cluster-devbox.yaml
+++ b/k8s_itests/deployments/kind/cluster-devbox.yaml
@@ -3,24 +3,15 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
-  - role: worker
-    labels: &worker-labels
+  - &worker-entry
+    role: worker
+    labels:
       yelp.com/pool: default
-    extraMounts: &worker-mounts
+    extraMounts:
       - hostPath: /nail/etc
         containerPath: /nail/etc
-  - role: worker
-    labels: *worker-labels
-    extraMounts: *worker-mounts
-  - role: worker
-    labels: *worker-labels
-    extraMounts: *worker-mounts
-  - role: worker
-    labels: *worker-labels
-    extraMounts: *worker-mounts
-  - role: worker
-    labels: *worker-labels
-    extraMounts: *worker-mounts
-  - role: worker
-    labels: *worker-labels
-    extraMounts: *worker-mounts
+  - *worker-entry
+  - *worker-entry
+  - *worker-entry
+  - *worker-entry
+  - *worker-entry

--- a/k8s_itests/scripts/set-paasta-registry-credentials.sh
+++ b/k8s_itests/scripts/set-paasta-registry-credentials.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 set -e
 
-CLUSTER=$1
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+CLUSTER=${1:?Usage: $0 <cluster-name>}
 REGISTRY="docker-paasta.yelpcorp.com:443"
 
 echo "Generating registry credentials..."
@@ -16,7 +17,7 @@ fi
 
 AUTH_TOKEN=$(echo -n "${USERNAME}:${SECRET}" | base64 -w 0)
 
-for node in $(./kind get nodes --name "${CLUSTER}"); do
+for node in $("${SCRIPT_DIR}/kind" get nodes --name "${CLUSTER}"); do
   echo "Setting up registry credentials on kind node: $node ..."
   podman exec "${node}" sh -c "
     mkdir -p /etc/containerd/certs.d/${REGISTRY} && \


### PR DESCRIPTION
- somewhat teach Claude how to run/test changes against a local k8s cluster. It allows testing/validating stuff that unit test can't reproduce
- added a few playground helper scripts
- updated kind cluster resource definition to use yaml anchors and added extra workers since 2 workers is a very small cluster