### PR TITLE
STREAMAPP-15217: Support explicit pool field in Flink yelpsoa-configs

### DIFF
--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -114,6 +114,7 @@ class FlinkInstanceDetails(TypedDict):
 class FlinkDeploymentConfigDict(LongRunningServiceConfigDict, total=False):
     taskmanager: TaskManagerConfig
     spot: bool
+    pool: str
     udf_plugin_name: str
     udf_plugin_version: str
 
@@ -166,19 +167,18 @@ class FlinkDeploymentConfig(LongRunningServiceConfig):
 
     def get_pool(self) -> Optional[str]:
         """
-        Parses flink_pool from a specific Flink Deployment instance's configuration data, using key 'spot'.
+        Returns the Karpenter pool name for this Flink instance.
 
-        Args:
-            flink_deployment_config_data: The FlinkDeploymentConfig for a specific Flink yelpsoa instance
-
-        Returns:
-            The flink pool string.
+        If an explicit 'pool' key is set, it takes precedence. Otherwise falls back
+        to the spot-based logic: spot=False -> "flink", else -> "flink-spot".
         """
+        pool = self.config_dict.get("pool", None)
+        if pool is not None:
+            return pool
         spot_config = self.config_dict.get("spot", None)
         if spot_config is False:
             return "flink"
         else:
-            # if not set or True, Flink instance defaults to use flink-spot pool
             return "flink-spot"
 
 

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -166,7 +166,7 @@ class FlinkDeploymentConfig(LongRunningServiceConfig):
 
     def get_pool(self) -> Optional[str]:
         """
-        Returns the Karpenter pool name for this Flink instance.
+        Returns the pool a Flink instance is configured to use.
 
         If an explicit 'pool' key is set, it takes precedence. Otherwise falls back
         to the spot-based logic: spot=False -> "flink", else -> "flink-spot".

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -114,7 +114,6 @@ class FlinkInstanceDetails(TypedDict):
 class FlinkDeploymentConfigDict(LongRunningServiceConfigDict, total=False):
     taskmanager: TaskManagerConfig
     spot: bool
-    pool: str
     udf_plugin_name: str
     udf_plugin_version: str
 

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -179,6 +179,7 @@ class FlinkDeploymentConfig(LongRunningServiceConfig):
         if spot_config is False:
             return "flink"
         else:
+            # if not set or True, Flink instance defaults to use flink-spot pool
             return "flink-spot"
 
 

--- a/tests/test_flink_tools.py
+++ b/tests/test_flink_tools.py
@@ -386,6 +386,7 @@ class TestGetFlinkPoolFromFlinkDeploymentConfig:
         "config_dict,expected_pool",
         [
             ({"pool": "flink-spot-ebs", "spot": True}, "flink-spot-ebs"),
+            ({"pool": "flink-spot-ebs", "spot": False}, "flink-spot-ebs"),
             ({"pool": "flink-spot-ebs"}, "flink-spot-ebs"),
         ],
     )

--- a/tests/test_flink_tools.py
+++ b/tests/test_flink_tools.py
@@ -382,31 +382,22 @@ class TestGetFlinkPoolFromFlinkDeploymentConfig:
         )
         assert flink_deployment_config.get_pool() == "flink-spot"
 
-    def test_explicit_pool_overrides_spot(self):
-        # When pool is explicitly set, it takes precedence over spot
-        config_dict = FlinkDeploymentConfigDict(
-            {"pool": "flink-spot-ebs", "spot": True}
-        )
+    @pytest.mark.parametrize(
+        "config_dict,expected_pool",
+        [
+            ({"pool": "flink-spot-ebs", "spot": True}, "flink-spot-ebs"),
+            ({"pool": "flink-spot-ebs"}, "flink-spot-ebs"),
+        ],
+    )
+    def test_explicit_pool_takes_precedence(self, config_dict, expected_pool):
         flink_deployment_config = FlinkDeploymentConfig(
             service="test_service",
             cluster="test_cluster",
             instance="test_instance",
-            config_dict=config_dict,
+            config_dict=FlinkDeploymentConfigDict(config_dict),
             branch_dict=None,
         )
-        assert flink_deployment_config.get_pool() == "flink-spot-ebs"
-
-    def test_explicit_pool_without_spot(self):
-        # When pool is explicitly set without spot, pool still takes precedence
-        config_dict = FlinkDeploymentConfigDict({"pool": "flink-spot-ebs"})
-        flink_deployment_config = FlinkDeploymentConfig(
-            service="test_service",
-            cluster="test_cluster",
-            instance="test_instance",
-            config_dict=config_dict,
-            branch_dict=None,
-        )
-        assert flink_deployment_config.get_pool() == "flink-spot-ebs"
+        assert flink_deployment_config.get_pool() == expected_pool
 
 
 @pytest.fixture

--- a/tests/test_flink_tools.py
+++ b/tests/test_flink_tools.py
@@ -384,7 +384,9 @@ class TestGetFlinkPoolFromFlinkDeploymentConfig:
 
     def test_explicit_pool_overrides_spot(self):
         # When pool is explicitly set, it takes precedence over spot
-        config_dict = FlinkDeploymentConfigDict({"pool": "flink-spot-ebs", "spot": True})
+        config_dict = FlinkDeploymentConfigDict(
+            {"pool": "flink-spot-ebs", "spot": True}
+        )
         flink_deployment_config = FlinkDeploymentConfig(
             service="test_service",
             cluster="test_cluster",

--- a/tests/test_flink_tools.py
+++ b/tests/test_flink_tools.py
@@ -382,6 +382,30 @@ class TestGetFlinkPoolFromFlinkDeploymentConfig:
         )
         assert flink_deployment_config.get_pool() == "flink-spot"
 
+    def test_explicit_pool_overrides_spot(self):
+        # When pool is explicitly set, it takes precedence over spot
+        config_dict = FlinkDeploymentConfigDict({"pool": "flink-spot-ebs", "spot": True})
+        flink_deployment_config = FlinkDeploymentConfig(
+            service="test_service",
+            cluster="test_cluster",
+            instance="test_instance",
+            config_dict=config_dict,
+            branch_dict=None,
+        )
+        assert flink_deployment_config.get_pool() == "flink-spot-ebs"
+
+    def test_explicit_pool_without_spot(self):
+        # When pool is explicitly set without spot, pool still takes precedence
+        config_dict = FlinkDeploymentConfigDict({"pool": "flink-spot-ebs"})
+        flink_deployment_config = FlinkDeploymentConfig(
+            service="test_service",
+            cluster="test_cluster",
+            instance="test_instance",
+            config_dict=config_dict,
+            branch_dict=None,
+        )
+        assert flink_deployment_config.get_pool() == "flink-spot-ebs"
+
 
 @pytest.fixture
 def flink_instance_config():


### PR DESCRIPTION
 - Adds `pool` field to `FlinkDeploymentConfigDict`
 - Updates `get_pool()` to check for explicit `pool` value before falling back to spot-based logic
 - Enables targeting custom Karpenter pools like `flink-spot-ebs` directly from yelpsoa-configs

 ## Usage

 ```yaml
 # yelpsoa-configs: flinkeks-pnw-devc.yaml
 my_ebs_trial_instance:
   pool: flink-spot-ebs
   taskmanager:
     disk: 100Gi
 ```

 ## Context

 Part of the flink-spot-ebs experiment to trial EBS-backed instances for Flink RocksDB state.

 - Jira: STREAMAPP-15217
 - Infra PR: https://github.yelpcorp.com/misc/compute-infra-k8s/pull/3138
 - Operator PR: https://github.yelpcorp.com/services/flink-operator/pull/211

 ## Backwards compatible

 When `pool` is not set, behavior is unchanged (spot=False -> "flink", else -> "flink-spot").

 ## Test plan

 - [x] Added unit tests for explicit pool override
 - [ ] CI passes
 - [ ] Integration: deploy a test Flink job with `pool: flink-spot-ebs` on devc