### PR TITLE
Support secrets for teams in paasta secret run

### DIFF
--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -31,6 +31,7 @@ from paasta_tools.cli.utils import list_instances
 from paasta_tools.cli.utils import select_k8s_secret_namespace
 from paasta_tools.kubernetes_tools import KUBE_CONFIG_USER_PATH
 from paasta_tools.kubernetes_tools import KubeClient
+from paasta_tools.kubernetes_tools import get_kubernetes_secret_env_variables
 from paasta_tools.kubernetes_tools import get_paasta_secret_name
 from paasta_tools.kubernetes_tools import get_secret
 from paasta_tools.secret_providers import SecretProvider
@@ -529,30 +530,42 @@ def paasta_secret(args):
     elif args.action == "run":
         new_environ = os.environ.copy()
 
-        system_paasta_config = load_system_paasta_config()
-        secret_provider_kwargs = {
-            "vault_cluster_config": system_paasta_config.get_vault_cluster_config(),
-            "vault_auth_method": args.vault_auth_method,
-            "vault_token_file": args.vault_token_file,
-        }
-
-        # This includes only the environment variables mapped to secrets,
-        # other environment variables are not included.
-        # All environment variables set in the current shell will also
-        # be passed through.
-        new_secret_vars = decrypt_secret_environment_variables(
-            secret_provider_name=system_paasta_config.get_secret_provider_name(),
-            environment=get_instance_config(
-                service=args.service,
-                instance=args.instance,
-                cluster=args.clusters,
-                soa_dir=args.yelpsoa_config_root,
-            ).get_env(),
+        instance_config = get_instance_config(
+            service=args.service,
+            instance=args.instance,
+            cluster=args.clusters,
             soa_dir=args.yelpsoa_config_root,
-            service_name=args.service,
-            cluster_name=args.clusters,
-            secret_provider_kwargs=secret_provider_kwargs,
         )
+        environment = instance_config.get_env()
+
+        if is_secrets_for_teams_enabled(service, args.yelpsoa_config_root):
+            cluster = instance_config.cluster
+            kube_context = cluster if cluster.startswith("eks-") else f"eks-{cluster}"
+            kube_client = KubeClient(
+                config_file=KUBE_CONFIG_USER_PATH, context=kube_context
+            )
+            new_secret_vars = get_kubernetes_secret_env_variables(
+                kube_client,
+                environment,
+                service,
+                instance_config.get_namespace(),
+            )
+        else:
+            system_paasta_config = load_system_paasta_config()
+            secret_provider_kwargs = {
+                "vault_cluster_config": system_paasta_config.get_vault_cluster_config(),
+                "vault_auth_method": args.vault_auth_method,
+                "vault_token_file": args.vault_token_file,
+            }
+
+            new_secret_vars = decrypt_secret_environment_variables(
+                secret_provider_name=system_paasta_config.get_secret_provider_name(),
+                environment=environment,
+                soa_dir=args.yelpsoa_config_root,
+                service_name=args.service,
+                cluster_name=args.clusters,
+                secret_provider_kwargs=secret_provider_kwargs,
+            )
 
         for var_name, var_value in new_secret_vars.items():
             new_environ[var_name] = var_value

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -273,11 +273,7 @@ def _add_common_args(parser: argparse.ArgumentParser, allow_shared: bool = True)
             action="store_true",
         )
     else:
-        service_group.add_argument(
-            "--shared",
-            action="store_false",
-            help=argparse.SUPPRESS,
-        )
+        service_group.set_defaults(shared=False)
 
 
 def add_subparser(subparsers):

--- a/tests/cli/test_cmds_secret.py
+++ b/tests/cli/test_cmds_secret.py
@@ -331,6 +331,10 @@ def test_paasta_secret_run():
         "paasta_tools.cli.cmds.secret.get_instance_config",
         autospec=True,
     ), mock.patch(
+        "paasta_tools.cli.cmds.secret.is_secrets_for_teams_enabled",
+        autospec=True,
+        return_value=False,
+    ), mock.patch(
         "paasta_tools.cli.cmds.secret.load_system_paasta_config", autospec=True
     ), mock.patch(
         "os.execvpe",
@@ -357,6 +361,52 @@ def test_paasta_secret_run():
         assert (
             mock_exec.call_args[0][2].get("PAASTA_SECRET_TEST") == "test secret value"
         )
+
+
+def test_paasta_secret_run_secrets_for_teams():
+    with mock.patch(
+        "paasta_tools.cli.cmds.secret.get_instance_config",
+        autospec=True,
+    ) as mock_get_instance_config, mock.patch(
+        "paasta_tools.cli.cmds.secret.is_secrets_for_teams_enabled",
+        autospec=True,
+        return_value=True,
+    ), mock.patch(
+        "paasta_tools.cli.cmds.secret.KubeClient",
+        autospec=True,
+    ), mock.patch(
+        "paasta_tools.cli.cmds.secret.get_kubernetes_secret_env_variables",
+        autospec=True,
+    ) as mock_get_k8s_secrets, mock.patch(
+        "os.execvpe",
+        autospec=True,
+    ) as mock_exec:
+        mock_instance_config = mock.MagicMock()
+        mock_instance_config.cluster = "pnw-devc"
+        mock_instance_config.get_namespace.return_value = "paasta"
+        mock_instance_config.get_env.return_value = {
+            "PAASTA_SECRET_FOO": "SECRET(foo)",
+        }
+        mock_get_instance_config.return_value = mock_instance_config
+        mock_get_k8s_secrets.return_value = {
+            "PAASTA_SECRET_FOO": "decrypted_value",
+        }
+        mock_args = mock.Mock(
+            action="run",
+            service="sast",
+            clusters="pnw-devc",
+            instance="main",
+            cmd=["foo"],
+        )
+
+        secret.paasta_secret(mock_args)
+
+        mock_exec.assert_called_once_with(
+            "foo",
+            ["foo"],
+            mock.ANY,
+        )
+        assert mock_exec.call_args[0][2].get("PAASTA_SECRET_FOO") == "decrypted_value"
 
 
 def test_update_extra_namespaces_set(tmp_path):


### PR DESCRIPTION
## Summary

`paasta secret run` on a service with secrets_for_teams enabled didn't know about the Kubernetes-based secret path, and always used vault as the secret provider.

I also fixed a bug encountered while testing where `paasta secret run` always treated the service as a shared secret due to an argparse misconfiguration (store_false defaults to True)

## Testing Done

- [x] Verified paasta secret run fetches secrets from Kubernetes for a service with secrets_for_teams enabled
- [x] Verified the vault path still works for services without secrets_for_teams
- [x] Unit tests added for the new code path
- [x] Existing tests updated and passing
