### PR TITLE
Add timeout_threshold_ratio to smartstack endpoint schema

### DIFF
--- a/paasta_tools/cli/schemas/smartstack_schema.json
+++ b/paasta_tools/cli/schemas/smartstack_schema.json
@@ -315,6 +315,11 @@
                                     "type": "number",
                                     "minimum": 0
                                 },
+                                "timeout_threshold_ratio": {
+                                    "type": "number",
+                                    "minimum": 0,
+                                    "maximum": 1
+                                },
                                 "team": {
                                     "type": "string"
                                 },


### PR DESCRIPTION
## Summary
- Adds `timeout_threshold_ratio` (number, 0-1) to `monitoring.endpoints[]` items in the smartstack schema
- Allows per-endpoint override of the namespace-level `timeout_threshold_ratio`
- Used by per-endpoint timeout alerting to compute individual thresholds based on `endpoint_timeouts` values

## Context
Part of per-endpoint timeout alerting (PEREL-5334). This is an additive schema change with no behavior change - the new field takes effect once the yelpsoa-configs mirror reads it.

## Test plan
- [ ] Verify schema validation passes for configs with and without the new field
- [ ] Confirm existing smartstack configs remain valid