### PR TITLE
Emit additional deployment metrics

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -15,6 +15,7 @@
 """Contains methods used by the paasta client to mark a docker image for
 deployment to a cluster.instance.
 """
+
 import argparse
 import asyncio
 import concurrent
@@ -28,6 +29,7 @@ import socket
 import sys
 import time
 import traceback
+from enum import Enum
 from threading import Thread
 from typing import Any
 from typing import Callable
@@ -94,6 +96,13 @@ from paasta_tools.utils import get_username
 from paasta_tools.utils import ldap_user_search
 from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
+
+
+class DeployOutcome(Enum):
+    SUCCESS = "success"
+    TIMEOUT = "timeout"
+    CANCELLED = "cancelled"
+
 
 DEFAULT_DEPLOYMENT_TIMEOUT = 3 * 3600  # seconds
 DEFAULT_WARN_PERCENT = 17  # ~30min for default timeout
@@ -685,14 +694,6 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         self.warn_pct = warn_pct
         self.mark_for_deployment_return_code = -1
         self.auto_certify_delay = auto_certify_delay
-        self.auto_abandon_delay = auto_abandon_delay
-        self.auto_rollback_delay = auto_rollback_delay
-        self.authors = authors
-        self.polling_interval = polling_interval
-        self.diagnosis_interval = diagnosis_interval
-        self.time_before_first_diagnosis = time_before_first_diagnosis
-        self.metrics_interface = metrics_interface
-        self.rollback_type: Optional[RollbackTypes] = None
         self.instance_configs_per_cluster: Dict[
             str, List[LongRunningServiceConfig]
         ] = get_instance_configs_for_service_in_deploy_group_all_clusters(
@@ -819,7 +820,7 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
 
     def schedule_paasta_status_reminder(self) -> None:
         def waiting_on_to_status(
-            waiting_on: Mapping[str, Collection[str]]
+            waiting_on: Mapping[str, Collection[str]],
         ) -> List[str]:
             if waiting_on is None:
                 return [
@@ -1147,7 +1148,7 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         if self.block:
             thread = Thread(
                 target=self.do_wait_for_deployment,
-                args=(self.commit, self.image_version, None),
+                args=(self.commit, self.image_version),
                 daemon=True,
             )
             thread.start()
@@ -1201,6 +1202,8 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         if self.block:
             thread = Thread(
                 target=self.do_wait_for_deployment,
+                # we pass in self.rollback_type to the thread instead of using self.rollback_type directly
+                # this avoids a race condition where self.rollback_type may change after the thread starts
                 args=(self.old_git_sha, self.old_image_version, self.rollback_type),
                 daemon=True,
             )
@@ -1871,7 +1874,7 @@ def _record_instance_duration(
     cluster: str,
     instance: str,
     elapsed: float,
-    outcome: str,
+    deploy_outcome: DeployOutcome,
     rollback_type: Optional[RollbackTypes] = None,
 ) -> None:
     if not metrics_interface:
@@ -1880,16 +1883,16 @@ def _record_instance_duration(
         cluster_info = kube_cluster.get(cluster, {})
         instance_timer = metrics_interface.create_timer(
             "instance_deploy_duration",
-            default_dimensions=dict(
-                paasta_service=service,
-                deploy_group=deploy_group,
-                paasta_cluster=cluster,
-                paasta_instance=instance,
-                superregion=cluster_info.get("superregion", "unknown"),
-                ecosystem=cluster_info.get("ecosystem", "unknown"),
-                outcome=outcome,
-                rollback_type=rollback_type.value if rollback_type else None,
-            ),
+            default_dimensions={
+                "paasta_service": service,
+                "deploy_group": deploy_group,
+                "paasta_cluster": cluster,
+                "paasta_instance": instance,
+                "superregion": cluster_info.get("superregion", "unknown"),
+                "ecosystem": cluster_info.get("ecosystem", "unknown"),
+                "deploy_outcome": deploy_outcome.value,
+                "rollback_type": rollback_type.value if rollback_type else "unknown",
+            },
         )
         instance_timer.record(elapsed)
     except Exception:
@@ -2015,7 +2018,7 @@ async def wait_for_deployment(
                         cluster,
                         instance,
                         elapsed,
-                        "success",
+                        DeployOutcome.SUCCESS,
                         rollback_type,
                     )
                     finished_instances += 1
@@ -2036,7 +2039,7 @@ async def wait_for_deployment(
                             cluster,
                             instance,
                             elapsed,
-                            "timeout",
+                            DeployOutcome.TIMEOUT,
                             rollback_type,
                         )
                 _log(
@@ -2064,7 +2067,7 @@ async def wait_for_deployment(
                             cluster,
                             instance,
                             elapsed,
-                            "cancelled",
+                            DeployOutcome.CANCELLED,
                             rollback_type,
                         )
                 # Wait for all the tasks to finish before closing out the ThreadPoolExecutor, to avoid RuntimeError('cannot schedule new futures after shutdown')

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -692,7 +692,7 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         self.diagnosis_interval = diagnosis_interval
         self.time_before_first_diagnosis = time_before_first_diagnosis
         self.metrics_interface = metrics_interface
-        self.deploy_reason = "deploy"
+        self.rollback_type: Optional[RollbackTypes] = None
         self.instance_configs_per_cluster: Dict[
             str, List[LongRunningServiceConfig]
         ] = get_instance_configs_for_service_in_deploy_group_all_clusters(
@@ -1147,7 +1147,7 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         if self.block:
             thread = Thread(
                 target=self.do_wait_for_deployment,
-                args=(self.commit, self.image_version, "deploy"),
+                args=(self.commit, self.image_version, None),
                 daemon=True,
             )
             thread.start()
@@ -1201,7 +1201,7 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         if self.block:
             thread = Thread(
                 target=self.do_wait_for_deployment,
-                args=(self.old_git_sha, self.old_image_version, self.deploy_reason),
+                args=(self.old_git_sha, self.old_image_version, self.rollback_type),
                 daemon=True,
             )
             thread.start()
@@ -1237,7 +1237,7 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         self,
         target_commit: str,
         target_image_version: Optional[str] = None,
-        reason: str = "deploy",
+        rollback_type: Optional[RollbackTypes] = None,
     ) -> None:
         try:
             target_version = DeploymentVersion(
@@ -1259,7 +1259,7 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
                     time_before_first_diagnosis=self.time_before_first_diagnosis,
                     notify_fn=self.ping_authors,
                     metrics_interface=self.metrics_interface,
-                    reason=reason,
+                    rollback_type=rollback_type,
                 )
             )
             self.wait_for_deployment_tasks[target_version] = wait_for_deployment_task
@@ -1433,21 +1433,21 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         }
 
     def log_slo_rollback(self) -> None:
-        self.deploy_reason = RollbackTypes.AUTOMATIC_SLO_ROLLBACK.value
+        self.rollback_type = RollbackTypes.AUTOMATIC_SLO_ROLLBACK
         rollback_details = self.__build_rollback_audit_details(
             RollbackTypes.AUTOMATIC_SLO_ROLLBACK
         )
         self._log_rollback(rollback_details)
 
     def log_metric_rollback(self) -> None:
-        self.deploy_reason = RollbackTypes.AUTOMATIC_METRIC_ROLLBACK.value
+        self.rollback_type = RollbackTypes.AUTOMATIC_METRIC_ROLLBACK
         rollback_details = self.__build_rollback_audit_details(
             RollbackTypes.AUTOMATIC_METRIC_ROLLBACK
         )
         self._log_rollback(rollback_details)
 
     def log_user_rollback(self) -> None:
-        self.deploy_reason = RollbackTypes.USER_INITIATED_ROLLBACK.value
+        self.rollback_type = RollbackTypes.USER_INITIATED_ROLLBACK
         rollback_details = self.__build_rollback_audit_details(
             RollbackTypes.USER_INITIATED_ROLLBACK
         )
@@ -1872,7 +1872,7 @@ def _record_instance_duration(
     instance: str,
     elapsed: float,
     outcome: str,
-    reason: str = "deploy",
+    rollback_type: Optional[RollbackTypes] = None,
 ) -> None:
     if not metrics_interface:
         return
@@ -1888,7 +1888,7 @@ def _record_instance_duration(
                 superregion=cluster_info.get("superregion", "unknown"),
                 ecosystem=cluster_info.get("ecosystem", "unknown"),
                 outcome=outcome,
-                reason=reason,
+                rollback_type=rollback_type.value if rollback_type else None,
             ),
         )
         instance_timer.record(elapsed)
@@ -1912,7 +1912,7 @@ async def wait_for_deployment(
     time_before_first_diagnosis: float = None,
     notify_fn: Optional[Callable[[str], None]] = None,
     metrics_interface: Optional[metrics_lib.BaseMetrics] = None,
-    reason: str = "deploy",
+    rollback_type: Optional[RollbackTypes] = None,
 ) -> Optional[int]:
     if not instance_configs_per_cluster:
         instance_configs_per_cluster = (
@@ -2016,7 +2016,7 @@ async def wait_for_deployment(
                         instance,
                         elapsed,
                         "success",
-                        reason,
+                        rollback_type,
                     )
                     finished_instances += 1
                     bar.update(finished_instances)
@@ -2037,7 +2037,7 @@ async def wait_for_deployment(
                             instance,
                             elapsed,
                             "timeout",
-                            reason,
+                            rollback_type,
                         )
                 _log(
                     service=service,
@@ -2065,7 +2065,7 @@ async def wait_for_deployment(
                             instance,
                             elapsed,
                             "cancelled",
-                            reason,
+                            rollback_type,
                         )
                 # Wait for all the tasks to finish before closing out the ThreadPoolExecutor, to avoid RuntimeError('cannot schedule new futures after shutdown')
                 for coro in instance_done_futures:

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -583,7 +583,13 @@ def paasta_mark_for_deployment(args: argparse.Namespace) -> int:
         ret = deploy_process.run()
         return ret
     finally:
-        deploy_timer.stop(tmp_dimensions={"exit_status": ret})
+        clusters = list(deploy_process.instance_configs_per_cluster.keys())
+        deploy_timer.stop(
+            tmp_dimensions={
+                "exit_status": ret,
+                "paasta_cluster": ",".join(clusters),
+            }
+        )
 
 
 class Progress:
@@ -1243,6 +1249,7 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
                     diagnosis_interval=self.diagnosis_interval,
                     time_before_first_diagnosis=self.time_before_first_diagnosis,
                     notify_fn=self.ping_authors,
+                    metrics_interface=self.metrics_interface,
                 )
             )
             self.wait_for_deployment_tasks[target_version] = wait_for_deployment_task
@@ -1444,6 +1451,13 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
                 name="rollback",
                 dimensions=dimensions,
             )
+        self.metrics_interface.create_counter(
+            "rollback_count",
+            default_dimensions=dict(
+                paasta_service=self.service,
+                deploy_group=self.deploy_group,
+            ),
+        ).count()
         _log_audit(
             action="rollback",
             action_details=rollback_details,
@@ -1850,6 +1864,7 @@ async def wait_for_deployment(
     diagnosis_interval: float = None,
     time_before_first_diagnosis: float = None,
     notify_fn: Optional[Callable[[str], None]] = None,
+    metrics_interface: Optional[metrics_lib.BaseMetrics] = None,
 ) -> Optional[int]:
     if not instance_configs_per_cluster:
         instance_configs_per_cluster = (
@@ -1893,6 +1908,9 @@ async def wait_for_deployment(
         time_before_first_diagnosis = (
             system_paasta_config.get_mark_for_deployment_default_time_before_first_diagnosis()
         )
+
+    kube_clusters = system_paasta_config.get_kube_clusters()
+    start_time = time.time()
 
     with progressbar.ProgressBar(max_value=total_instances) as bar:
         instance_done_futures = []
@@ -1940,6 +1958,21 @@ async def wait_for_deployment(
                     instance_done_futures, timeout=timeout
                 ):
                     cluster, instance = await coro
+                    if metrics_interface:
+                        elapsed = time.time() - start_time
+                        cluster_info = kube_clusters.get(cluster, {})
+                        instance_timer = metrics_interface.create_timer(
+                            "instance_deploy_duration",
+                            default_dimensions=dict(
+                                paasta_service=service,
+                                deploy_group=deploy_group,
+                                paasta_cluster=cluster,
+                                paasta_instance=instance,
+                                superregion=cluster_info.get("superregion", "unknown"),
+                                ecosystem=cluster_info.get("ecosystem", "unknown"),
+                            ),
+                        )
+                        instance_timer.record(elapsed)
                     finished_instances += 1
                     bar.update(finished_instances)
                     if progress is not None:

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -545,7 +545,14 @@ def paasta_mark_for_deployment(args: argparse.Namespace) -> int:
             old_version=str(old_deployment_version),
             new_version=str(deployment_version),
             deploy_timeout=args.timeout,
-            wait_for_deployment=args.block,  # always True
+            wait_for_deployment=args.block,
+            # atm, we'll only ever actually emit this with a
+            # value of True, but this might change in the
+            # future as we update how paasta handles
+            # "redeploying" to an unhealthy deploy group
+            # with --wait-for-deployment
+            # (or even just to start getting metrics for the
+            # non-wait-for-deployment case :p)
         ),
     )
 
@@ -685,6 +692,7 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         self.diagnosis_interval = diagnosis_interval
         self.time_before_first_diagnosis = time_before_first_diagnosis
         self.metrics_interface = metrics_interface
+        self.deploy_reason = "deploy"
         self.instance_configs_per_cluster: Dict[
             str, List[LongRunningServiceConfig]
         ] = get_instance_configs_for_service_in_deploy_group_all_clusters(
@@ -1139,7 +1147,7 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         if self.block:
             thread = Thread(
                 target=self.do_wait_for_deployment,
-                args=(self.commit, self.image_version),
+                args=(self.commit, self.image_version, "deploy"),
                 daemon=True,
             )
             thread.start()
@@ -1193,7 +1201,7 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         if self.block:
             thread = Thread(
                 target=self.do_wait_for_deployment,
-                args=(self.old_git_sha, self.old_image_version),
+                args=(self.old_git_sha, self.old_image_version, self.deploy_reason),
                 daemon=True,
             )
             thread.start()
@@ -1226,7 +1234,10 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
 
     @to_blocking
     async def do_wait_for_deployment(
-        self, target_commit: str, target_image_version: Optional[str] = None
+        self,
+        target_commit: str,
+        target_image_version: Optional[str] = None,
+        reason: str = "deploy",
     ) -> None:
         try:
             target_version = DeploymentVersion(
@@ -1248,6 +1259,7 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
                     time_before_first_diagnosis=self.time_before_first_diagnosis,
                     notify_fn=self.ping_authors,
                     metrics_interface=self.metrics_interface,
+                    reason=reason,
                 )
             )
             self.wait_for_deployment_tasks[target_version] = wait_for_deployment_task
@@ -1421,18 +1433,21 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         }
 
     def log_slo_rollback(self) -> None:
+        self.deploy_reason = RollbackTypes.AUTOMATIC_SLO_ROLLBACK.value
         rollback_details = self.__build_rollback_audit_details(
             RollbackTypes.AUTOMATIC_SLO_ROLLBACK
         )
         self._log_rollback(rollback_details)
 
     def log_metric_rollback(self) -> None:
+        self.deploy_reason = RollbackTypes.AUTOMATIC_METRIC_ROLLBACK.value
         rollback_details = self.__build_rollback_audit_details(
             RollbackTypes.AUTOMATIC_METRIC_ROLLBACK
         )
         self._log_rollback(rollback_details)
 
     def log_user_rollback(self) -> None:
+        self.deploy_reason = RollbackTypes.USER_INITIATED_ROLLBACK.value
         rollback_details = self.__build_rollback_audit_details(
             RollbackTypes.USER_INITIATED_ROLLBACK
         )
@@ -1454,6 +1469,7 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
             default_dimensions=dict(
                 paasta_service=self.service,
                 deploy_group=self.deploy_group,
+                rollback_type=rollback_details.get("rollback_type", "unknown"),
             ),
         ).count()
         _log_audit(
@@ -1847,6 +1863,39 @@ def get_instance_configs_for_service_in_deploy_group_all_clusters(
     return instance_configs_per_cluster
 
 
+def _record_instance_duration(
+    metrics_interface: Optional[metrics_lib.BaseMetrics],
+    kube_cluster: Dict[str, Any],
+    service: str,
+    deploy_group: str,
+    cluster: str,
+    instance: str,
+    elapsed: float,
+    outcome: str,
+    reason: str = "deploy",
+) -> None:
+    if not metrics_interface:
+        return
+    try:
+        cluster_info = kube_cluster.get(cluster, {})
+        instance_timer = metrics_interface.create_timer(
+            "instance_deploy_duration",
+            default_dimensions=dict(
+                paasta_service=service,
+                deploy_group=deploy_group,
+                paasta_cluster=cluster,
+                paasta_instance=instance,
+                superregion=cluster_info.get("superregion", "unknown"),
+                ecosystem=cluster_info.get("ecosystem", "unknown"),
+                outcome=outcome,
+                reason=reason,
+            ),
+        )
+        instance_timer.record(elapsed)
+    except Exception:
+        log.warning("Failed to record instance deploy duration metrics", exc_info=True)
+
+
 async def wait_for_deployment(
     service: str,
     deploy_group: str,
@@ -1863,6 +1912,7 @@ async def wait_for_deployment(
     time_before_first_diagnosis: float = None,
     notify_fn: Optional[Callable[[str], None]] = None,
     metrics_interface: Optional[metrics_lib.BaseMetrics] = None,
+    reason: str = "deploy",
 ) -> Optional[int]:
     if not instance_configs_per_cluster:
         instance_configs_per_cluster = (
@@ -1910,30 +1960,6 @@ async def wait_for_deployment(
     kube_clusters = system_paasta_config.get_kube_clusters()
     start_time = time.time()
 
-    def record_instance_duration(cluster: str, instance: str, outcome: str) -> None:
-        if not metrics_interface:
-            return
-        try:
-            elapsed = time.time() - start_time
-            cluster_info = kube_clusters.get(cluster, {})
-            instance_timer = metrics_interface.create_timer(
-                "instance_deploy_duration",
-                default_dimensions=dict(
-                    paasta_service=service,
-                    deploy_group=deploy_group,
-                    paasta_cluster=cluster,
-                    paasta_instance=instance,
-                    superregion=cluster_info.get("superregion", "unknown"),
-                    ecosystem=cluster_info.get("ecosystem", "unknown"),
-                    outcome=outcome,
-                ),
-            )
-            instance_timer.record(elapsed)
-        except Exception:
-            log.warning(
-                "Failed to record instance deploy duration metrics", exc_info=True
-            )
-
     with progressbar.ProgressBar(max_value=total_instances) as bar:
         instance_done_futures = []
         with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -1980,7 +2006,18 @@ async def wait_for_deployment(
                     instance_done_futures, timeout=timeout
                 ):
                     cluster, instance = await coro
-                    record_instance_duration(cluster, instance, "success")
+                    elapsed = time.time() - start_time
+                    _record_instance_duration(
+                        metrics_interface,
+                        kube_clusters,
+                        service,
+                        deploy_group,
+                        cluster,
+                        instance,
+                        elapsed,
+                        "success",
+                        reason,
+                    )
                     finished_instances += 1
                     bar.update(finished_instances)
                     if progress is not None:
@@ -1988,9 +2025,20 @@ async def wait_for_deployment(
                         remaining_instances[cluster].remove(instance)
                         progress.waiting_on = remaining_instances
             except asyncio.TimeoutError:
+                elapsed = time.time() - start_time
                 for cluster, instances in remaining_instances.items():
                     for instance in instances:
-                        record_instance_duration(cluster, instance, "timeout")
+                        _record_instance_duration(
+                            metrics_interface,
+                            kube_clusters,
+                            service,
+                            deploy_group,
+                            cluster,
+                            instance,
+                            elapsed,
+                            "timeout",
+                            reason,
+                        )
                 _log(
                     service=service,
                     component="deploy",
@@ -2005,9 +2053,20 @@ async def wait_for_deployment(
                 )
                 raise TimeoutError
             except asyncio.CancelledError:
+                elapsed = time.time() - start_time
                 for cluster, instances in remaining_instances.items():
                     for instance in instances:
-                        record_instance_duration(cluster, instance, "cancelled")
+                        _record_instance_duration(
+                            metrics_interface,
+                            kube_clusters,
+                            service,
+                            deploy_group,
+                            cluster,
+                            instance,
+                            elapsed,
+                            "cancelled",
+                            reason,
+                        )
                 # Wait for all the tasks to finish before closing out the ThreadPoolExecutor, to avoid RuntimeError('cannot schedule new futures after shutdown')
                 for coro in instance_done_futures:
                     coro.cancel()

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -694,6 +694,14 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         self.warn_pct = warn_pct
         self.mark_for_deployment_return_code = -1
         self.auto_certify_delay = auto_certify_delay
+        self.auto_abandon_delay = auto_abandon_delay
+        self.auto_rollback_delay = auto_rollback_delay
+        self.authors = authors
+        self.polling_interval = polling_interval
+        self.diagnosis_interval = diagnosis_interval
+        self.time_before_first_diagnosis = time_before_first_diagnosis
+        self.metrics_interface = metrics_interface
+        self.rollback_type: Optional[RollbackTypes] = None
         self.instance_configs_per_cluster: Dict[
             str, List[LongRunningServiceConfig]
         ] = get_instance_configs_for_service_in_deploy_group_all_clusters(

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -583,11 +583,9 @@ def paasta_mark_for_deployment(args: argparse.Namespace) -> int:
         ret = deploy_process.run()
         return ret
     finally:
-        clusters = list(deploy_process.instance_configs_per_cluster.keys())
         deploy_timer.stop(
             tmp_dimensions={
                 "exit_status": ret,
-                "paasta_cluster": ",".join(clusters),
             }
         )
 
@@ -1912,6 +1910,30 @@ async def wait_for_deployment(
     kube_clusters = system_paasta_config.get_kube_clusters()
     start_time = time.time()
 
+    def record_instance_duration(cluster: str, instance: str, outcome: str) -> None:
+        if not metrics_interface:
+            return
+        try:
+            elapsed = time.time() - start_time
+            cluster_info = kube_clusters.get(cluster, {})
+            instance_timer = metrics_interface.create_timer(
+                "instance_deploy_duration",
+                default_dimensions=dict(
+                    paasta_service=service,
+                    deploy_group=deploy_group,
+                    paasta_cluster=cluster,
+                    paasta_instance=instance,
+                    superregion=cluster_info.get("superregion", "unknown"),
+                    ecosystem=cluster_info.get("ecosystem", "unknown"),
+                    outcome=outcome,
+                ),
+            )
+            instance_timer.record(elapsed)
+        except Exception:
+            log.warning(
+                "Failed to record instance deploy duration metrics", exc_info=True
+            )
+
     with progressbar.ProgressBar(max_value=total_instances) as bar:
         instance_done_futures = []
         with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as executor:
@@ -1958,21 +1980,7 @@ async def wait_for_deployment(
                     instance_done_futures, timeout=timeout
                 ):
                     cluster, instance = await coro
-                    if metrics_interface:
-                        elapsed = time.time() - start_time
-                        cluster_info = kube_clusters.get(cluster, {})
-                        instance_timer = metrics_interface.create_timer(
-                            "instance_deploy_duration",
-                            default_dimensions=dict(
-                                paasta_service=service,
-                                deploy_group=deploy_group,
-                                paasta_cluster=cluster,
-                                paasta_instance=instance,
-                                superregion=cluster_info.get("superregion", "unknown"),
-                                ecosystem=cluster_info.get("ecosystem", "unknown"),
-                            ),
-                        )
-                        instance_timer.record(elapsed)
+                    record_instance_duration(cluster, instance, "success")
                     finished_instances += 1
                     bar.update(finished_instances)
                     if progress is not None:
@@ -1980,6 +1988,9 @@ async def wait_for_deployment(
                         remaining_instances[cluster].remove(instance)
                         progress.waiting_on = remaining_instances
             except asyncio.TimeoutError:
+                for cluster, instances in remaining_instances.items():
+                    for instance in instances:
+                        record_instance_duration(cluster, instance, "timeout")
                 _log(
                     service=service,
                     component="deploy",
@@ -1994,6 +2005,9 @@ async def wait_for_deployment(
                 )
                 raise TimeoutError
             except asyncio.CancelledError:
+                for cluster, instances in remaining_instances.items():
+                    for instance in instances:
+                        record_instance_duration(cluster, instance, "cancelled")
                 # Wait for all the tasks to finish before closing out the ThreadPoolExecutor, to avoid RuntimeError('cannot schedule new futures after shutdown')
                 for coro in instance_done_futures:
                     coro.cancel()

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -545,7 +545,6 @@ def paasta_mark_for_deployment(args: argparse.Namespace) -> int:
             old_version=str(old_deployment_version),
             new_version=str(deployment_version),
             deploy_timeout=args.timeout,
-            wait_for_deployment=args.block,
             # atm, we'll only ever actually emit this with a
             # value of True, but this might change in the
             # future as we update how paasta handles
@@ -553,6 +552,7 @@ def paasta_mark_for_deployment(args: argparse.Namespace) -> int:
             # with --wait-for-deployment
             # (or even just to start getting metrics for the
             # non-wait-for-deployment case :p)
+            wait_for_deployment=args.block,
         ),
     )
 
@@ -1466,11 +1466,11 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
             )
         self.metrics_interface.create_counter(
             "rollback_count",
-            default_dimensions=dict(
-                paasta_service=self.service,
-                deploy_group=self.deploy_group,
-                rollback_type=rollback_details.get("rollback_type", "unknown"),
-            ),
+            default_dimensions={
+                "paasta_service": self.service,
+                "deploy_group": self.deploy_group,
+                "rollback_type": rollback_details.get("rollback_type", "unknown"),
+            },
         ).count()
         _log_audit(
             action="rollback",

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -545,6 +545,7 @@ def paasta_mark_for_deployment(args: argparse.Namespace) -> int:
             old_version=str(old_deployment_version),
             new_version=str(deployment_version),
             deploy_timeout=args.timeout,
+            wait_for_deployment=args.block,  # always True
         ),
     )
 

--- a/paasta_tools/cli/cmds/rollback.py
+++ b/paasta_tools/cli/cmds/rollback.py
@@ -31,6 +31,7 @@ from paasta_tools.cli.utils import list_deploy_groups
 from paasta_tools.cli.utils import validate_full_git_sha
 from paasta_tools.cli.utils import validate_given_deploy_groups
 from paasta_tools.deployment_utils import get_currently_deployed_version
+from paasta_tools.metrics import metrics_lib
 from paasta_tools.remote_git import create_rollback_tag
 from paasta_tools.remote_git import list_remote_refs
 from paasta_tools.utils import DEFAULT_SOA_DIR
@@ -334,6 +335,15 @@ def paasta_rollback(args: argparse.Namespace) -> int:
         # rollback than we care about if the underlying machinery was successfully able to complete the request
         if rolled_back_from != new_version:
             performed_rollback = True
+            metrics = metrics_lib.get_metrics_interface("paasta.mark_for_deployment")
+            metrics.create_counter(
+                "rollback_count",
+                default_dimensions=dict(
+                    paasta_service=service,
+                    deploy_group=deploy_group,
+                    rollback_type="cli_rollback",
+                ),
+            ).count()
             audit_action_details = {
                 "rolled_back_from": str(rolled_back_from),
                 "rolled_back_to": str(new_version),

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -236,7 +236,9 @@ def test_paasta_mark_for_deployment_with_good_rollback(
     mock_get_instance_configs.return_value = {"fake_cluster": [], "fake_cluster2": []}
     mock_mark_for_deployment.return_value = 0
 
-    def do_wait_for_deployment_side_effect(self, target_commit, target_image_version):
+    def do_wait_for_deployment_side_effect(
+        self, target_commit, target_image_version, reason="deploy"
+    ):
         if (
             target_commit == FakeArgs.commit
             and target_image_version == FakeArgs.image_version
@@ -278,9 +280,11 @@ def test_paasta_mark_for_deployment_with_good_rollback(
     assert mock_mark_for_deployment.call_count == 2
 
     mock_do_wait_for_deployment.assert_any_call(
-        mock.ANY, "d670460b4b4aece5915caf5c68d12f560a9fe3e4", "extrastuff"
+        mock.ANY, "d670460b4b4aece5915caf5c68d12f560a9fe3e4", "extrastuff", "deploy"
     )
-    mock_do_wait_for_deployment.assert_any_call(mock.ANY, "old-sha", None)
+    mock_do_wait_for_deployment.assert_any_call(
+        mock.ANY, "old-sha", None, "user_initiated_rollback"
+    )
     assert mock_do_wait_for_deployment.call_count == 2
     # in normal usage, this would also be called once per m-f-d, but we mock that out above
     # so _log_audit is only called as part of handling the rollback

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -313,7 +313,6 @@ def test_paasta_mark_for_deployment_with_good_rollback(
     mock_timer.stop.assert_called_once_with(
         tmp_dimensions=dict(
             exit_status=1,
-            paasta_cluster="fake_cluster,fake_cluster2",
         )
     )
     mock_emit_event = mock_get_metrics.return_value.emit_event

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -281,7 +281,7 @@ def test_paasta_mark_for_deployment_with_good_rollback(
     assert mock_mark_for_deployment.call_count == 2
 
     mock_do_wait_for_deployment.assert_any_call(
-        mock.ANY, "d670460b4b4aece5915caf5c68d12f560a9fe3e4", "extrastuff", None
+        mock.ANY, "d670460b4b4aece5915caf5c68d12f560a9fe3e4", "extrastuff"
     )
     mock_do_wait_for_deployment.assert_any_call(
         mock.ANY, "old-sha", None, RollbackTypes.USER_INITIATED_ROLLBACK

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -305,11 +305,17 @@ def test_paasta_mark_for_deployment_with_good_rollback(
             old_version="old-sha",
             new_version="DeploymentVersion(sha=d670460b4b4aece5915caf5c68d12f560a9fe3e4, image_version=extrastuff)",
             deploy_timeout=600,
+            wait_for_deployment=True,
         ),
     )
     mock_timer = mock_get_metrics.return_value.create_timer.return_value
     mock_timer.start.assert_called_once_with()
-    mock_timer.stop.assert_called_once_with(tmp_dimensions=dict(exit_status=1))
+    mock_timer.stop.assert_called_once_with(
+        tmp_dimensions=dict(
+            exit_status=1,
+            paasta_cluster="fake_cluster,fake_cluster2",
+        )
+    )
     mock_emit_event = mock_get_metrics.return_value.emit_event
     event_dimensions = dict(
         paasta_service="test_service",

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -27,6 +27,7 @@ from slackclient import SlackClient
 
 from paasta_tools.cli.cmds import mark_for_deployment
 from paasta_tools.utils import DeploymentVersion
+from paasta_tools.utils import RollbackTypes
 from paasta_tools.utils import TimeoutError
 
 
@@ -237,7 +238,7 @@ def test_paasta_mark_for_deployment_with_good_rollback(
     mock_mark_for_deployment.return_value = 0
 
     def do_wait_for_deployment_side_effect(
-        self, target_commit, target_image_version, reason="deploy"
+        self, target_commit, target_image_version, rollback_type=None
     ):
         if (
             target_commit == FakeArgs.commit
@@ -280,10 +281,10 @@ def test_paasta_mark_for_deployment_with_good_rollback(
     assert mock_mark_for_deployment.call_count == 2
 
     mock_do_wait_for_deployment.assert_any_call(
-        mock.ANY, "d670460b4b4aece5915caf5c68d12f560a9fe3e4", "extrastuff", "deploy"
+        mock.ANY, "d670460b4b4aece5915caf5c68d12f560a9fe3e4", "extrastuff", None
     )
     mock_do_wait_for_deployment.assert_any_call(
-        mock.ANY, "old-sha", None, "user_initiated_rollback"
+        mock.ANY, "old-sha", None, RollbackTypes.USER_INITIATED_ROLLBACK
     )
     assert mock_do_wait_for_deployment.call_count == 2
     # in normal usage, this would also be called once per m-f-d, but we mock that out above

--- a/tests/cli/test_cmds_rollback.py
+++ b/tests/cli/test_cmds_rollback.py
@@ -847,6 +847,7 @@ def test_create_rollback_tag_called_after_rollback():
     ) as mock_create_rollback_tag, patch(
         "paasta_tools.cli.cmds.rollback.metrics_lib.get_metrics_interface",
         autospec=True,
+    ), patch(
         "paasta_tools.cli.cmds.rollback.notify_rollback_slack", autospec=True
     ):
         assert paasta_rollback(fake_args) == 0

--- a/tests/cli/test_cmds_rollback.py
+++ b/tests/cli/test_cmds_rollback.py
@@ -26,6 +26,9 @@ from paasta_tools.utils import DeploymentVersion
 from paasta_tools.utils import RollbackTypes
 
 
+@patch(
+    "paasta_tools.cli.cmds.rollback.metrics_lib.get_metrics_interface", autospec=True
+)
 @patch("paasta_tools.cli.cmds.rollback.create_rollback_tag", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_version", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback._log_audit", autospec=True)
@@ -45,6 +48,7 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
     mock_log_audit,
     mock_get_currently_deployed_version,
     mock_create_rollback_tag,
+    mock_get_metrics_interface,
 ):
     fake_args, _ = parse_args(
         ["rollback", "-s", "fakeservice", "-k", "abcd" * 10, "-l", "fake_deploy_group1"]
@@ -96,6 +100,9 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
         assert call_kwargs["service"] == fake_args.service
 
 
+@patch(
+    "paasta_tools.cli.cmds.rollback.metrics_lib.get_metrics_interface", autospec=True
+)
 @patch("paasta_tools.cli.cmds.rollback.create_rollback_tag", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_version", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback._log_audit", autospec=True)
@@ -115,6 +122,7 @@ def test_paasta_rollback_mark_for_deployment_with_image(
     mock_log_audit,
     mock_get_currently_deployed_version,
     mock_create_rollback_tag,
+    mock_get_metrics_interface,
 ):
     fake_args, _ = parse_args(
         [
@@ -182,6 +190,9 @@ def test_paasta_rollback_mark_for_deployment_with_image(
         assert call_kwargs["service"] == fake_args.service
 
 
+@patch(
+    "paasta_tools.cli.cmds.rollback.metrics_lib.get_metrics_interface", autospec=True
+)
 @patch("paasta_tools.cli.cmds.rollback.create_rollback_tag", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_version", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback._log_audit", autospec=True)
@@ -201,6 +212,7 @@ def test_paasta_rollback_with_force(
     mock_log_audit,
     mock_get_currently_deployed_version,
     mock_create_rollback_tag,
+    mock_get_metrics_interface,
 ):
     fake_args, _ = parse_args(
         [
@@ -325,6 +337,9 @@ def test_paasta_rollback_mark_for_deployment_no_deploy_group_arg(
         assert call_kwargs["service"] == fake_args.service
 
 
+@patch(
+    "paasta_tools.cli.cmds.rollback.metrics_lib.get_metrics_interface", autospec=True
+)
 @patch("paasta_tools.cli.cmds.rollback.create_rollback_tag", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_version", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback._log_audit", autospec=True)
@@ -344,6 +359,7 @@ def test_paasta_rollback_mark_for_deployment_all_deploy_groups_arg(
     mock_log_audit,
     mock_get_currently_deployed_version,
     mock_create_rollback_tag,
+    mock_get_metrics_interface,
 ):
     fake_args, _ = parse_args(
         ["rollback", "-s", "fakeservice", "-k", "abcd" * 10, "-a"]
@@ -484,6 +500,9 @@ def test_paasta_rollback_git_sha_was_not_marked_before(
     assert not mock_log_audit.called
 
 
+@patch(
+    "paasta_tools.cli.cmds.rollback.metrics_lib.get_metrics_interface", autospec=True
+)
 @patch("paasta_tools.cli.cmds.rollback.create_rollback_tag", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback.get_currently_deployed_version", autospec=True)
 @patch("paasta_tools.cli.cmds.rollback._log_audit", autospec=True)
@@ -503,6 +522,7 @@ def test_paasta_rollback_mark_for_deployment_multiple_deploy_group_args(
     mock_log_audit,
     mock_get_currently_deployed_version,
     mock_create_rollback_tag,
+    mock_get_metrics_interface,
 ):
     fake_args, _ = parse_args(
         [
@@ -800,7 +820,10 @@ def test_create_rollback_tag_called_after_rollback():
         return_value=old_version,
     ), patch(
         "paasta_tools.cli.cmds.rollback.create_rollback_tag", autospec=True
-    ) as mock_create_rollback_tag:
+    ) as mock_create_rollback_tag, patch(
+        "paasta_tools.cli.cmds.rollback.metrics_lib.get_metrics_interface",
+        autospec=True,
+    ):
         assert paasta_rollback(fake_args) == 0
 
         mock_create_rollback_tag.assert_called_once_with(

--- a/tests/cli/test_cmds_rollback.py
+++ b/tests/cli/test_cmds_rollback.py
@@ -49,8 +49,8 @@ def test_paasta_rollback_mark_for_deployment_simple_invocation(
     mock_log_audit,
     mock_get_currently_deployed_version,
     mock_create_rollback_tag,
-    mock_get_metrics_interface,
     mock_notify_rollback_slack,
+    mock_get_metrics_interface,
 ):
     fake_args, _ = parse_args(
         ["rollback", "-s", "fakeservice", "-k", "abcd" * 10, "-l", "fake_deploy_group1"]


### PR DESCRIPTION
- [x] How long does it take to rollback? 
- [x] How many times did rollback happen?
- [x] Add reason (rollout, rollback, automatic and etc..) label to `paasta_mark_for_deployment_deploy_duration` 
- [x] add wait_for_deployment (true, false) to `paasta_mark_for_deployment_deploy_duration` metric. 
- [x] add "paasta_instance" label to the metrics.  current one only knows about service and deploy_group.
- [x] add yelpy labels to metrics (ecosystem, runtimeenv, superregion, paasta_cluster and etc)


[Example of instance metrics](https://grafana.yelpcorp.com/explore?schemaVersion=1&panes=%7B%22qp5%22:%7B%22datasource%22:%22P627274A7C77417EA%22,%22queries%22:%5B%7B%22refId%22:%22B%22,%22expr%22:%22sum%20by%28paasta_instance,%20paasta_cluster,%20deploy_group,%20paasta_service,%20outcome,%20superregion,%20ecosystem%29%20%28paasta_mark_for_deployment_instance_deploy_duration%29%22,%22range%22:true,%22instant%22:true,%22datasource%22:%7B%22type%22:%22prometheus%22,%22uid%22:%22P627274A7C77417EA%22%7D,%22editorMode%22:%22builder%22,%22legendFormat%22:%22__auto%22,%22useBackend%22:false,%22disableTextWrap%22:false,%22fullMetaSearch%22:false,%22includeNullMetadata%22:false,%22exemplar%22:false%7D%5D,%22range%22:%7B%22from%22:%22now-1h%22,%22to%22:%22now%22%7D%7D%7D&orgId=1)