### PR TITLE
Add comment clarifying job monitoring config scope in validate.py

### DIFF
--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -1311,6 +1311,9 @@ def validate_flink_monitoring_team(service_path: str) -> bool:
                 if not isinstance(job_config, dict):
                     continue
 
+                # Note: this is the job's own monitoring config, defined directly under the job.
+                # It does not inherit any fields from the instance-level or service-level monitoring
+                # and has no relation to them.
                 monitoring_raw = job_config.get("monitoring")
                 if monitoring_raw is None:
                     print(


### PR DESCRIPTION
## Summary
- https://github.com/Yelp/paasta/pull/4320/changes/BASE..695f5cd9ff395ff096a7649f817b1eda80ff4a7c#r3266263864
- Adds a comment in `paasta_tools/cli/cmds/validate.py` clarifying that the `monitoring` block under a Flink job is the job's own monitoring config
- It does not inherit any fields from instance-level or service-level monitoring and has no relation to them

## Test plan
- [ ] No logic changes; comment only

🤖 Generated with [Claude Code](https://claude.com/claude-code)