### PR TITLE
Add more labels to paasta_secrets_sync timers, and support setting arbitrary dimensions via envvar

### DIFF
--- a/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
+++ b/paasta_tools/kubernetes/bin/paasta_secrets_sync.py
@@ -185,6 +185,9 @@ def main() -> None:
     timer = metrics_lib.system_timer(
         dimensions=dict(
             cluster=cluster,
+            secret_type=args.secret_type,
+            namespace=args.namespace or "",
+            only_extra_namespaces=args.only_extra_namespaces,
         )
     )
 

--- a/paasta_tools/metrics/metrics_lib.py
+++ b/paasta_tools/metrics/metrics_lib.py
@@ -201,6 +201,21 @@ class NoMetrics(BaseMetrics):
         return True
 
 
+def _parse_metric_labels_env() -> Dict[str, str]:
+    """Parse PAASTA_METRICS_LABELS envvar (comma-separated KEY=VALUE pairs) into a dict."""
+    raw = os.environ.get("PAASTA_METRICS_LABELS", "")
+    if not raw:
+        return {}
+    result: Dict[str, str] = {}
+    for token in raw.split(","):
+        token = token.strip()
+        if "=" not in token:
+            continue
+        key, _, value = token.partition("=")
+        result[key.strip()] = value.strip()
+    return result
+
+
 def system_timer(
     name: str = "system_process_duration", dimensions: Dict[str, Any] = {}
 ) -> TimerProtocol:
@@ -220,6 +235,7 @@ def system_timer(
         "parent_pid": parent_pid,
         "pid": pid,
     }
+    default_dimensions.update(_parse_metric_labels_env())
     default_dimensions.update(dimensions)
     return metrics_interface.create_timer(
         name=name, default_dimensions=default_dimensions

--- a/tests/kubernetes/bin/test_paasta_secrets_sync.py
+++ b/tests/kubernetes/bin/test_paasta_secrets_sync.py
@@ -41,6 +41,45 @@ def test_parse_args():
         assert parse_args()
 
 
+def test_main_dimensions_include_secret_type_and_namespace():
+    with mock.patch(
+        "paasta_tools.kubernetes.bin.paasta_secrets_sync.parse_args", autospec=True
+    ) as mock_parse_args, mock.patch(
+        "paasta_tools.kubernetes.bin.paasta_secrets_sync.load_system_paasta_config",
+        autospec=True,
+    ) as mock_load_config, mock.patch(
+        "paasta_tools.kubernetes.bin.paasta_secrets_sync.metrics_lib.system_timer",
+        autospec=True,
+    ) as mock_system_timer, mock.patch(
+        "paasta_tools.kubernetes.bin.paasta_secrets_sync.KubeClient", autospec=True
+    ), mock.patch(
+        "paasta_tools.kubernetes.bin.paasta_secrets_sync.get_services_to_k8s_namespaces_to_allowlist",
+        autospec=True,
+        return_value={},
+    ), mock.patch(
+        "paasta_tools.kubernetes.bin.paasta_secrets_sync.sync_all_secrets",
+        autospec=True,
+        return_value=True,
+    ):
+        mock_parse_args.return_value = mock.Mock(
+            cluster="my-cluster",
+            service_list=["my-service"],
+            secret_type="paasta-secret",
+            namespace="paasta-flinks",
+            only_extra_namespaces=False,
+        )
+        mock_load_config.return_value.get_cluster.return_value = "my-cluster"
+
+        with pytest.raises(SystemExit):
+            main()
+
+        _, kwargs = mock_system_timer.call_args
+        dims = kwargs["dimensions"]
+        assert dims["secret_type"] == "paasta-secret"
+        assert dims["namespace"] == "paasta-flinks"
+        assert dims["only_extra_namespaces"] is False
+
+
 def test_main():
     with mock.patch(
         "paasta_tools.kubernetes.bin.paasta_secrets_sync.parse_args", autospec=True

--- a/tests/metrics/test_metrics_lib.py
+++ b/tests/metrics/test_metrics_lib.py
@@ -76,12 +76,7 @@ class TestParseMetricLabelsEnv(unittest.TestCase):
             self.assertEqual(_parse_metric_labels_env(), {})
 
     def test_envvar_absent(self):
-        env = {
-            k: v
-            for k, v in __import__("os").environ.items()
-            if k != "PAASTA_METRICS_LABELS"
-        }
-        with mock.patch.dict("os.environ", env, clear=True):
+        with mock.patch.dict("os.environ", {}, clear=True):
             self.assertEqual(_parse_metric_labels_env(), {})
 
     def test_single_label(self):

--- a/tests/metrics/test_metrics_lib.py
+++ b/tests/metrics/test_metrics_lib.py
@@ -4,6 +4,7 @@ from unittest import mock
 from py.test import raises
 
 from paasta_tools.metrics import metrics_lib
+from paasta_tools.metrics.metrics_lib import _parse_metric_labels_env
 
 
 class TestNoMetrics(unittest.TestCase):
@@ -67,3 +68,46 @@ class TestMeteoriteMetrics(unittest.TestCase):
 
     def tearDown(self):
         metrics_lib.yelp_meteorite = None
+
+
+class TestParseMetricLabelsEnv(unittest.TestCase):
+    def test_empty_envvar(self):
+        with mock.patch.dict("os.environ", {"PAASTA_METRICS_LABELS": ""}):
+            self.assertEqual(_parse_metric_labels_env(), {})
+
+    def test_envvar_absent(self):
+        env = {
+            k: v
+            for k, v in __import__("os").environ.items()
+            if k != "PAASTA_METRICS_LABELS"
+        }
+        with mock.patch.dict("os.environ", env, clear=True):
+            self.assertEqual(_parse_metric_labels_env(), {})
+
+    def test_single_label(self):
+        with mock.patch.dict(
+            "os.environ", {"PAASTA_METRICS_LABELS": "job=sync_paasta_secrets_flink"}
+        ):
+            self.assertEqual(
+                _parse_metric_labels_env(), {"job": "sync_paasta_secrets_flink"}
+            )
+
+    def test_multiple_labels(self):
+        with mock.patch.dict(
+            "os.environ", {"PAASTA_METRICS_LABELS": "job=sync_flink,workload=flink"}
+        ):
+            self.assertEqual(
+                _parse_metric_labels_env(), {"job": "sync_flink", "workload": "flink"}
+            )
+
+    def test_malformed_token_skipped(self):
+        with mock.patch.dict(
+            "os.environ", {"PAASTA_METRICS_LABELS": "bad_token_no_equals"}
+        ):
+            self.assertEqual(_parse_metric_labels_env(), {})
+
+    def test_mixed_valid_and_malformed(self):
+        with mock.patch.dict(
+            "os.environ", {"PAASTA_METRICS_LABELS": "good=val,bad_token,other=x"}
+        ):
+            self.assertEqual(_parse_metric_labels_env(), {"good": "val", "other": "x"})


### PR DESCRIPTION
I recently added Yet Another Cronjob for paasta secrets after #4290 , but realized our paasta_system_process_duration metrics didn't have enough information to distinguish between our standard paasta servcie secret sync, and only-namespaces syncs. 

This updates the paasta_secrets_sync system_timers to use some of our passed-in args as metric dimensions, but also adds support for callers to be able to set any arbitrary dimensions for a script using `system_timer` using a `PAASTA_METRICS_LABELS` envvar (e.g. they can set this in their cronjob(s), if they have any special labels they want to be consistent with others). 

I installed this version into eksstage and verified it would still operate as expected, and it emitted new metric labels as expected: [grafana](https://grafana.yelpcorp.com/explore?schemaVersion=1&panes=%7B%22a5k%22:%7B%22datasource%22:%22P627274A7C77417EA%22,%22queries%22:%5B%7B%22refId%22:%22A%22,%22expr%22:%22paasta_system_process_duration%7Bcluster%3D%5C%22eksstage%5C%22,%20host%3D%5C%2210-81-17-39-uswest2adevc%5C%22,%20cron_job_name%3D~%5C%22.%2A%5C%22%7D%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P627274A7C77417EA%22%7D,%22editorMode%22:%22code%22,%22legendFormat%22:%22__auto%22%7D%5D,%22range%22:%7B%22to%22:%221778283811313%22,%22from%22:%221778283511313%22%7D%7D%7D) 

