### PR TITLE
AIRFLOW-3: Add a new set-namespaces subcmd to paasta secret

### DIFF
--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -282,7 +282,7 @@ def _add_common_args(
         service_group.set_defaults(shared=False)
 
 
-def add_set_namespaces_subparser(subparsers):
+def add_set_namespaces_subparser(subparsers) -> None:
     parser = subparsers.add_parser(
         "set-namespaces",
         help="update the extra_namespaces field of an existing secret without changing its value",
@@ -295,6 +295,8 @@ def add_set_namespaces_subparser(subparsers):
             "changed JSON file to apply the update."
         ),
     )
+    # NOTE: this sub-command is entirely local, so we don't
+    # need to clutter the help-text with vault nonsense
     _add_common_args(parser, include_vault_args=False)
     parser.add_argument(
         "-n",
@@ -460,7 +462,7 @@ def _update_extra_namespaces(secret_path: str, namespaces: List[str]) -> None:
         f.write("\n")
 
 
-def paasta_secret_set_namespaces(args) -> None:
+def paasta_secret_set_namespaces(args: argparse.Namespace) -> None:
     service = SHARED_SECRET_SERVICE if args.shared else args.service
     soa_dir = os.getcwd()
     secret_path = os.path.join(soa_dir, service, "secrets", f"{args.secret_name}.json")

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -241,7 +241,11 @@ def _add_vault_auth_args(parser: argparse.ArgumentParser):
     )
 
 
-def _add_common_args(parser: argparse.ArgumentParser, allow_shared: bool = True):
+def _add_common_args(
+    parser: argparse.ArgumentParser,
+    allow_shared: bool = True,
+    include_vault_args: bool = True,
+):
     # available from any subcommand
     parser.add_argument(
         "-y",
@@ -251,7 +255,8 @@ def _add_common_args(parser: argparse.ArgumentParser, allow_shared: bool = True)
         default=DEFAULT_SOA_DIR,
     )
 
-    _add_vault_auth_args(parser)
+    if include_vault_args:
+        _add_vault_auth_args(parser)
 
     if allow_shared:
         service_group = parser.add_mutually_exclusive_group(required=True)
@@ -275,6 +280,45 @@ def _add_common_args(parser: argparse.ArgumentParser, allow_shared: bool = True)
         )
     else:
         service_group.set_defaults(shared=False)
+
+
+def add_set_namespaces_subparser(subparsers):
+    parser = subparsers.add_parser(
+        "set-namespaces",
+        help="update the extra_namespaces field of an existing secret without changing its value",
+        description=(
+            "Replaces the extra_namespaces list on an existing PaaSTA secret JSON file "
+            "without touching the encrypted secret value. No Vault authentication required. "
+            "The supplied list completely replaces any previously set namespaces — include all "
+            "namespaces you want, not just new ones. "
+            "Run from the root of your yelpsoa-configs checkout, then commit and push the "
+            "changed JSON file to apply the update."
+        ),
+    )
+    _add_common_args(parser, include_vault_args=False)
+    parser.add_argument(
+        "-n",
+        "--secret-name",
+        type=check_secret_name,
+        required=True,
+        help="The name of the secret to modify (filename without .json extension).",
+    )
+    parser.add_argument(
+        "--extra-namespaces",
+        "--namespaces",
+        required=True,
+        type=lambda v: v.split(",") if v else [],
+        help=(
+            "Comma-separated list of additional Kubernetes namespaces to sync this secret to, "
+            "beyond those derived from PaaSTA instance configs (e.g. 'mwaa,other-ns'). "
+            "If this secret is used by a PaaSTA instance, its namespace is handled automatically "
+            "and does not need to be included here. "
+            "This REPLACES the existing list — include all extra namespaces you want to keep. "
+            "Pass an empty string to remove all extra namespaces."
+        ),
+        metavar="NAMESPACES",
+        dest="extra_namespaces",
+    )
 
 
 def add_subparser(subparsers):
@@ -303,6 +347,7 @@ def add_subparser(subparsers):
     add_decrypt_subparser(secret_subparsers)
     add_update_subparser(secret_subparsers)
     add_run_subparser(secret_subparsers)
+    add_set_namespaces_subparser(secret_subparsers)
 
 
 def secret_name_for_env(secret_name):
@@ -415,7 +460,43 @@ def _update_extra_namespaces(secret_path: str, namespaces: List[str]) -> None:
         f.write("\n")
 
 
+def paasta_secret_set_namespaces(args) -> None:
+    service = SHARED_SECRET_SERVICE if args.shared else args.service
+    soa_dir = os.getcwd()
+    secret_path = os.path.join(soa_dir, service, "secrets", f"{args.secret_name}.json")
+
+    if not os.path.isfile(secret_path):
+        print(
+            f"Secret file not found: {secret_path}\n"
+            "Ensure you are in the root of your yelpsoa-configs checkout "
+            "and the secret already exists (use 'paasta secret add' to create it)."
+        )
+        sys.exit(1)
+
+    _update_extra_namespaces(secret_path, args.extra_namespaces)
+    _log_audit(
+        action="set-namespaces-secret",
+        action_details={
+            "secret_name": args.secret_name,
+            "extra_namespaces": args.extra_namespaces,
+        },
+        service=service,
+    )
+
+    if args.extra_namespaces:
+        print(
+            f"Updated extra_namespaces for '{args.secret_name}': {args.extra_namespaces}"
+        )
+    else:
+        print(f"Cleared extra_namespaces for '{args.secret_name}'.")
+    print(f"Commit and push {secret_path} to apply the update.")
+
+
 def paasta_secret(args):
+    if args.action == "set-namespaces":
+        paasta_secret_set_namespaces(args)
+        return
+
     if args.shared:
         service = SHARED_SECRET_SERVICE
         if not args.clusters:

--- a/tests/cli/test_cmds_secret.py
+++ b/tests/cli/test_cmds_secret.py
@@ -437,3 +437,102 @@ def test_update_extra_namespaces_clear(tmp_path):
 
     data = json.loads(secret_path.read_text())
     assert "extra_namespaces" not in data
+
+
+def test_paasta_secret_set_namespaces_sets(tmp_path):
+    secret_dir = tmp_path / "mysvc" / "secrets"
+    secret_dir.mkdir(parents=True)
+    secret_file = secret_dir / "my-secret.json"
+    secret_file.write_text('{"environments": {}}')
+
+    mock_args = mock.Mock(
+        shared=False,
+        service="mysvc",
+        secret_name="my-secret",
+        extra_namespaces=["mwaa", "other-ns"],
+    )
+    with mock.patch("os.getcwd", return_value=str(tmp_path)), mock.patch(
+        "paasta_tools.cli.cmds.secret._log_audit", autospec=True
+    ) as mock_log_audit:
+        secret.paasta_secret_set_namespaces(mock_args)
+
+    data = json.loads(secret_file.read_text())
+    assert data["extra_namespaces"] == ["mwaa", "other-ns"]
+    mock_log_audit.assert_called_once_with(
+        action="set-namespaces-secret",
+        action_details={
+            "secret_name": "my-secret",
+            "extra_namespaces": ["mwaa", "other-ns"],
+        },
+        service="mysvc",
+    )
+
+
+def test_paasta_secret_set_namespaces_clears(tmp_path):
+    secret_dir = tmp_path / "mysvc" / "secrets"
+    secret_dir.mkdir(parents=True)
+    secret_file = secret_dir / "my-secret.json"
+    secret_file.write_text('{"extra_namespaces": ["old"], "environments": {}}')
+
+    mock_args = mock.Mock(
+        shared=False,
+        service="mysvc",
+        secret_name="my-secret",
+        extra_namespaces=[],
+    )
+    with mock.patch("os.getcwd", return_value=str(tmp_path)), mock.patch(
+        "paasta_tools.cli.cmds.secret._log_audit", autospec=True
+    ):
+        secret.paasta_secret_set_namespaces(mock_args)
+
+    data = json.loads(secret_file.read_text())
+    assert "extra_namespaces" not in data
+
+
+def test_paasta_secret_set_namespaces_missing_file(tmp_path):
+    secret_dir = tmp_path / "mysvc" / "secrets"
+    secret_dir.mkdir(parents=True)
+
+    mock_args = mock.Mock(
+        shared=False,
+        service="mysvc",
+        secret_name="nonexistent",
+        extra_namespaces=["mwaa"],
+    )
+    with mock.patch("os.getcwd", return_value=str(tmp_path)), raises(SystemExit):
+        secret.paasta_secret_set_namespaces(mock_args)
+
+
+def test_paasta_secret_set_namespaces_shared(tmp_path):
+    secret_dir = tmp_path / secret.SHARED_SECRET_SERVICE / "secrets"
+    secret_dir.mkdir(parents=True)
+    secret_file = secret_dir / "shared-sec.json"
+    secret_file.write_text('{"environments": {}}')
+
+    mock_args = mock.Mock(
+        shared=True,
+        service=None,
+        secret_name="shared-sec",
+        extra_namespaces=["mwaa"],
+    )
+    with mock.patch("os.getcwd", return_value=str(tmp_path)), mock.patch(
+        "paasta_tools.cli.cmds.secret._log_audit", autospec=True
+    ) as mock_log_audit:
+        secret.paasta_secret_set_namespaces(mock_args)
+
+    data = json.loads(secret_file.read_text())
+    assert data["extra_namespaces"] == ["mwaa"]
+    mock_log_audit.assert_called_once_with(
+        action="set-namespaces-secret",
+        action_details={"secret_name": "shared-sec", "extra_namespaces": ["mwaa"]},
+        service=secret.SHARED_SECRET_SERVICE,
+    )
+
+
+def test_paasta_secret_dispatches_set_namespaces():
+    with mock.patch(
+        "paasta_tools.cli.cmds.secret.paasta_secret_set_namespaces", autospec=True
+    ) as mock_handler:
+        mock_args = mock.Mock(action="set-namespaces", shared=False, service="mysvc")
+        secret.paasta_secret(mock_args)
+        mock_handler.assert_called_once_with(mock_args)


### PR DESCRIPTION
In #4290  I added an option to add `extra_namespaces` to a secret w/ `paasta secret`, but doing so with an existing secret could only be done with `paasta secret update` which forced users to go through the entire process of re-encrypting the secret. 

This PR instead just adds a new `set-namespaces` subcommand to `secret` so folks can manage *just* the extra_namespaces field w/o needing vault access etc. 

Invocation will look like:
```
$ paasta secret set-namespaces --namespaces temporal,mwaa -s paasta-contract-monitor -n goss
Before: (none)
After:  ['temporal', 'mwaa']
Apply this change to 'goss'?
(y/N)? y
Done. Commit and push /nail/home/jfong/work/yelpsoa-configs/paasta-contract-monitor/secrets/goss.json to apply the update.

$ git diff
diff --git a/paasta-contract-monitor/secrets/goss.json b/paasta-contract-monitor/secrets/goss.json
index 3db848fa687b..0de29363e587 100644
--- a/paasta-contract-monitor/secrets/goss.json
+++ b/paasta-contract-monitor/secrets/goss.json
@@ -48,6 +48,10 @@
         "yelpwifistage": {},
         "yrprod": {}
     },
+    "extra_namespaces": [
+        "temporal",
+        "mwaa"
+    ],
     "key_context": "paasta-contract-monitor",
...

$ paasta secret set-namespaces --namespaces '' -s paasta-contract-monitor -n goss
Before: ['temporal', 'mwaa']
After:  (none)
Apply this change to 'goss'?
(y/N)? y
Done. Commit and push /nail/home/jfong/work/yelpsoa-configs/paasta-contract-monitor/secrets/goss.json to apply the update.

$ git diff 
# no output; back to current version

$ paasta secret set-namespaces --namespaces temporal,mwaa -s paasta-contract-monitor -n goss -Y
Before: (none)
After:  ['temporal', 'mwaa']
Done. Commit and push /nail/home/jfong/work/yelpsoa-configs/paasta-contract-monitor/secrets/goss.json to apply the update.
```

Note that this does a full replace of namespaces with the given --extra-namespaces, it does not append, and the help text reflects that appropriately. For now, this seems fine? Lmk if you think otherwise. 

Because it does a full replace and because we don't have (and I didn't really think it merited it) a command to list current namespaces, the default option is to print out the old + new namespace lists and asks for confirmation.  This can be skipped with `-Y/--yes` (`-y` is reserved already for setting the yelpsoa-configs dir in a shared arg to `paasta secret`)

This PR does not change the support of adding `--extra-namespaces` at either secret creation or update that was already added in #4290 