### PR TITLE
add yelp.com/cost_owner label, default value specified in service.yaml with instance level overriding possible for paasta instances and tron jobs

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -1276,7 +1276,7 @@ Various PaaSTA utilities look at the following keys from service.yaml
  * ``description``
  * ``external_link``
  * ``docker_registry`` This is optional. Set this to override the `system-wide docker registry <system_configs.html#configuration-options>`_, and specify an alternate docker registry for your service.
- * ``cost_owner`` A string identifying the team responsible for the cost of this service. Applied as a ``yelp.com/cost_owner`` Kubernetes pod label for cost attribution. Must match the pattern ``^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`` and be at most 63 characters. Can be overridden per-instance in EKS configs or per-job/action in Tron configs.
+ * ``cost_owner`` A string identifying the team responsible for the cost of this service. Applied as a ``yelp.com/cost_owner`` Kubernetes pod label for cost attribution. Must match the pattern ``^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`` and be at most 63 characters. Can be overridden per-instance in instance configs or per-job/action in Tron configs.
 
 Where does paasta_tools look for yelpsoa-configs?
 -------------------------------------------------------------

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -503,8 +503,9 @@ instance MAY have:
 
   * ``cost_owner``: A string identifying the team responsible for the cost of this
     instance. Applied as a ``yelp.com/cost_owner`` Kubernetes pod label for cost
-    attribution. Must match the pattern ``^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`` and be
-    at most 63 characters. If not specified, inherits from ``service.yaml``.
+    attribution. Should be in kebab-case and match a canonical owner name from the
+    Ownership service. Must match the pattern ``^[a-z0-9]([a-z0-9-]*[a-z0-9])?$``
+    and be at most 63 characters. If not specified, inherits from ``service.yaml``.
 
   * ``replication_threshold``: An integer representing the percentage of instances that
     need to be available for monitoring purposes. If less than ``replication_threshold``
@@ -729,9 +730,10 @@ Each Tron **job** configuration MAY specify the following options:
 
   * ``cost_owner``: A string identifying the team responsible for the cost of this
     job. Applied as a ``yelp.com/cost_owner`` Kubernetes pod label for cost
-    attribution. Inherited by all actions unless overridden at the action level.
-    Must match the pattern ``^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`` and be at most
-    63 characters.
+    attribution. Should be in kebab-case and match a canonical owner name from the
+    Ownership service. Inherited by all actions unless overridden at the action level.
+    If not specified, inherits from ``service.yaml``. Must match the pattern
+    ``^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`` and be at most 63 characters.
 
 Each Tron **action** of a job MAY specify the following:
 
@@ -1276,7 +1278,7 @@ Various PaaSTA utilities look at the following keys from service.yaml
  * ``description``
  * ``external_link``
  * ``docker_registry`` This is optional. Set this to override the `system-wide docker registry <system_configs.html#configuration-options>`_, and specify an alternate docker registry for your service.
- * ``cost_owner`` A string identifying the team responsible for the cost of this service. Applied as a ``yelp.com/cost_owner`` Kubernetes pod label for cost attribution. Must match the pattern ``^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`` and be at most 63 characters. Can be overridden per-instance in instance configs or per-job/action in Tron configs.
+ * ``cost_owner`` A string identifying the team responsible for the cost of this service. Applied as a ``yelp.com/cost_owner`` Kubernetes pod label for cost attribution. Should be in kebab-case and match a canonical owner name from the Ownership service. Must match the pattern ``^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`` and be at most 63 characters. Can be overridden per-instance in instance configs or per-job/action in Tron configs.
 
 Where does paasta_tools look for yelpsoa-configs?
 -------------------------------------------------------------

--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -501,6 +501,11 @@ instance MAY have:
     to determine the order in which to build & deploy deploy groups. Defaults to
     ``clustername.instancename``. See the deploy group doc_ for more information.
 
+  * ``cost_owner``: A string identifying the team responsible for the cost of this
+    instance. Applied as a ``yelp.com/cost_owner`` Kubernetes pod label for cost
+    attribution. Must match the pattern ``^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`` and be
+    at most 63 characters. If not specified, inherits from ``service.yaml``.
+
   * ``replication_threshold``: An integer representing the percentage of instances that
     need to be available for monitoring purposes. If less than ``replication_threshold``
     percent instances of a service's backends are available, the monitoring
@@ -722,6 +727,12 @@ Each Tron **job** configuration MAY specify the following options:
 
   * ``monitoring``: See the `monitoring.yaml`_ section for details.
 
+  * ``cost_owner``: A string identifying the team responsible for the cost of this
+    job. Applied as a ``yelp.com/cost_owner`` Kubernetes pod label for cost
+    attribution. Inherited by all actions unless overridden at the action level.
+    Must match the pattern ``^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`` and be at most
+    63 characters.
+
 Each Tron **action** of a job MAY specify the following:
 
   * Anything in the `Common Settings`_.
@@ -739,6 +750,9 @@ Each Tron **action** of a job MAY specify the following:
     composed of mixed ``paasta`` and ``ssh`` actions.
 
   * ``deploy_group``: Same setting as the ``Job``, but on a per-action basis. Defaults
+    to the setting for the entire job.
+
+  * ``cost_owner``: Same setting as the ``Job``, but on a per-action basis. Defaults
     to the setting for the entire job.
 
   * ``command``: The command to run. If the action is configured with ``executor: paasta`` (default),
@@ -1262,6 +1276,7 @@ Various PaaSTA utilities look at the following keys from service.yaml
  * ``description``
  * ``external_link``
  * ``docker_registry`` This is optional. Set this to override the `system-wide docker registry <system_configs.html#configuration-options>`_, and specify an alternate docker registry for your service.
+ * ``cost_owner`` A string identifying the team responsible for the cost of this service. Applied as a ``yelp.com/cost_owner`` Kubernetes pod label for cost attribution. Must match the pattern ``^[a-z0-9]([a-z0-9-]*[a-z0-9])?$`` and be at most 63 characters. Can be overridden per-instance in EKS configs or per-job/action in Tron configs.
 
 Where does paasta_tools look for yelpsoa-configs?
 -------------------------------------------------------------

--- a/paasta_tools/cli/schemas/eks_schema.json
+++ b/paasta_tools/cli/schemas/eks_schema.json
@@ -197,6 +197,11 @@
                 "deploy_group": {
                     "type": "string"
                 },
+                "cost_owner": {
+                    "type": "string",
+                    "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+                    "maxLength": 63
+                },
                 "bounce_overprovision_factor": {
                     "type": "number",
                     "minimum": 0.25,

--- a/paasta_tools/cli/schemas/service_schema.json
+++ b/paasta_tools/cli/schemas/service_schema.json
@@ -19,6 +19,11 @@
         },
         "external_link": {
             "type": "string"
+        },
+        "cost_owner": {
+            "type": "string",
+            "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+            "maxLength": 63
         }
     },
     "required": [

--- a/paasta_tools/cli/schemas/tron_schema.json
+++ b/paasta_tools/cli/schemas/tron_schema.json
@@ -104,6 +104,11 @@
                 "deploy_group": {
                     "type": "string"
                 },
+                "cost_owner": {
+                    "type": "string",
+                    "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+                    "maxLength": 63
+                },
                 "pool": {
                     "type": "string"
                 },
@@ -706,6 +711,11 @@
                 },
                 "deploy_group": {
                     "type": "string"
+                },
+                "cost_owner": {
+                    "type": "string",
+                    "pattern": "^[a-z0-9]([a-z0-9-]*[a-z0-9])?$",
+                    "maxLength": 63
                 }
             }
         }

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -385,6 +385,7 @@ KubePodLabels = TypedDict(
         "paasta.yelp.com/pool": str,
         "paasta.yelp.com/weight": str,
         "yelp.com/owner": str,
+        "yelp.com/cost_owner": str,
         "paasta.yelp.com/managed": str,
         "elbv2.k8s.aws/pod-readiness-gate-inject": str,
     },
@@ -2496,6 +2497,11 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
 
         if self.is_istio_sidecar_injection_enabled():
             labels["sidecar.istio.io/inject"] = "true"
+
+        if system_paasta_config.get_enable_cost_owner_label():
+            cost_owner = self.get_cost_owner()
+            if cost_owner:
+                labels["yelp.com/cost_owner"] = cost_owner
 
         # not all services use autoscaling, so we label those that do in order to have
         # prometheus selectively discover/scrape them

--- a/paasta_tools/monitoring_tools.py
+++ b/paasta_tools/monitoring_tools.py
@@ -36,6 +36,7 @@ from paasta_tools.long_running_service_tools import LongRunningServiceConfig
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import PaastaNotConfiguredError
 from paasta_tools.utils import _log
+from paasta_tools.utils import cached_read_service_configuration
 from paasta_tools.utils import is_under_replicated
 from paasta_tools.utils import load_system_paasta_config
 from paasta_tools.utils import time_cache
@@ -152,13 +153,6 @@ def get_description(overrides, service, soa_dir=DEFAULT_SOA_DIR):
     return __get_monitoring_config_value("description", overrides, service, soa_dir)
 
 
-# Our typical usage pattern is that we call all the different get_* functions back to back. Applying a small amount of
-# cache here helps cut down on the number of times we re-parse service.yaml.
-_cached_read_service_configuration = time_cache(ttl=5)(
-    service_configuration_lib.read_service_configuration
-)
-
-
 def __get_monitoring_config_value(
     key,
     overrides,
@@ -166,7 +160,7 @@ def __get_monitoring_config_value(
     soa_dir=DEFAULT_SOA_DIR,
     monitoring_defaults=monitoring_defaults,
 ):
-    general_config = _cached_read_service_configuration(service, soa_dir=soa_dir)
+    general_config = cached_read_service_configuration(service, soa_dir=soa_dir)
     monitor_config = read_monitoring_config(service, soa_dir=soa_dir)
     service_default = general_config.get(key, monitoring_defaults(key))
     service_default = general_config.get("monitoring", {key: service_default}).get(

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -28,7 +28,6 @@ from typing import cast
 
 from mypy_extensions import TypedDict
 from service_configuration_lib import read_extra_service_information
-from service_configuration_lib import read_service_configuration
 from service_configuration_lib import read_yaml_file
 from service_configuration_lib.spark_config import SparkConfBuilder
 from service_configuration_lib.spark_config import get_total_driver_memory_mb
@@ -77,6 +76,7 @@ from paasta_tools.utils import PoolsNotConfiguredError
 from paasta_tools.utils import ProjectedSAVolume
 from paasta_tools.utils import SystemPaastaConfig
 from paasta_tools.utils import TronSecretVolume
+from paasta_tools.utils import cached_read_service_configuration
 from paasta_tools.utils import filter_templates_from_config
 from paasta_tools.utils import get_k8s_url_for_cluster
 from paasta_tools.utils import load_system_paasta_config
@@ -732,9 +732,6 @@ class TronActionConfig(InstanceConfig):
         return projected_volumes if projected_volumes else None
 
 
-_cached_read_service_configuration = time_cache(ttl=5)(read_service_configuration)
-
-
 class TronJobConfig:
     """Represents a job in Tron, consisting of action(s) and job-level configuration values."""
 
@@ -830,7 +827,7 @@ class TronJobConfig:
     def get_cost_owner(self) -> Optional[str]:
         cost_owner = self.config_dict.get("cost_owner")
         if not cost_owner and self.get_service():
-            service_config = _cached_read_service_configuration(
+            service_config = cached_read_service_configuration(
                 self.get_service(), soa_dir=self.soa_dir
             )
             cost_owner = service_config.get("cost_owner")

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -28,6 +28,7 @@ from typing import cast
 
 from mypy_extensions import TypedDict
 from service_configuration_lib import read_extra_service_information
+from service_configuration_lib import read_service_configuration
 from service_configuration_lib import read_yaml_file
 from service_configuration_lib.spark_config import SparkConfBuilder
 from service_configuration_lib.spark_config import get_total_driver_memory_mb
@@ -829,6 +830,11 @@ class TronJobConfig:
             "deploy_group", self.get_deploy_group()
         )
         job_cost_owner = self.config_dict.get("cost_owner")
+        if not job_cost_owner and self.get_service():
+            service_config = read_service_configuration(
+                self.get_service(), soa_dir=self.soa_dir
+            )
+            job_cost_owner = service_config.get("cost_owner")
         if job_cost_owner:
             action_dict.setdefault("cost_owner", job_cost_owner)
         if action_service and action_deploy_group and self.load_deployments:

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -828,6 +828,9 @@ class TronJobConfig:
         action_deploy_group = action_dict.setdefault(
             "deploy_group", self.get_deploy_group()
         )
+        job_cost_owner = self.config_dict.get("cost_owner")
+        if job_cost_owner:
+            action_dict.setdefault("cost_owner", job_cost_owner)
         if action_service and action_deploy_group and self.load_deployments:
             try:
                 deployments_json = load_v2_deployments_json(
@@ -1073,6 +1076,11 @@ def format_tron_action_dict(action_config: TronActionConfig):
         }
 
         result["labels"]["yelp.com/owner"] = "compute_infra_platform_experience"
+
+        if system_paasta_config.get_enable_cost_owner_label():
+            cost_owner = action_config.get_cost_owner()
+            if cost_owner:
+                result["labels"]["yelp.com/cost_owner"] = cost_owner
 
         if (
             action_config.get_iam_role_provider() == "aws"

--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -732,6 +732,9 @@ class TronActionConfig(InstanceConfig):
         return projected_volumes if projected_volumes else None
 
 
+_cached_read_service_configuration = time_cache(ttl=5)(read_service_configuration)
+
+
 class TronJobConfig:
     """Represents a job in Tron, consisting of action(s) and job-level configuration values."""
 
@@ -824,17 +827,21 @@ class TronJobConfig:
     def get_expected_runtime(self):
         return self.config_dict.get("expected_runtime")
 
+    def get_cost_owner(self) -> Optional[str]:
+        cost_owner = self.config_dict.get("cost_owner")
+        if not cost_owner and self.get_service():
+            service_config = _cached_read_service_configuration(
+                self.get_service(), soa_dir=self.soa_dir
+            )
+            cost_owner = service_config.get("cost_owner")
+        return cost_owner
+
     def _get_action_config(self, action_name, action_dict) -> TronActionConfig:
         action_service = action_dict.setdefault("service", self.get_service())
         action_deploy_group = action_dict.setdefault(
             "deploy_group", self.get_deploy_group()
         )
-        job_cost_owner = self.config_dict.get("cost_owner")
-        if not job_cost_owner and self.get_service():
-            service_config = read_service_configuration(
-                self.get_service(), soa_dir=self.soa_dir
-            )
-            job_cost_owner = service_config.get("cost_owner")
+        job_cost_owner = self.get_cost_owner()
         if job_cost_owner:
             action_dict.setdefault("cost_owner", job_cost_owner)
         if action_service and action_deploy_group and self.load_deployments:

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -230,6 +230,10 @@ class time_cache:
         return cache
 
 
+# Avoid re-reading service.yaml when multiple callers need it in quick succession.
+cached_read_service_configuration = time_cache(ttl=5)(read_service_configuration)
+
+
 _SortDictsT = TypeVar("_SortDictsT", bound=Mapping)
 
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -358,6 +358,7 @@ class InstanceConfigDict(TypedDict, total=False):
     service: str
     uses_bulkdata: bool
     docker_url: str
+    cost_owner: str
 
 
 class BranchDictV1(TypedDict, total=False):
@@ -955,6 +956,9 @@ class InstanceConfig:
     def get_role(self) -> Optional[str]:
         """Which mesos role of nodes this job should run on."""
         return self.config_dict.get("role")
+
+    def get_cost_owner(self) -> Optional[str]:
+        return self.config_dict.get("cost_owner")
 
     def get_pool(self) -> str:
         """Which pool of nodes this job should run on. This can be used to mitigate noisy neighbors, by putting
@@ -2018,6 +2022,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     uses_bulkdata_default: bool
     enable_automated_redeploys_default: bool
     enable_tron_tsc: bool
+    enable_cost_owner_label: bool
     default_spark_iam_user: str
     default_spark_driver_pool_override: str
     readonly_docker_registry_auth_file: str
@@ -2762,6 +2767,9 @@ class SystemPaastaConfig:
 
     def get_enable_tron_tsc(self) -> bool:
         return self.config_dict.get("enable_tron_tsc", True)
+
+    def get_enable_cost_owner_label(self) -> bool:
+        return self.config_dict.get("enable_cost_owner_label", False)
 
     def get_remote_run_duration_limit(self, default: int) -> int:
         return self.config_dict.get("remote_run_duration_limit", default)

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -1970,9 +1970,10 @@ test_instance:
   cost_owner: {cost_owner}
 """
     with patch(
-        "paasta_tools.cli.cmds.validate.get_file_contents", autospec=True
+        "paasta_tools.cli.cmds.validate.get_file_contents",
+        return_value=instance_content,
+        autospec=True
     ) as mock_get_file_contents:
-        mock_get_file_contents.return_value = instance_content
         assert validate_schema("unused_service_path.yaml", instance_type) == expected
         expected_output = SCHEMA_VALID if expected else SCHEMA_INVALID
         output, _ = capsys.readouterr()

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -1941,3 +1941,100 @@ def test_validate_flink_monitoring_team_missing_monitoring():
         return_value=mock_config,
     ):
         assert validate_flink_monitoring_team("/fake/service/path") is False
+
+
+@pytest.mark.parametrize(
+    "cost_owner,expected,instance_type",
+    [
+        ("data-eng", True, "eks"),
+        ("compute-infra-batch", True, "eks"),
+        ("a", True, "eks"),
+        ("a1b2c3", True, "eks"),
+        # invalid: uppercase
+        ("Data-Eng", False, "eks"),
+        # invalid: starts with hyphen
+        ("-data-eng", False, "eks"),
+        # invalid: ends with hyphen
+        ("data-eng-", False, "eks"),
+        # invalid: contains underscore
+        ("data_eng", False, "eks"),
+        # invalid: exceeds 63 characters
+        ("a" * 64, False, "eks"),
+        # valid: exactly 63 characters
+        ("a" * 63, True, "eks"),
+    ],
+)
+def test_cost_owner_schema_validation_eks(cost_owner, expected, instance_type, capsys):
+    instance_content = f"""
+test_instance:
+  cost_owner: {cost_owner}
+"""
+    with patch(
+        "paasta_tools.cli.cmds.validate.get_file_contents", autospec=True
+    ) as mock_get_file_contents:
+        mock_get_file_contents.return_value = instance_content
+        assert validate_schema("unused_service_path.yaml", instance_type) == expected
+        expected_output = SCHEMA_VALID if expected else SCHEMA_INVALID
+        output, _ = capsys.readouterr()
+        assert expected_output in output
+
+
+@pytest.mark.parametrize(
+    "cost_owner,expected",
+    [
+        ("data-eng", True),
+        ("compute-infra-batch", True),
+        # invalid: uppercase
+        ("Data-Eng", False),
+        # invalid: starts with hyphen
+        ("-data-eng", False),
+        # invalid: exceeds 63 characters
+        ("a" * 64, False),
+    ],
+)
+@patch("paasta_tools.cli.cmds.validate.get_file_contents", autospec=True)
+def test_cost_owner_schema_validation_tron_job(
+    mock_get_file_contents, cost_owner, expected, capsys
+):
+    tron_content = f"""
+test_job:
+  node: batch_box
+  schedule: "daily 04:00:00"
+  cost_owner: {cost_owner}
+  actions:
+    first:
+      command: echo hello world
+"""
+    mock_get_file_contents.return_value = tron_content
+    assert validate_schema("unused_service_path.yaml", "tron") == expected
+    expected_output = SCHEMA_VALID if expected else SCHEMA_INVALID
+    output, _ = capsys.readouterr()
+    assert expected_output in output
+
+
+@pytest.mark.parametrize(
+    "cost_owner,expected",
+    [
+        ("ml-team", True),
+        # invalid: uppercase
+        ("ML-Team", False),
+    ],
+)
+@patch("paasta_tools.cli.cmds.validate.get_file_contents", autospec=True)
+def test_cost_owner_schema_validation_tron_action(
+    mock_get_file_contents, cost_owner, expected, capsys
+):
+    tron_content = f"""
+test_job:
+  node: batch_box
+  schedule: "daily 04:00:00"
+  actions:
+    first:
+      command: echo hello world
+      cost_owner: {cost_owner}
+"""
+    mock_get_file_contents.return_value = tron_content
+    assert validate_schema("unused_service_path.yaml", "tron") == expected
+    expected_output = SCHEMA_VALID if expected else SCHEMA_INVALID
+    output, _ = capsys.readouterr()
+    assert expected_output in output

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -1972,8 +1972,8 @@ test_instance:
     with patch(
         "paasta_tools.cli.cmds.validate.get_file_contents",
         return_value=instance_content,
-        autospec=True
-    ) as mock_get_file_contents:
+        autospec=True,
+    ):
         assert validate_schema("unused_service_path.yaml", instance_type) == expected
         expected_output = SCHEMA_VALID if expected else SCHEMA_INVALID
         output, _ = capsys.readouterr()
@@ -1993,24 +1993,25 @@ test_instance:
         ("a" * 64, False),
     ],
 )
-@patch("paasta_tools.cli.cmds.validate.get_file_contents", autospec=True)
-def test_cost_owner_schema_validation_tron_job(
-    mock_get_file_contents, cost_owner, expected, capsys
-):
+def test_cost_owner_schema_validation_tron_job(cost_owner, expected, capsys):
     tron_content = f"""
 test_job:
-  node: batch_box
+  node: paasta
   schedule: "daily 04:00:00"
   cost_owner: {cost_owner}
   actions:
     first:
       command: echo hello world
 """
-    mock_get_file_contents.return_value = tron_content
-    assert validate_schema("unused_service_path.yaml", "tron") == expected
-    expected_output = SCHEMA_VALID if expected else SCHEMA_INVALID
-    output, _ = capsys.readouterr()
-    assert expected_output in output
+    with patch(
+        "paasta_tools.cli.cmds.validate.get_file_contents",
+        return_value=tron_content,
+        autospec=True,
+    ):
+        assert validate_schema("unused_service_path.yaml", "tron") == expected
+        expected_output = SCHEMA_VALID if expected else SCHEMA_INVALID
+        output, _ = capsys.readouterr()
+        assert expected_output in output
 
 
 @pytest.mark.parametrize(
@@ -2021,21 +2022,22 @@ test_job:
         ("ML-Team", False),
     ],
 )
-@patch("paasta_tools.cli.cmds.validate.get_file_contents", autospec=True)
-def test_cost_owner_schema_validation_tron_action(
-    mock_get_file_contents, cost_owner, expected, capsys
-):
+def test_cost_owner_schema_validation_tron_action(cost_owner, expected, capsys):
     tron_content = f"""
 test_job:
-  node: batch_box
+  node: paasta
   schedule: "daily 04:00:00"
   actions:
     first:
       command: echo hello world
       cost_owner: {cost_owner}
 """
-    mock_get_file_contents.return_value = tron_content
-    assert validate_schema("unused_service_path.yaml", "tron") == expected
-    expected_output = SCHEMA_VALID if expected else SCHEMA_INVALID
-    output, _ = capsys.readouterr()
-    assert expected_output in output
+    with patch(
+        "paasta_tools.cli.cmds.validate.get_file_contents",
+        return_value=tron_content,
+        autospec=True,
+    ):
+        assert validate_schema("unused_service_path.yaml", "tron") == expected
+        expected_output = SCHEMA_VALID if expected else SCHEMA_INVALID
+        output, _ = capsys.readouterr()
+        assert expected_output in output

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -6118,6 +6118,10 @@ def test_delete_pod_by_name_no_pods():
 
 class TestCostOwnerLabel:
     @mock.patch(
+        "paasta_tools.kubernetes_tools.load_system_paasta_config",
+        autospec=True,
+    )
+    @mock.patch(
         "paasta_tools.kubernetes_tools.load_service_namespace_config",
         autospec=True,
     )
@@ -6150,6 +6154,7 @@ class TestCostOwnerLabel:
         mock_get_volumes,
         mock_get_kubernetes_containers,
         mock_load_service_namespace_config,
+        mock_load_system_paasta_config,
     ):
         mock_service_namespace_config = mock.Mock()
         mock_service_namespace_config.is_in_smartstack.return_value = False
@@ -6163,6 +6168,7 @@ class TestCostOwnerLabel:
         mock_system_paasta_config.get_pod_defaults.return_value = {}
         mock_system_paasta_config.get_enable_cost_owner_label.return_value = True
         mock_system_paasta_config.get_service_auth_token_volume_config.return_value = {}
+        mock_load_system_paasta_config.return_value = mock_system_paasta_config
 
         deployment = KubernetesDeploymentConfig(
             service="myservice",
@@ -6179,6 +6185,10 @@ class TestCostOwnerLabel:
         )
         assert ret.metadata.labels["yelp.com/cost_owner"] == "compute-infra-batch"
 
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.load_system_paasta_config",
+        autospec=True,
+    )
     @mock.patch(
         "paasta_tools.kubernetes_tools.load_service_namespace_config",
         autospec=True,
@@ -6212,6 +6222,7 @@ class TestCostOwnerLabel:
         mock_get_volumes,
         mock_get_kubernetes_containers,
         mock_load_service_namespace_config,
+        mock_load_system_paasta_config,
     ):
         mock_service_namespace_config = mock.Mock()
         mock_service_namespace_config.is_in_smartstack.return_value = False
@@ -6225,6 +6236,7 @@ class TestCostOwnerLabel:
         mock_system_paasta_config.get_pod_defaults.return_value = {}
         mock_system_paasta_config.get_enable_cost_owner_label.return_value = False
         mock_system_paasta_config.get_service_auth_token_volume_config.return_value = {}
+        mock_load_system_paasta_config.return_value = mock_system_paasta_config
 
         deployment = KubernetesDeploymentConfig(
             service="myservice",
@@ -6241,6 +6253,10 @@ class TestCostOwnerLabel:
         )
         assert "yelp.com/cost_owner" not in ret.metadata.labels
 
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.load_system_paasta_config",
+        autospec=True,
+    )
     @mock.patch(
         "paasta_tools.kubernetes_tools.load_service_namespace_config",
         autospec=True,
@@ -6274,6 +6290,7 @@ class TestCostOwnerLabel:
         mock_get_volumes,
         mock_get_kubernetes_containers,
         mock_load_service_namespace_config,
+        mock_load_system_paasta_config,
     ):
         mock_service_namespace_config = mock.Mock()
         mock_service_namespace_config.is_in_smartstack.return_value = False
@@ -6287,6 +6304,7 @@ class TestCostOwnerLabel:
         mock_system_paasta_config.get_pod_defaults.return_value = {}
         mock_system_paasta_config.get_enable_cost_owner_label.return_value = True
         mock_system_paasta_config.get_service_auth_token_volume_config.return_value = {}
+        mock_load_system_paasta_config.return_value = mock_system_paasta_config
 
         deployment = KubernetesDeploymentConfig(
             service="myservice",

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -6114,3 +6114,190 @@ def test_delete_pod_by_name_no_pods():
 
         assert result is False
         mock_client.core.delete_namespaced_pod.assert_not_called()
+
+
+class TestCostOwnerLabel:
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.load_service_namespace_config",
+        autospec=True,
+    )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_kubernetes_containers",
+        autospec=True,
+    )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_volumes",
+        autospec=True,
+    )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_pod_volumes",
+        autospec=True,
+        return_value=[],
+    )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_node_affinity",
+        autospec=True,
+    )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.create_pod_topology_spread_constraints",
+        autospec=True,
+    )
+    def test_cost_owner_label_present_when_enabled(
+        self,
+        mock_create_pod_topology_spread_constraints,
+        mock_get_node_affinity,
+        mock_get_pod_volumes,
+        mock_get_volumes,
+        mock_get_kubernetes_containers,
+        mock_load_service_namespace_config,
+    ):
+        mock_service_namespace_config = mock.Mock()
+        mock_service_namespace_config.is_in_smartstack.return_value = False
+        mock_load_service_namespace_config.return_value = mock_service_namespace_config
+
+        mock_system_paasta_config = mock.Mock()
+        mock_system_paasta_config.get_kubernetes_add_registration_labels.return_value = (
+            False
+        )
+        mock_system_paasta_config.get_topology_spread_constraints.return_value = []
+        mock_system_paasta_config.get_pod_defaults.return_value = {}
+        mock_system_paasta_config.get_enable_cost_owner_label.return_value = True
+        mock_system_paasta_config.get_service_auth_token_volume_config.return_value = {}
+
+        deployment = KubernetesDeploymentConfig(
+            service="myservice",
+            instance="main",
+            cluster="testcluster",
+            config_dict=KubernetesDeploymentConfigDict(
+                cost_owner="compute-infra-batch",
+                deploy_group="testcluster.main",
+            ),
+            branch_dict=None,
+        )
+        ret = deployment.get_pod_template_spec(
+            git_sha="abc123", system_paasta_config=mock_system_paasta_config
+        )
+        assert ret.metadata.labels["yelp.com/cost_owner"] == "compute-infra-batch"
+
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.load_service_namespace_config",
+        autospec=True,
+    )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_kubernetes_containers",
+        autospec=True,
+    )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_volumes",
+        autospec=True,
+    )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_pod_volumes",
+        autospec=True,
+        return_value=[],
+    )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_node_affinity",
+        autospec=True,
+    )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.create_pod_topology_spread_constraints",
+        autospec=True,
+    )
+    def test_cost_owner_label_absent_when_gate_disabled(
+        self,
+        mock_create_pod_topology_spread_constraints,
+        mock_get_node_affinity,
+        mock_get_pod_volumes,
+        mock_get_volumes,
+        mock_get_kubernetes_containers,
+        mock_load_service_namespace_config,
+    ):
+        mock_service_namespace_config = mock.Mock()
+        mock_service_namespace_config.is_in_smartstack.return_value = False
+        mock_load_service_namespace_config.return_value = mock_service_namespace_config
+
+        mock_system_paasta_config = mock.Mock()
+        mock_system_paasta_config.get_kubernetes_add_registration_labels.return_value = (
+            False
+        )
+        mock_system_paasta_config.get_topology_spread_constraints.return_value = []
+        mock_system_paasta_config.get_pod_defaults.return_value = {}
+        mock_system_paasta_config.get_enable_cost_owner_label.return_value = False
+        mock_system_paasta_config.get_service_auth_token_volume_config.return_value = {}
+
+        deployment = KubernetesDeploymentConfig(
+            service="myservice",
+            instance="main",
+            cluster="testcluster",
+            config_dict=KubernetesDeploymentConfigDict(
+                cost_owner="compute-infra-batch",
+                deploy_group="testcluster.main",
+            ),
+            branch_dict=None,
+        )
+        ret = deployment.get_pod_template_spec(
+            git_sha="abc123", system_paasta_config=mock_system_paasta_config
+        )
+        assert "yelp.com/cost_owner" not in ret.metadata.labels
+
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.load_service_namespace_config",
+        autospec=True,
+    )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_kubernetes_containers",
+        autospec=True,
+    )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_volumes",
+        autospec=True,
+    )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_pod_volumes",
+        autospec=True,
+        return_value=[],
+    )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_node_affinity",
+        autospec=True,
+    )
+    @mock.patch(
+        "paasta_tools.kubernetes_tools.create_pod_topology_spread_constraints",
+        autospec=True,
+    )
+    def test_cost_owner_label_absent_when_not_configured(
+        self,
+        mock_create_pod_topology_spread_constraints,
+        mock_get_node_affinity,
+        mock_get_pod_volumes,
+        mock_get_volumes,
+        mock_get_kubernetes_containers,
+        mock_load_service_namespace_config,
+    ):
+        mock_service_namespace_config = mock.Mock()
+        mock_service_namespace_config.is_in_smartstack.return_value = False
+        mock_load_service_namespace_config.return_value = mock_service_namespace_config
+
+        mock_system_paasta_config = mock.Mock()
+        mock_system_paasta_config.get_kubernetes_add_registration_labels.return_value = (
+            False
+        )
+        mock_system_paasta_config.get_topology_spread_constraints.return_value = []
+        mock_system_paasta_config.get_pod_defaults.return_value = {}
+        mock_system_paasta_config.get_enable_cost_owner_label.return_value = True
+        mock_system_paasta_config.get_service_auth_token_volume_config.return_value = {}
+
+        deployment = KubernetesDeploymentConfig(
+            service="myservice",
+            instance="main",
+            cluster="testcluster",
+            config_dict=KubernetesDeploymentConfigDict(
+                deploy_group="testcluster.main",
+            ),
+            branch_dict=None,
+        )
+        ret = deployment.get_pod_template_spec(
+            git_sha="abc123", system_paasta_config=mock_system_paasta_config
+        )
+        assert "yelp.com/cost_owner" not in ret.metadata.labels

--- a/tests/test_monitoring_tools.py
+++ b/tests/test_monitoring_tools.py
@@ -204,7 +204,7 @@ class TestMonitoring_Tools:
     def test_get_monitoring_config_value_with_monitor_config(self):
         expected = "monitor_test_team"
         with mock.patch(
-            "paasta_tools.monitoring_tools._cached_read_service_configuration",
+            "paasta_tools.monitoring_tools.cached_read_service_configuration",
             autospec=True,
             return_value=self.fake_general_service_config,
         ) as service_configuration_lib_patch, mock.patch(
@@ -231,7 +231,7 @@ class TestMonitoring_Tools:
     def test_get_monitoring_config_value_with_service_config(self):
         expected = "general_test_team"
         with mock.patch(
-            "paasta_tools.monitoring_tools._cached_read_service_configuration",
+            "paasta_tools.monitoring_tools.cached_read_service_configuration",
             autospec=True,
             return_value=self.fake_general_service_config,
         ) as service_configuration_lib_patch, mock.patch(
@@ -258,7 +258,7 @@ class TestMonitoring_Tools:
     def test_get_monitoring_config_value_with_defaults(self):
         expected = None
         with mock.patch(
-            "paasta_tools.monitoring_tools._cached_read_service_configuration",
+            "paasta_tools.monitoring_tools.cached_read_service_configuration",
             autospec=True,
             return_value=self.empty_job_config,
         ) as service_configuration_lib_patch, mock.patch(

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -28,6 +28,7 @@ MOCK_SYSTEM_PAASTA_CONFIG = utils.SystemPaastaConfig(
             "dockercfg_location": "/mock/dockercfg",
             "spark_k8s_role": "spark",
             "enable_tron_tsc": True,
+            "enable_cost_owner_label": True,
         }
     ),
     "/mock/system/configs",
@@ -2290,6 +2291,8 @@ fake_job:
 
 
 class TestCostOwnerLabel:
+    # autospec=None is used here because we're passing a pre-configured Mock as the
+    # new value rather than letting patch create one with autospec constraints.
     @pytest.fixture(autouse=True)
     def mock_read_monitoring_config(self):
         with mock.patch(
@@ -2358,61 +2361,42 @@ class TestCostOwnerLabel:
         actions = job_config.get_actions()
         assert actions[0].get_cost_owner() == "ml-team"
 
-    def test_cost_owner_label_in_format_tron_action_dict_when_enabled(self):
-        action_dict = {
-            "command": "echo hello",
-            "service": "my_service",
-            "deploy_group": "prod",
-            "executor": "paasta",
-            "cost_owner": "data-eng",
-        }
-        branch_dict = {
-            "docker_image": "my_service:paasta-123abcde",
-            "git_sha": "aabbcc44",
-            "desired_state": "start",
-            "force_bounce": None,
-        }
-        action_config = tron_tools.TronActionConfig(
-            service="my_service",
-            instance=tron_tools.compose_instance("my_job", "do_something"),
-            config_dict=action_dict,
-            branch_dict=branch_dict,
+    @mock.patch(
+        "paasta_tools.tron_tools.read_service_configuration",
+        autospec=True,
+        return_value={"cost_owner": "platform-eng"},
+    )
+    @mock.patch(
+        "paasta_tools.tron_tools.load_system_paasta_config",
+        autospec=True,
+        return_value=MOCK_SYSTEM_PAASTA_CONFIG,
+    )
+    def test_cost_owner_inherited_from_service_yaml(
+        self, mock_load_system_paasta_config, mock_read_service_config
+    ):
+        job_config = tron_tools.TronJobConfig(
+            name="my_job",
+            config_dict={
+                "node": "paasta",
+                "schedule": "daily 04:00:00",
+                "service": "my_service",
+                "deploy_group": "prod",
+                "monitoring": {"team": "noop"},
+                "actions": {
+                    "do_something": {
+                        "command": "echo hello",
+                    },
+                },
+            },
             cluster="test-cluster",
+            load_deployments=False,
+            soa_dir="/mock/soa",
         )
-        mock_system_config = utils.SystemPaastaConfig(
-            utils.SystemPaastaConfigDict(
-                {
-                    "docker_registry": "mock_registry",
-                    "volumes": [],
-                    "dockercfg_location": "/mock/dockercfg",
-                    "enable_cost_owner_label": True,
-                    "enable_tron_tsc": True,
-                }
-            ),
-            "/mock/system/configs",
-        )
-        with mock.patch.object(
-            action_config,
-            "get_docker_registry",
-            return_value="docker-registry.com:400",
-        ), mock.patch(
-            "paasta_tools.utils.InstanceConfig.use_docker_disk_quota",
-            autospec=True,
-            return_value=False,
-        ), mock.patch(
-            "paasta_tools.tron_tools.load_system_paasta_config",
-            autospec=True,
-            return_value=mock_system_config,
-        ), mock.patch(
-            "paasta_tools.tron_tools.add_volumes_for_authenticating_services",
-            autospec=True,
-            return_value=[],
-        ):
-            result = tron_tools.format_tron_action_dict(action_config)
+        actions = job_config.get_actions()
+        assert actions[0].get_cost_owner() == "platform-eng"
+        mock_read_service_config.assert_called_with("my_service", soa_dir="/mock/soa")
 
-        assert result["labels"]["yelp.com/cost_owner"] == "data-eng"
-
-    def test_cost_owner_label_absent_when_gate_disabled(self):
+    def test_cost_owner_label_in_format_tron_action_dict(self):
         action_dict = {
             "command": "echo hello",
             "service": "my_service",
@@ -2452,6 +2436,60 @@ class TestCostOwnerLabel:
         ):
             result = tron_tools.format_tron_action_dict(action_config)
 
+        assert result["labels"]["yelp.com/cost_owner"] == "data-eng"
+
+    def test_cost_owner_label_absent_when_gate_disabled(self):
+        mock_system_config_disabled = utils.SystemPaastaConfig(
+            utils.SystemPaastaConfigDict(
+                {
+                    "docker_registry": "mock_registry",
+                    "volumes": [],
+                    "dockercfg_location": "/mock/dockercfg",
+                    "enable_cost_owner_label": False,
+                    "enable_tron_tsc": True,
+                }
+            ),
+            "/mock/system/configs",
+        )
+        action_dict = {
+            "command": "echo hello",
+            "service": "my_service",
+            "deploy_group": "prod",
+            "executor": "paasta",
+            "cost_owner": "data-eng",
+        }
+        branch_dict = {
+            "docker_image": "my_service:paasta-123abcde",
+            "git_sha": "aabbcc44",
+            "desired_state": "start",
+            "force_bounce": None,
+        }
+        action_config = tron_tools.TronActionConfig(
+            service="my_service",
+            instance=tron_tools.compose_instance("my_job", "do_something"),
+            config_dict=action_dict,
+            branch_dict=branch_dict,
+            cluster="test-cluster",
+        )
+        with mock.patch.object(
+            action_config,
+            "get_docker_registry",
+            return_value="docker-registry.com:400",
+        ), mock.patch(
+            "paasta_tools.utils.InstanceConfig.use_docker_disk_quota",
+            autospec=True,
+            return_value=False,
+        ), mock.patch(
+            "paasta_tools.tron_tools.load_system_paasta_config",
+            autospec=True,
+            return_value=mock_system_config_disabled,
+        ), mock.patch(
+            "paasta_tools.tron_tools.add_volumes_for_authenticating_services",
+            autospec=True,
+            return_value=[],
+        ):
+            result = tron_tools.format_tron_action_dict(action_config)
+
         assert "yelp.com/cost_owner" not in result["labels"]
 
     def test_cost_owner_label_absent_when_not_configured(self):
@@ -2474,18 +2512,6 @@ class TestCostOwnerLabel:
             branch_dict=branch_dict,
             cluster="test-cluster",
         )
-        mock_system_config = utils.SystemPaastaConfig(
-            utils.SystemPaastaConfigDict(
-                {
-                    "docker_registry": "mock_registry",
-                    "volumes": [],
-                    "dockercfg_location": "/mock/dockercfg",
-                    "enable_cost_owner_label": True,
-                    "enable_tron_tsc": True,
-                }
-            ),
-            "/mock/system/configs",
-        )
         with mock.patch.object(
             action_config,
             "get_docker_registry",
@@ -2497,7 +2523,7 @@ class TestCostOwnerLabel:
         ), mock.patch(
             "paasta_tools.tron_tools.load_system_paasta_config",
             autospec=True,
-            return_value=mock_system_config,
+            return_value=MOCK_SYSTEM_PAASTA_CONFIG,
         ), mock.patch(
             "paasta_tools.tron_tools.add_volumes_for_authenticating_services",
             autospec=True,

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -2287,3 +2287,222 @@ fake_job:
         ]
         result = tron_tools.list_tron_clusters("foo")
         assert sorted(result) == ["dev-cluster2", "prod"]
+
+
+class TestCostOwnerLabel:
+    @pytest.fixture(autouse=True)
+    def mock_read_monitoring_config(self):
+        with mock.patch(
+            "paasta_tools.monitoring_tools.read_monitoring_config",
+            mock.Mock(return_value={"team": "default_team"}),
+            autospec=None,
+        ) as f:
+            yield f
+
+    @mock.patch(
+        "paasta_tools.tron_tools.load_system_paasta_config",
+        autospec=True,
+        return_value=MOCK_SYSTEM_PAASTA_CONFIG,
+    )
+    def test_cost_owner_inherited_from_job_to_action(
+        self, mock_load_system_paasta_config
+    ):
+        job_config = tron_tools.TronJobConfig(
+            name="my_job",
+            config_dict={
+                "node": "paasta",
+                "schedule": "daily 04:00:00",
+                "service": "my_service",
+                "deploy_group": "prod",
+                "monitoring": {"team": "noop"},
+                "cost_owner": "data-eng",
+                "actions": {
+                    "do_something": {
+                        "command": "echo hello",
+                    },
+                },
+            },
+            cluster="test-cluster",
+            load_deployments=False,
+            soa_dir="/mock/soa",
+        )
+        actions = job_config.get_actions()
+        assert actions[0].get_cost_owner() == "data-eng"
+
+    @mock.patch(
+        "paasta_tools.tron_tools.load_system_paasta_config",
+        autospec=True,
+        return_value=MOCK_SYSTEM_PAASTA_CONFIG,
+    )
+    def test_cost_owner_action_overrides_job(self, mock_load_system_paasta_config):
+        job_config = tron_tools.TronJobConfig(
+            name="my_job",
+            config_dict={
+                "node": "paasta",
+                "schedule": "daily 04:00:00",
+                "service": "my_service",
+                "deploy_group": "prod",
+                "monitoring": {"team": "noop"},
+                "cost_owner": "data-eng",
+                "actions": {
+                    "do_something": {
+                        "command": "echo hello",
+                        "cost_owner": "ml-team",
+                    },
+                },
+            },
+            cluster="test-cluster",
+            load_deployments=False,
+            soa_dir="/mock/soa",
+        )
+        actions = job_config.get_actions()
+        assert actions[0].get_cost_owner() == "ml-team"
+
+    def test_cost_owner_label_in_format_tron_action_dict_when_enabled(self):
+        action_dict = {
+            "command": "echo hello",
+            "service": "my_service",
+            "deploy_group": "prod",
+            "executor": "paasta",
+            "cost_owner": "data-eng",
+        }
+        branch_dict = {
+            "docker_image": "my_service:paasta-123abcde",
+            "git_sha": "aabbcc44",
+            "desired_state": "start",
+            "force_bounce": None,
+        }
+        action_config = tron_tools.TronActionConfig(
+            service="my_service",
+            instance=tron_tools.compose_instance("my_job", "do_something"),
+            config_dict=action_dict,
+            branch_dict=branch_dict,
+            cluster="test-cluster",
+        )
+        mock_system_config = utils.SystemPaastaConfig(
+            utils.SystemPaastaConfigDict(
+                {
+                    "docker_registry": "mock_registry",
+                    "volumes": [],
+                    "dockercfg_location": "/mock/dockercfg",
+                    "enable_cost_owner_label": True,
+                    "enable_tron_tsc": True,
+                }
+            ),
+            "/mock/system/configs",
+        )
+        with mock.patch.object(
+            action_config,
+            "get_docker_registry",
+            return_value="docker-registry.com:400",
+        ), mock.patch(
+            "paasta_tools.utils.InstanceConfig.use_docker_disk_quota",
+            autospec=True,
+            return_value=False,
+        ), mock.patch(
+            "paasta_tools.tron_tools.load_system_paasta_config",
+            autospec=True,
+            return_value=mock_system_config,
+        ), mock.patch(
+            "paasta_tools.tron_tools.add_volumes_for_authenticating_services",
+            autospec=True,
+            return_value=[],
+        ):
+            result = tron_tools.format_tron_action_dict(action_config)
+
+        assert result["labels"]["yelp.com/cost_owner"] == "data-eng"
+
+    def test_cost_owner_label_absent_when_gate_disabled(self):
+        action_dict = {
+            "command": "echo hello",
+            "service": "my_service",
+            "deploy_group": "prod",
+            "executor": "paasta",
+            "cost_owner": "data-eng",
+        }
+        branch_dict = {
+            "docker_image": "my_service:paasta-123abcde",
+            "git_sha": "aabbcc44",
+            "desired_state": "start",
+            "force_bounce": None,
+        }
+        action_config = tron_tools.TronActionConfig(
+            service="my_service",
+            instance=tron_tools.compose_instance("my_job", "do_something"),
+            config_dict=action_dict,
+            branch_dict=branch_dict,
+            cluster="test-cluster",
+        )
+        with mock.patch.object(
+            action_config,
+            "get_docker_registry",
+            return_value="docker-registry.com:400",
+        ), mock.patch(
+            "paasta_tools.utils.InstanceConfig.use_docker_disk_quota",
+            autospec=True,
+            return_value=False,
+        ), mock.patch(
+            "paasta_tools.tron_tools.load_system_paasta_config",
+            autospec=True,
+            return_value=MOCK_SYSTEM_PAASTA_CONFIG,
+        ), mock.patch(
+            "paasta_tools.tron_tools.add_volumes_for_authenticating_services",
+            autospec=True,
+            return_value=[],
+        ):
+            result = tron_tools.format_tron_action_dict(action_config)
+
+        assert "yelp.com/cost_owner" not in result["labels"]
+
+    def test_cost_owner_label_absent_when_not_configured(self):
+        action_dict = {
+            "command": "echo hello",
+            "service": "my_service",
+            "deploy_group": "prod",
+            "executor": "paasta",
+        }
+        branch_dict = {
+            "docker_image": "my_service:paasta-123abcde",
+            "git_sha": "aabbcc44",
+            "desired_state": "start",
+            "force_bounce": None,
+        }
+        action_config = tron_tools.TronActionConfig(
+            service="my_service",
+            instance=tron_tools.compose_instance("my_job", "do_something"),
+            config_dict=action_dict,
+            branch_dict=branch_dict,
+            cluster="test-cluster",
+        )
+        mock_system_config = utils.SystemPaastaConfig(
+            utils.SystemPaastaConfigDict(
+                {
+                    "docker_registry": "mock_registry",
+                    "volumes": [],
+                    "dockercfg_location": "/mock/dockercfg",
+                    "enable_cost_owner_label": True,
+                    "enable_tron_tsc": True,
+                }
+            ),
+            "/mock/system/configs",
+        )
+        with mock.patch.object(
+            action_config,
+            "get_docker_registry",
+            return_value="docker-registry.com:400",
+        ), mock.patch(
+            "paasta_tools.utils.InstanceConfig.use_docker_disk_quota",
+            autospec=True,
+            return_value=False,
+        ), mock.patch(
+            "paasta_tools.tron_tools.load_system_paasta_config",
+            autospec=True,
+            return_value=mock_system_config,
+        ), mock.patch(
+            "paasta_tools.tron_tools.add_volumes_for_authenticating_services",
+            autospec=True,
+            return_value=[],
+        ):
+            result = tron_tools.format_tron_action_dict(action_config)
+
+        assert "yelp.com/cost_owner" not in result["labels"]

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -2291,16 +2291,14 @@ fake_job:
 
 
 class TestCostOwnerLabel:
-    # autospec=None is used here because we're passing a pre-configured Mock as the
-    # new value rather than letting patch create one with autospec constraints.
     @pytest.fixture(autouse=True)
     def mock_read_monitoring_config(self):
         with mock.patch(
             "paasta_tools.monitoring_tools.read_monitoring_config",
-            mock.Mock(return_value={"team": "default_team"}),
-            autospec=None,
-        ) as f:
-            yield f
+            return_value={"team": "default_team"},
+            autospec=True,
+        ):
+            yield
 
     @mock.patch(
         "paasta_tools.tron_tools.load_system_paasta_config",
@@ -2362,7 +2360,7 @@ class TestCostOwnerLabel:
         assert actions[0].get_cost_owner() == "ml-team"
 
     @mock.patch(
-        "paasta_tools.tron_tools.read_service_configuration",
+        "paasta_tools.tron_tools._cached_read_service_configuration",
         autospec=True,
         return_value={"cost_owner": "platform-eng"},
     )

--- a/tests/test_tron_tools.py
+++ b/tests/test_tron_tools.py
@@ -2360,7 +2360,7 @@ class TestCostOwnerLabel:
         assert actions[0].get_cost_owner() == "ml-team"
 
     @mock.patch(
-        "paasta_tools.tron_tools._cached_read_service_configuration",
+        "paasta_tools.tron_tools.cached_read_service_configuration",
         autospec=True,
         return_value={"cost_owner": "platform-eng"},
     )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2075,6 +2075,22 @@ class TestInstanceConfig:
         )
         assert fake_conf.get_extra_volumes() == fake_extra_volumes
 
+    def test_get_cost_owner(self):
+        fake_conf = utils.InstanceConfig(
+            service="",
+            cluster="",
+            instance="",
+            config_dict={"cost_owner": "compute-infra-batch"},
+            branch_dict=None,
+        )
+        assert fake_conf.get_cost_owner() == "compute-infra-batch"
+
+    def test_get_cost_owner_default(self):
+        fake_conf = utils.InstanceConfig(
+            service="", cluster="", instance="", config_dict={}, branch_dict=None
+        )
+        assert fake_conf.get_cost_owner() is None
+
     def test_get_pool(self):
         pool = "poolname"
         fake_conf = utils.InstanceConfig(
@@ -3021,3 +3037,15 @@ class TestGetDefaultBounceOverprovisionFactor:
             directory="/fake/dir",
         )
         assert config.get_bounce_overprovision_factor() == 1.0
+
+
+def test_SystemPaastaConfig_get_enable_cost_owner_label_default():
+    fake_config = utils.SystemPaastaConfig({}, "/some/fake/dir")
+    assert fake_config.get_enable_cost_owner_label() is False
+
+
+def test_SystemPaastaConfig_get_enable_cost_owner_label_enabled():
+    fake_config = utils.SystemPaastaConfig(
+        {"enable_cost_owner_label": True}, "/some/fake/dir"
+    )
+    assert fake_config.get_enable_cost_owner_label() is True


### PR DESCRIPTION
## Overview

Add a new Kubernetes pod label `yelp.com/cost_owner` to all pods managed by PaaSTA — both long-running EKS services and Tron jobs. The label value comes from soa-config files (`service.yaml` with instance/action-level overrides). 

This enables cost monitoring systems to attribute compute spend to the correct owning team at the pod level.

There will be a separate set of PRs in yelpsoa-configs that adds this metadata in for all services via recurring batch jobs. Teams will be informed that they can modify this at an instance level.

## Tech spec with all the details
https://docs.google.com/document/d/1jYWkNizn--1Hhmf_DANg9h9wmaZFa4c4SCMMdmu9ku4/edit?tab=t.np4y4uvd0upy#heading=h.kycyvvor8o1u

## Rollout plan

This is disabled by default and gated behind a puppet config. See further details [here](https://docs.google.com/document/d/1jYWkNizn--1Hhmf_DANg9h9wmaZFa4c4SCMMdmu9ku4/edit?tab=t.np4y4uvd0upy#heading=h.pi0efdafniks). 

## Discussion with CI (luisp) about design choices for more context
https://yelp.slack.com/archives/C0ARHDH4WSG/p1777047093823859

## Testing on paasta playground
I modified some of the playground files as seen in the below diff
https://fluffy.yelpcorp.com/i/pGLBqjjRNJwV81QtBLG90HhtfSR5qGSX.html

A couple of additional files to the playground were required
```
cat k8s_itests/deployments/paasta/fake_etc_paasta/cost_owner.json
{
    "enable_cost_owner_label": true
}

cat general_itests/fake_soa_configs_tron/fake_simple_service/service.yaml
---
cost_owner: data-eng
```

Then running the playground I was able to verify that the expected labels showed up on the service pods with the right inheritance

```
╰─ KUBECONFIG=./k8s_itests/kubeconfig kubectl get pods -n paastasvc-compute-infra-test-service -l "paasta.yelp.com/instance=autoscaling,paasta.yelp.com/config_sha=configbcca568a" -o custom-columns='NAME:.metadata.name,COST_OWNER:.metadata.labels.yelp\.com/cost_owner'                                   
NAME                                                      COST_OWNER
compute-infra-test-service-autoscaling-869586ff9f-5dxrt   compute-infrastructure-batch
compute-infra-test-service-autoscaling-869586ff9f-5hjvr   compute-infrastructure-batch
compute-infra-test-service-autoscaling-869586ff9f-5znw2   compute-infrastructure-batch
compute-infra-test-service-autoscaling-869586ff9f-82xnl   compute-infrastructure-batch
compute-infra-test-service-autoscaling-869586ff9f-97xjx   compute-infrastructure-batch
compute-infra-test-service-autoscaling-869586ff9f-bg686   compute-infrastructure-batch
compute-infra-test-service-autoscaling-869586ff9f-hfsxf   compute-infrastructure-batch
compute-infra-test-service-autoscaling-869586ff9f-jx85c   compute-infrastructure-batch
compute-infra-test-service-autoscaling-869586ff9f-p6ms8   compute-infrastructure-batch
compute-infra-test-service-autoscaling-869586ff9f-sx7jt   compute-infrastructure-batch


╰─ KUBECONFIG=./k8s_itests/kubeconfig kubectl get pods -n paastasvc-compute-infra-test-service -l "paasta.yelp.com/instance=cost-owner-override-test" -o custom-columns='NAME:.metadata.name,COST_OWNER:.metadata.labels.yelp\.com/cost_owner'                                                                
NAME                                                              COST_OWNER
compute-infra-test-service-cost-owner-override-test-75f7d5vvscr   compute-infrastructure-services

```

For tron testing it looks like we can't launch pods like paasta instances but the tronfigs are inheriting the right values now. [Full output](https://fluffy.yelpcorp.com/i/DC274MBf5LWVsV3SFwHzJlcdMsgbc6xR.html)

```
╰─ PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_playground/ .tox/py310-linux/bin/python -m paasta_tools.setup_tron_namespace --dry-run -a --soa-dir general_itests/fake_soa_configs_tron --cluster test-cluster 2>&1 | grep -A 2 "yelp.com/cost_owner"
          yelp.com/cost_owner: ml-team
          yelp.com/owner: compute_infra_platform_experience
        mem: 4096
--
          yelp.com/cost_owner: platform-eng
          yelp.com/owner: compute_infra_platform_experience
        mem: 4096
--
          yelp.com/cost_owner: data-eng
          yelp.com/owner: compute_infra_platform_experience
        mem: 4096
--
          yelp.com/cost_owner: data-eng
          yelp.com/owner: compute_infra_platform_experience
        mem: 4096
```