### PR TITLE
STREAMHAUS-1242 Validate Flink job monitoring team in paasta validate

### DIFF
--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -1144,7 +1144,7 @@ def _check_proxy_port_in_use(service: str, namespace: str, port: int) -> bool:
 
 
 def _check_advertise_discover(
-    smartstack_data: dict[str, Any]
+    smartstack_data: dict[str, Any],
 ) -> None:  # XXX: we should use a TypedDict here
     """Need to ensure a few properties about smartstack files
     1) discover is a member of advertise

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -71,6 +71,7 @@ from paasta_tools.long_running_service_tools import METRICS_PROVIDER_UWSGI
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_UWSGI_V2
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_WORKER_LOAD
 from paasta_tools.long_running_service_tools import LongRunningServiceConfig
+from paasta_tools.monitoring_tools import get_sensu_team_data
 from paasta_tools.secret_tools import get_secret_name_from_ref
 from paasta_tools.secret_tools import is_secret_ref
 from paasta_tools.secret_tools import is_shared_secret
@@ -1272,6 +1273,95 @@ def validate_smartstack(service_path: str) -> bool:
     return True
 
 
+def validate_flink_monitoring_team(service_path: str) -> bool:
+    """Check that every Flink job's monitoring.team is a valid Sensu team.
+
+    Reads all flink-*.yaml and flinkeks-*.yaml files in service_path and
+    validates the team field inside each job's monitoring block.
+
+    :param service_path: path to location of configuration files
+    """
+    flink_files = glob(os.path.join(service_path, "flink-*.yaml")) + glob(
+        os.path.join(service_path, "flinkeks-*.yaml")
+    )
+    if not flink_files:
+        return True
+
+    returncode = True
+    for file_path in flink_files:
+        filename = os.path.relpath(file_path, start=os.path.dirname(service_path))
+        try:
+            with open(file_path) as f:
+                config = yaml.safe_load(f)
+        except Exception:
+            continue
+
+        if not isinstance(config, dict):
+            continue
+
+        for instance_name, instance_config in config.items():
+            if not isinstance(instance_config, dict):
+                continue
+
+            jobs = instance_config.get("jobs")
+            if not isinstance(jobs, dict):
+                continue
+
+            for job_name, job_config in jobs.items():
+                if not isinstance(job_config, dict):
+                    continue
+
+                monitoring_raw = job_config.get("monitoring")
+                if monitoring_raw is None:
+                    print(
+                        failure(
+                            f"Missing 'monitoring' block in {filename} "
+                            f"at {instance_name}.jobs.{job_name}",
+                            "",
+                        )
+                    )
+                    returncode = False
+                    continue
+
+                if isinstance(monitoring_raw, str):
+                    try:
+                        monitoring = yaml.safe_load(monitoring_raw)
+                    except Exception:
+                        continue
+                elif isinstance(monitoring_raw, dict):
+                    monitoring = monitoring_raw
+                else:
+                    continue
+
+                if not isinstance(monitoring, dict):
+                    continue
+
+                team = monitoring.get("team")
+                if team is None:
+                    print(
+                        failure(
+                            f"Missing 'team' in {filename} "
+                            f"at {instance_name}.jobs.{job_name}.monitoring",
+                            "",
+                        )
+                    )
+                    returncode = False
+                elif not get_sensu_team_data(team):
+                    print(
+                        failure(
+                            f"Invalid monitoring team '{team}' in {filename} "
+                            f"at {instance_name}.jobs.{job_name}.monitoring.team "
+                            f"— not a valid Sensu team",
+                            "",
+                        )
+                    )
+                    returncode = False
+
+    if returncode:
+        print(success("All Flink job monitoring teams are valid"))
+    return returncode
+
+
 def paasta_validate_soa_configs(
     service: str, service_path: str, verbose: bool = False
 ) -> bool:
@@ -1295,6 +1385,7 @@ def paasta_validate_soa_configs(
         validate_min_max_instances,
         validate_cpu_burst,
         validate_smartstack,
+        validate_flink_monitoring_team,
     ]
 
     # NOTE: we're explicitly passing a list comprehension to all()

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -46,6 +46,7 @@ from paasta_tools.cli.cmds.validate import validate_paasta_objects
 from paasta_tools.cli.cmds.validate import validate_rollback_bounds
 from paasta_tools.cli.cmds.validate import validate_schema
 from paasta_tools.cli.cmds.validate import validate_secrets
+from paasta_tools.cli.cmds.validate import validate_flink_monitoring_team
 from paasta_tools.cli.cmds.validate import validate_smartstack
 from paasta_tools.cli.cmds.validate import validate_tron
 from paasta_tools.cli.cmds.validate import validate_unique_instance_names
@@ -1841,3 +1842,114 @@ def test_get_etc_services_entry_malformed_line():
     ):
         result = _get_etc_services_entry(20000)
         assert result == "my-service.main"
+
+
+def test_validate_flink_monitoring_team_no_flink_files():
+    with mock.patch(
+        "paasta_tools.cli.cmds.validate.glob",
+        return_value=[],
+        autospec=True,
+    ):
+        assert validate_flink_monitoring_team("/fake/service/path") is True
+
+
+def test_validate_flink_monitoring_team_valid():
+    mock_config = {
+        "my_instance": {
+            "jobs": {
+                "my_job": {
+                    "monitoring": {"team": "streamhouse", "page": False},
+                }
+            }
+        }
+    }
+    with mock.patch(
+        "paasta_tools.cli.cmds.validate.glob",
+        side_effect=[["flinkeks-pnw-prod.yaml"], []],
+        autospec=True,
+    ), mock.patch(
+        "builtins.open",
+        mock.mock_open(read_data=""),
+    ), mock.patch(
+        "paasta_tools.cli.cmds.validate.yaml.safe_load",
+        return_value=mock_config,
+    ), mock.patch(
+        "paasta_tools.cli.cmds.validate.get_sensu_team_data",
+        return_value={"pages_slack_channel": "#streamhouse"},
+        autospec=True,
+    ):
+        assert validate_flink_monitoring_team("/fake/service/path") is True
+
+
+def test_validate_flink_monitoring_team_invalid_team():
+    mock_config = {
+        "my_instance": {
+            "jobs": {
+                "my_job": {
+                    "monitoring": {"team": "dre-analytics", "page": False},
+                }
+            }
+        }
+    }
+    with mock.patch(
+        "paasta_tools.cli.cmds.validate.glob",
+        side_effect=[["flinkeks-pnw-prod.yaml"], []],
+        autospec=True,
+    ), mock.patch(
+        "builtins.open",
+        mock.mock_open(read_data=""),
+    ), mock.patch(
+        "paasta_tools.cli.cmds.validate.yaml.safe_load",
+        return_value=mock_config,
+    ), mock.patch(
+        "paasta_tools.cli.cmds.validate.get_sensu_team_data",
+        return_value={},
+        autospec=True,
+    ):
+        assert validate_flink_monitoring_team("/fake/service/path") is False
+
+
+def test_validate_flink_monitoring_team_missing_team():
+    mock_config = {
+        "my_instance": {
+            "jobs": {
+                "my_job": {
+                    "monitoring": {"page": False},
+                }
+            }
+        }
+    }
+    with mock.patch(
+        "paasta_tools.cli.cmds.validate.glob",
+        side_effect=[["flinkeks-pnw-prod.yaml"], []],
+        autospec=True,
+    ), mock.patch(
+        "builtins.open",
+        mock.mock_open(read_data=""),
+    ), mock.patch(
+        "paasta_tools.cli.cmds.validate.yaml.safe_load",
+        return_value=mock_config,
+    ):
+        assert validate_flink_monitoring_team("/fake/service/path") is False
+
+
+def test_validate_flink_monitoring_team_missing_monitoring():
+    mock_config = {
+        "my_instance": {
+            "jobs": {
+                "my_job": {},
+            }
+        }
+    }
+    with mock.patch(
+        "paasta_tools.cli.cmds.validate.glob",
+        side_effect=[["flinkeks-pnw-prod.yaml"], []],
+        autospec=True,
+    ), mock.patch(
+        "builtins.open",
+        mock.mock_open(read_data=""),
+    ), mock.patch(
+        "paasta_tools.cli.cmds.validate.yaml.safe_load",
+        return_value=mock_config,
+    ):
+        assert validate_flink_monitoring_team("/fake/service/path") is False

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -1867,10 +1867,7 @@ def test_validate_flink_monitoring_team_valid():
         "paasta_tools.cli.cmds.validate.glob",
         side_effect=[["flinkeks-pnw-prod.yaml"], []],
         autospec=True,
-    ), mock.patch(
-        "builtins.open",
-        mock.mock_open(read_data=""),
-    ), mock.patch(
+    ), mock.patch("builtins.open", mock.mock_open(read_data=""),), mock.patch(
         "paasta_tools.cli.cmds.validate.yaml.safe_load",
         return_value=mock_config,
     ), mock.patch(
@@ -1895,10 +1892,7 @@ def test_validate_flink_monitoring_team_invalid_team():
         "paasta_tools.cli.cmds.validate.glob",
         side_effect=[["flinkeks-pnw-prod.yaml"], []],
         autospec=True,
-    ), mock.patch(
-        "builtins.open",
-        mock.mock_open(read_data=""),
-    ), mock.patch(
+    ), mock.patch("builtins.open", mock.mock_open(read_data=""),), mock.patch(
         "paasta_tools.cli.cmds.validate.yaml.safe_load",
         return_value=mock_config,
     ), mock.patch(
@@ -1923,10 +1917,7 @@ def test_validate_flink_monitoring_team_missing_team():
         "paasta_tools.cli.cmds.validate.glob",
         side_effect=[["flinkeks-pnw-prod.yaml"], []],
         autospec=True,
-    ), mock.patch(
-        "builtins.open",
-        mock.mock_open(read_data=""),
-    ), mock.patch(
+    ), mock.patch("builtins.open", mock.mock_open(read_data=""),), mock.patch(
         "paasta_tools.cli.cmds.validate.yaml.safe_load",
         return_value=mock_config,
     ):
@@ -1945,10 +1936,7 @@ def test_validate_flink_monitoring_team_missing_monitoring():
         "paasta_tools.cli.cmds.validate.glob",
         side_effect=[["flinkeks-pnw-prod.yaml"], []],
         autospec=True,
-    ), mock.patch(
-        "builtins.open",
-        mock.mock_open(read_data=""),
-    ), mock.patch(
+    ), mock.patch("builtins.open", mock.mock_open(read_data=""),), mock.patch(
         "paasta_tools.cli.cmds.validate.yaml.safe_load",
         return_value=mock_config,
     ):

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -40,13 +40,13 @@ from paasta_tools.cli.cmds.validate import paasta_validate
 from paasta_tools.cli.cmds.validate import paasta_validate_soa_configs
 from paasta_tools.cli.cmds.validate import validate_autoscaling_configs
 from paasta_tools.cli.cmds.validate import validate_cpu_burst
+from paasta_tools.cli.cmds.validate import validate_flink_monitoring_team
 from paasta_tools.cli.cmds.validate import validate_instance_names
 from paasta_tools.cli.cmds.validate import validate_min_max_instances
 from paasta_tools.cli.cmds.validate import validate_paasta_objects
 from paasta_tools.cli.cmds.validate import validate_rollback_bounds
 from paasta_tools.cli.cmds.validate import validate_schema
 from paasta_tools.cli.cmds.validate import validate_secrets
-from paasta_tools.cli.cmds.validate import validate_flink_monitoring_team
 from paasta_tools.cli.cmds.validate import validate_smartstack
 from paasta_tools.cli.cmds.validate import validate_tron
 from paasta_tools.cli.cmds.validate import validate_unique_instance_names


### PR DESCRIPTION
## Summary

- Adds \`validate_flink_monitoring_team()\` to \`paasta validate\`, checking that every job's \`monitoring.team\` in \`flink-*.yaml\` and \`flinkeks-*.yaml\` files is a valid Sensu team name
- Uses \`get_sensu_team_data()\` for validation — returns \`{}\` for unknown teams
- Wired into \`paasta_validate_soa_configs\` alongside existing checks
- Catches both missing \`team\` fields and invalid team names

## Motivation

Previously this check lived as a custom pre-commit hook in yelpsoa-configs using the paasta venv directly. Moving it to \`paasta validate\` is the right architectural fit since it's a static config check and \`paasta validate\` already runs on all changed flink configs via the \`run-paasta-validate.sh\` hook.

## Test plan

- [x] 5 unit tests added covering: no flink files, valid team, invalid team, missing team, missing monitoring block
- [x] Manually tested against all streamhouse-family services in yelpsoa-configs

🤖 Generated with [Claude Code](https://claude.com/claude-code)