### PR TITLE
fix: paasta cli autocomplete entrypoint

### DIFF
--- a/paasta_tools/cli/paasta_tabcomplete.sh
+++ b/paasta_tools/cli/paasta_tabcomplete.sh
@@ -20,4 +20,4 @@ fi
 # This magic eval enables tab-completion for the "paasta" command
 # http://argcomplete.readthedocs.io/en/latest/index.html#synopsis
 # This comes from the paasta-tools system package
-eval "$(/opt/venvs/paasta-tools/bin/register-python-argcomplete paasta)"
+eval "$(/opt/venvs/paasta-tools/bin/register-python-argcomplete /opt/venvs/paasta-tools/bin/paasta)"


### PR DESCRIPTION
`PAASTA-18866` was the fix for the CLI autocomplete, but needed to also change the entry point for `paasta`. From my understanding, `/usr/bin/paasta` is the binary called when we run `paasta` commands. We also have `/opt/venvs/paasta-tools/bin/paasta` that can be the Python entry point for `paasta` commands. The `/usr/bin/paasta` cannot respond to the python environment vars ( _ARGCOMPLETE=1) which is required for autocompelte,  so this change makes the autocomplete use the correct `paasta` entry point.