### PR TITLE
Fix flaky Flink status tests by mocking get_pod_uptime

### DIFF
--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -2841,8 +2841,14 @@ class TestPrintFlinkStatus:
     @mock.patch("paasta_tools.cli.cmds.status.get_paasta_oapi_client", autospec=True)
     @patch("paasta_tools.cli.cmds.status.humanize.naturaltime", autospec=True)
     @patch("paasta_tools.cli.cmds.status.load_flink_instance_config", autospec=True)
+    @patch(
+        "paasta_tools.cli.cmds.status.get_pod_uptime",
+        autospec=True,
+        return_value="0d0h0m0s",
+    )
     def test_output_stopping_jobmanager(
         self,
+        mock_get_pod_uptime,
         mock_load_flink_instance_config,
         mock_naturaltime,
         mock_get_paasta_oapi_client,
@@ -2891,8 +2897,14 @@ class TestPrintFlinkStatus:
     @mock.patch("paasta_tools.cli.cmds.status.get_paasta_oapi_client", autospec=True)
     @patch("paasta_tools.cli.cmds.status.humanize.naturaltime", autospec=True)
     @patch("paasta_tools.cli.cmds.status.load_flink_instance_config", autospec=True)
+    @patch(
+        "paasta_tools.cli.cmds.status.get_pod_uptime",
+        autospec=True,
+        return_value="0d0h0m0s",
+    )
     def test_output_stopping_taskmanagers(
         self,
+        mock_get_pod_uptime,
         mock_load_flink_instance_config,
         mock_naturaltime,
         mock_get_paasta_oapi_client,
@@ -2944,8 +2956,14 @@ class TestPrintFlinkStatus:
     @patch("paasta_tools.cli.cmds.status.load_flink_instance_config", autospec=True)
     @patch("paasta_tools.cli.cmds.status.humanize.naturaltime", autospec=True)
     @patch("paasta_tools.cli.cmds.status.load_system_paasta_config", autospec=True)
+    @patch(
+        "paasta_tools.cli.cmds.status.get_pod_uptime",
+        autospec=True,
+        return_value="0d0h0m0s",
+    )
     def test_output_1_verbose(
         self,
+        mock_get_pod_uptime,
         mock_load_system_paasta_config,
         mock_naturaltime,
         mock_load_flink_instance_config,


### PR DESCRIPTION
## Summary

- Fixes flaky `TestPrintFlinkStatus` tests (`test_output_stopping_jobmanager`, `test_output_stopping_taskmanagers`, `test_output_1_verbose`) that intermittently fail due to time-sensitive uptime string comparison
- Root cause: both the actual call and expected-output construction call `get_pod_uptime(datetime.now())` at slightly different times, causing mismatched uptime strings when a second boundary is crossed
- Fix: mock `get_pod_uptime` to return a deterministic value, eliminating the race condition

## Test plan

- [x] All 13 `TestPrintFlinkStatus` tests pass locally
- [x] Pre-commit checks pass (black, flake8, isort, autospec enforcement)

Slack Thread: https://yelp.slack.com/archives/C0787CMMS1L/p1778681194857489?thread_ts=1778681190.961459&cid=C0787CMMS1L