### PR TITLE
remove no-manylinux1 from dh_virtualenv build

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -21,7 +21,6 @@ DH_VENV_DIR=debian/$(PACKAGE)$(DH_VIRTUALENV_INSTALL_ROOT)/$(PACKAGE)
 override_dh_virtualenv:
 	dh_virtualenv \
         --python=/usr/bin/python3.10 \
-		--preinstall no-manylinux1 \
 		--preinstall=-rrequirements-bootstrap.txt
 	cp yelp_package/gopath/paasta_go $(DH_VENV_DIR)/bin/paasta_go
 	@echo patching k8s client lib


### PR DESCRIPTION
I'm not entirely sure why this was chosen to use, but manylinux is (for better or worse) the standard for python. Practically speaking, we need to use it for some of the dependencies of this project.