### PR TITLE
feat: send Slack notification to authors after paasta rollback

### DIFF
--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+from typing import Any
 from typing import Collection
 from typing import Dict
 from typing import Generator
@@ -22,6 +23,7 @@ from typing import Tuple
 from humanize import naturaltime
 
 from paasta_tools.cli.cmds.mark_for_deployment import can_user_deploy_service
+from paasta_tools.cli.cmds.mark_for_deployment import get_authors_to_be_notified
 from paasta_tools.cli.cmds.mark_for_deployment import get_deploy_info
 from paasta_tools.cli.cmds.mark_for_deployment import mark_for_deployment
 from paasta_tools.cli.utils import extract_tags
@@ -33,6 +35,7 @@ from paasta_tools.cli.utils import validate_given_deploy_groups
 from paasta_tools.deployment_utils import get_currently_deployed_version
 from paasta_tools.remote_git import create_rollback_tag
 from paasta_tools.remote_git import list_remote_refs
+from paasta_tools.slack import get_slack_client
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import DeploymentVersion
 from paasta_tools.utils import PaastaColors
@@ -240,6 +243,34 @@ def list_previous_versions(
         )
 
 
+def notify_rollback_slack(
+    service: str,
+    deploy_group: str,
+    git_url: str,
+    rolled_back_from: DeploymentVersion,
+    new_version: DeploymentVersion,
+    deploy_info: Dict[str, Any],
+) -> None:
+    slack_client = get_slack_client()
+    channels = deploy_info.get("slack_channels", [])
+    if not channels:
+        return
+
+    authors = get_authors_to_be_notified(
+        git_url=git_url,
+        from_sha=new_version.sha,  # rollback target (old good SHA)
+        to_sha=rolled_back_from.sha,  # the bad SHA being rolled back
+        authors=None,
+    )
+
+    message = (
+        f":rewind: *Rollback* of `{service}` in `{deploy_group}`\n"
+        f"Rolled back from `{rolled_back_from.sha[:8]}` to `{new_version.sha[:8]}`\n"
+        f"{authors}"
+    )
+    slack_client.post(channels=[channels[0]], message=message)
+
+
 def paasta_rollback(args: argparse.Namespace) -> int:
     """Call mark_for_deployment with rollback parameters
     :param args: contains all the arguments passed onto the script: service,
@@ -334,6 +365,14 @@ def paasta_rollback(args: argparse.Namespace) -> int:
         # rollback than we care about if the underlying machinery was successfully able to complete the request
         if rolled_back_from != new_version:
             performed_rollback = True
+            notify_rollback_slack(
+                service=service,
+                deploy_group=deploy_group,
+                git_url=git_url,
+                rolled_back_from=rolled_back_from,
+                new_version=new_version,
+                deploy_info=deploy_info,
+            )
             audit_action_details = {
                 "rolled_back_from": str(rolled_back_from),
                 "rolled_back_to": str(new_version),

--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -23,7 +23,6 @@ from typing import Tuple
 from humanize import naturaltime
 
 from paasta_tools.cli.cmds.mark_for_deployment import can_user_deploy_service
-from paasta_tools.cli.cmds.mark_for_deployment import get_authors_to_be_notified
 from paasta_tools.cli.cmds.mark_for_deployment import get_deploy_info
 from paasta_tools.cli.cmds.mark_for_deployment import mark_for_deployment
 from paasta_tools.cli.utils import extract_tags
@@ -247,36 +246,32 @@ def list_previous_versions(
 def notify_rollback_slack(
     service: str,
     deploy_group: str,
-    git_url: str,
     rolled_back_from: DeploymentVersion,
     new_version: DeploymentVersion,
     deploy_info: Dict[str, Any],
 ) -> None:
-    slack_client = get_slack_client()
-    channels = deploy_info.get("slack_channels", [])
+    try:
+        slack_client = get_slack_client()
+        channels = deploy_info.get("slack_channels", [])
 
-    authors = get_authors_to_be_notified(
-        git_url=git_url,
-        from_sha=new_version.sha,  # rollback target (old good SHA)
-        to_sha=rolled_back_from.sha,  # the bad SHA being rolled back
-        authors=None,
-    )
+        # TODO(PAASTA-16927): we don't have a way of getting the authors for a range of commits
+        # from within paasta, but ideally we'd add the author list to the deploy channel's message
+        # (and potentially DM them to let them know their changes have been rolled back by @<rollback_user>
+        # and will likely be reverted soon)
+        rollback_user = get_username()
+        message = (
+            f":rewind: *Rollback* of `{service}` in `{deploy_group}` by <@{rollback_user}>\n"
+            f"Rolled back from `{rolled_back_from.sha[:8]}` to `{new_version.sha[:8]}`\n"
+            f":warning: The rolled-back commits must also be reverted in Git, "
+            f"or they will be redeployed on the next push."
+        )
 
-    rollback_user = get_username()
-    message = (
-        f":rewind: *Rollback* of `{service}` in `{deploy_group}` by <@{rollback_user}>\n"
-        f"Rolled back from `{rolled_back_from.sha[:8]}` to `{new_version.sha[:8]}`\n"
-        f"{authors}\n"
-        f":warning: The rolled-back commits must also be reverted in Git, "
-        f"or they will be redeployed on the next push."
-    )
+        if channels:
+            slack_client.post(channels=channels, message=message)
 
-    if channels:
-        slack_client.post(channels=channels, message=message)
-
-    # NICE TO HAVE: we DM all the authors but ticket below is a blocker
-    # TODO: PAASTA-16927: support getting authors for services on GHE has to be fixed first
-    slack_client.post_single(channel=f"@{rollback_user}", message=message)
+        slack_client.post_single(channel=f"@{rollback_user}", message=message)
+    except Exception:
+        print("Warning: Failed to send rollback Slack notification")
 
 
 def paasta_rollback(args: argparse.Namespace) -> int:
@@ -376,7 +371,6 @@ def paasta_rollback(args: argparse.Namespace) -> int:
             notify_rollback_slack(
                 service=service,
                 deploy_group=deploy_group,
-                git_url=git_url,
                 rolled_back_from=rolled_back_from,
                 new_version=new_version,
                 deploy_info=deploy_info,

--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -254,7 +254,7 @@ def notify_rollback_slack(
 ) -> None:
     try:
         slack_client = get_slack_client()
-        channels = deploy_info.get("slack_channels", [])
+        channels = deploy_info.get("slack_channels", [DEFAULT_SLACK_CHANNEL])
 
         # TODO(PAASTA-16927): we don't have a way of getting the authors for a range of commits
         # from within paasta, but ideally we'd add the author list to the deploy channel's message
@@ -270,8 +270,6 @@ def notify_rollback_slack(
 
         if channels:
             slack_client.post(channels=channels, message=message)
-        else:
-            slack_client.post(channels=[DEFAULT_SLACK_CHANNEL], message=message)
 
         slack_client.post_single(channel=f"@{rollback_user}", message=message)
     except Exception:

--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -47,6 +47,8 @@ from paasta_tools.utils import get_username
 from paasta_tools.utils import list_services
 from paasta_tools.utils import parse_timestamp
 
+DEFAULT_SLACK_CHANNEL = "#deploy"
+
 
 def add_subparser(subparsers: argparse._SubParsersAction) -> None:
     list_parser = subparsers.add_parser(
@@ -268,6 +270,8 @@ def notify_rollback_slack(
 
         if channels:
             slack_client.post(channels=channels, message=message)
+        else:
+            slack_client.post(channels=[DEFAULT_SLACK_CHANNEL], message=message)
 
         slack_client.post_single(channel=f"@{rollback_user}", message=message)
     except Exception:

--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -13,6 +13,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
+import re
 from typing import Any
 from typing import Collection
 from typing import Dict
@@ -44,6 +45,7 @@ from paasta_tools.utils import _log_audit
 from paasta_tools.utils import datetime_from_utc_to_local
 from paasta_tools.utils import format_table
 from paasta_tools.utils import get_git_url
+from paasta_tools.utils import get_username
 from paasta_tools.utils import list_services
 from paasta_tools.utils import parse_timestamp
 
@@ -263,12 +265,26 @@ def notify_rollback_slack(
         authors=None,
     )
 
+    rollback_user = get_username()
     message = (
-        f":rewind: *Rollback* of `{service}` in `{deploy_group}`\n"
+        f":rewind: *Rollback* of `{service}` in `{deploy_group}` by <@{rollback_user}>\n"
         f"Rolled back from `{rolled_back_from.sha[:8]}` to `{new_version.sha[:8]}`\n"
-        f"{authors}"
+        f"{authors}\n"
+        f":warning: The rolled-back commits must also be reverted in Git, "
+        f"or they will be redeployed on the next push."
     )
-    slack_client.post(channels=[channels[0]], message=message)
+
+    slack_client.post(channels=channels, message=message)
+
+    # DM each author directly
+    # parse usernames from the "<@user1>, <@user2>" format in authors string
+    # TODO: PAASTA-16927: support getting authors for services on GHE has to be fixed first
+    author_list = re.findall(r"<@(\w+)>", authors)
+    for author in author_list:
+        slack_client.post_single(
+            channel=f"@{author}",
+            message=message,
+        )
 
 
 def paasta_rollback(args: argparse.Namespace) -> int:

--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -13,7 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import argparse
-import re
 from typing import Any
 from typing import Collection
 from typing import Dict
@@ -255,8 +254,6 @@ def notify_rollback_slack(
 ) -> None:
     slack_client = get_slack_client()
     channels = deploy_info.get("slack_channels", [])
-    if not channels:
-        return
 
     authors = get_authors_to_be_notified(
         git_url=git_url,
@@ -274,17 +271,12 @@ def notify_rollback_slack(
         f"or they will be redeployed on the next push."
     )
 
-    slack_client.post(channels=channels, message=message)
+    if channels:
+        slack_client.post(channels=channels, message=message)
 
-    # DM each author directly
-    # parse usernames from the "<@user1>, <@user2>" format in authors string
+    # NICE TO HAVE: we DM all the authors but ticket below is a blocker
     # TODO: PAASTA-16927: support getting authors for services on GHE has to be fixed first
-    author_list = re.findall(r"<@(\w+)>", authors)
-    for author in author_list:
-        slack_client.post_single(
-            channel=f"@{author}",
-            message=message,
-        )
+    slack_client.post_single(channel=f"@{rollback_user}", message=message)
 
 
 def paasta_rollback(args: argparse.Namespace) -> int:

--- a/tests/cli/test_cmds_rollback.py
+++ b/tests/cli/test_cmds_rollback.py
@@ -26,6 +26,7 @@ from paasta_tools.utils import DeploymentVersion
 from paasta_tools.utils import RollbackTypes
 
 
+@patch("paasta_tools.cli.cmds.rollback.notify_rollback_slack", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.create_rollback_tag", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_version", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback._log_audit", autospec=True)
@@ -45,6 +46,7 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
     mock_log_audit,
     mock_get_currently_deployed_version,
     mock_create_rollback_tag,
+    mock_notify_rollback_slack,
 ):
     fake_args, _ = parse_args(
         ["rollback", "-s", "fakeservice", "-k", "abcd" * 10, "-l", "fake_deploy_group1"]
@@ -96,6 +98,7 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
         assert call_kwargs["service"] == fake_args.service
 
 
+@patch("paasta_tools.cli.cmds.rollback.notify_rollback_slack", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.create_rollback_tag", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_version", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback._log_audit", autospec=True)
@@ -115,6 +118,7 @@ def test_paasta_rollback_mark_for_deployment_with_image(
     mock_log_audit,
     mock_get_currently_deployed_version,
     mock_create_rollback_tag,
+    mock_notify_rollback_slack,
 ):
     fake_args, _ = parse_args(
         [
@@ -182,6 +186,7 @@ def test_paasta_rollback_mark_for_deployment_with_image(
         assert call_kwargs["service"] == fake_args.service
 
 
+@patch("paasta_tools.cli.cmds.rollback.notify_rollback_slack", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.create_rollback_tag", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_version", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback._log_audit", autospec=True)
@@ -201,6 +206,7 @@ def test_paasta_rollback_with_force(
     mock_log_audit,
     mock_get_currently_deployed_version,
     mock_create_rollback_tag,
+    mock_notify_rollback_slack,
 ):
     fake_args, _ = parse_args(
         [
@@ -260,6 +266,7 @@ def test_paasta_rollback_with_force(
         assert call_kwargs["service"] == fake_args.service
 
 
+@patch("paasta_tools.cli.cmds.rollback.notify_rollback_slack", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_version", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback._log_audit", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.list_deploy_groups", autospec=True)
@@ -277,6 +284,7 @@ def test_paasta_rollback_mark_for_deployment_no_deploy_group_arg(
     mock_list_deploy_groups,
     mock_log_audit,
     mock_get_currently_deployed_version,
+    mock_notify_rollback_slack,
 ):
     fake_args, _ = parse_args(["rollback", "-s", "fakeservice", "-k", "abcd" * 10])
 
@@ -325,6 +333,7 @@ def test_paasta_rollback_mark_for_deployment_no_deploy_group_arg(
         assert call_kwargs["service"] == fake_args.service
 
 
+@patch("paasta_tools.cli.cmds.rollback.notify_rollback_slack", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.create_rollback_tag", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_version", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback._log_audit", autospec=True)
@@ -344,6 +353,7 @@ def test_paasta_rollback_mark_for_deployment_all_deploy_groups_arg(
     mock_log_audit,
     mock_get_currently_deployed_version,
     mock_create_rollback_tag,
+    mock_notify_rollback_slack,
 ):
     fake_args, _ = parse_args(
         ["rollback", "-s", "fakeservice", "-k", "abcd" * 10, "-a"]
@@ -484,6 +494,7 @@ def test_paasta_rollback_git_sha_was_not_marked_before(
     assert not mock_log_audit.called
 
 
+@patch("paasta_tools.cli.cmds.rollback.notify_rollback_slack", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.create_rollback_tag", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_version", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback._log_audit", autospec=True)
@@ -503,6 +514,7 @@ def test_paasta_rollback_mark_for_deployment_multiple_deploy_group_args(
     mock_log_audit,
     mock_get_currently_deployed_version,
     mock_create_rollback_tag,
+    mock_notify_rollback_slack,
 ):
     fake_args, _ = parse_args(
         [
@@ -800,7 +812,9 @@ def test_create_rollback_tag_called_after_rollback():
         return_value=old_version,
     ), patch(
         "paasta_tools.cli.cmds.rollback.create_rollback_tag", autospec=True
-    ) as mock_create_rollback_tag:
+    ) as mock_create_rollback_tag, patch(
+        "paasta_tools.cli.cmds.rollback.notify_rollback_slack", autospec=True
+    ):
         assert paasta_rollback(fake_args) == 0
 
         mock_create_rollback_tag.assert_called_once_with(
@@ -852,7 +866,9 @@ def test_create_rollback_tag_not_called_when_same_version():
         return_value=DeploymentVersion(sha=commit, image_version=None),
     ), patch(
         "paasta_tools.cli.cmds.rollback.create_rollback_tag", autospec=True
-    ) as mock_create_rollback_tag:
+    ) as mock_create_rollback_tag, patch(
+        "paasta_tools.cli.cmds.rollback.notify_rollback_slack", autospec=True
+    ):
         paasta_rollback(fake_args)
 
         assert not mock_create_rollback_tag.called

--- a/tests/cli/test_cmds_rollback.py
+++ b/tests/cli/test_cmds_rollback.py
@@ -81,6 +81,18 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
         image_version=None,
     )
 
+    mock_notify_rollback_slack.assert_called_once()
+    notify_kwargs = mock_notify_rollback_slack.call_args[1]
+    assert notify_kwargs["service"] == fake_args.service
+    assert notify_kwargs["deploy_group"] == fake_args.deploy_groups
+    assert (
+        notify_kwargs["rolled_back_from"]
+        == mock_get_currently_deployed_version.return_value
+    )
+    assert notify_kwargs["new_version"] == DeploymentVersion(
+        sha=fake_args.commit, image_version=None
+    )
+
     # ensure that we logged each deploy group that was rolled back AND that we logged things correctly
     mock_log_audit.call_count == len(fake_args.deploy_groups)
     for call_args in mock_log_audit.call_args_list:


### PR DESCRIPTION
Pings the git authors whose commits are being rolled back via the service's configured Slack channel, improving visibility when a rollback occurs.

<img width="607" height="148" alt="Screenshot 2026-05-11 at 15 02 55" src="https://github.com/user-attachments/assets/a0c7ca43-12cc-400e-bb7c-1134f805f3f8" />

