### PR TITLE
fix: broken os.errno usage and mutable defaults in render_template

### DIFF
--- a/paasta_tools/contrib/render_template.py
+++ b/paasta_tools/contrib/render_template.py
@@ -36,7 +36,11 @@ def write_file(dst, name, src, values):
             new.write(replace(old.read(), values))
 
 
-def render(src, dst, values={}, exclude={}, overwrite=True):
+def render(src, dst, values=None, exclude=None, overwrite=True):
+    if values is None:
+        values = {}
+    if exclude is None:
+        exclude = set()
     if os.path.isfile(src):
         render_file(src, dst, values, overwrite)
         return
@@ -47,11 +51,7 @@ def render(src, dst, values={}, exclude={}, overwrite=True):
             render_file(f.path, dst, values, overwrite)
         else:
             new_dst = replace(f"{dst}/{f.name}", values)
-            try:
-                os.makedirs(new_dst, exist_ok=True)
-            except OSError as e:
-                if e.errno != os.errno.EEXIST:
-                    raise
+            os.makedirs(new_dst, exist_ok=True)
             render(f.path, new_dst, values, exclude, overwrite)
 
 


### PR DESCRIPTION
`render_template.py` has two bugs in the `render()` function.

os.errno is gone in Python 3. The try/except around makedirs checked `os.errno.EEXIST`, but `os.errno` was removed in Python 3. So if makedirs raises any non-EEXIST OSError (like permission denied), instead of re-raising it you get `AttributeError: module 'os' has no attribute 'errno'` -- the real error is swallowed. The fix is to drop the try/except since `exist_ok=True` already handles the EEXIST case anyway.

Mutable default args. `values={}` and `exclude={}` are shared across calls (classic Python gotcha). Switched to `None` with in-body init. Also corrected `exclude` default from `{}` (dict) to `set()`, which matches how callers actually pass it.

How to reproduce the AttributeError:
```python
import os, stat, tempfile
from paasta_tools.contrib.render_template import render

with tempfile.TemporaryDirectory() as tmp:
    src = tmp + '/src'
    dst = tmp + '/dst'
    os.makedirs(src + '/subdir')
    os.makedirs(dst)
    os.chmod(dst, stat.S_IRUSR | stat.S_IXUSR)  # no write perms
    render(src, dst)  # raises AttributeError instead of PermissionError
```