### PR TITLE
Automatically rollback after persistent crashlooping

### DIFF
--- a/docs/source/deploy_groups.rst
+++ b/docs/source/deploy_groups.rst
@@ -144,3 +144,39 @@ As an example the following deploy.yaml will execute steps ``security-check`` & 
    - step: prod.canary
      trigger_next_step_manually: true
    - step: prod.non_canary
+
+Crashloop auto-rollback
+------------------------
+
+When ``wait_for_deployment`` is active, PaaSTA can automatically roll back if the new
+version is persistently crashlooping (or OOMing - anything that restarts the underlying Pods).
+This is configured per deploy_group in deploy.yaml:
+
+* ``enable_crashloop_auto_rollback`` (boolean, optional): Enable or disable crashloop
+  detection for this step.
+  NOTE: this feature may be enabled or disabled at the PaaSTA cluster-level: this value overrides that state
+
+* ``min_restarts_for_crashloop_rollback`` (integer, optional): Number of container restarts
+  per replica before considering it crashlooping. (default: 2).
+
+* ``crashloop_rollback_percentage_threshold`` (float 0-1, optional): Fraction of replicas
+  that must be crashlooping to trigger the rollback.
+  (default: 1.0, i.e., all replicas must be crashlooping).
+
+Once triggered, the rollback countdown starts and can only be cancelled by a human in Slack.
+
+A replica recovering does not cancel the rollback under the assumption that if we've had had enough repeated restarts
+across all replicas, something is fundamentally unsafe with the new deployment.
+
+.. sourcecode:: yaml
+
+   # deploy.yaml
+   ---
+   pipeline:
+   - step: prod.canary
+     trigger_next_step_manually: true
+     enable_crashloop_auto_rollback: true
+     min_restarts_for_crashloop_rollback: 3
+     crashloop_rollback_percentage_threshold: 0.8
+   - step: prod.non_canary
+     enable_crashloop_auto_rollback: true

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -29,6 +29,7 @@ import socket
 import sys
 import time
 import traceback
+from collections import defaultdict
 from enum import Enum
 from threading import Thread
 from typing import Any
@@ -109,6 +110,7 @@ DEFAULT_WARN_PERCENT = 17  # ~30min for default timeout
 DEFAULT_AUTO_CERTIFY_DELAY = 600  # seconds
 DEFAULT_SLACK_CHANNEL = "#deploy"
 DEFAULT_STUCK_BOUNCE_RUNBOOK = "y/stuckbounce"
+MIN_CONSECUTIVE_CRASHES_FOR_ROLLBACK = 2
 
 
 log = logging.getLogger(__name__)
@@ -496,7 +498,7 @@ def paasta_mark_for_deployment(args: argparse.Namespace) -> int:
     deployment_version = DeploymentVersion(commit, args.image_version)
 
     old_deployment_version = get_currently_deployed_version(
-        service=service, deploy_group=deploy_group
+        service=service, deploy_group=deploy_group, soa_dir=args.soa_dir
     )
     if deployment_version == old_deployment_version:
         print(
@@ -708,8 +710,25 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
             service, deploy_group, soa_dir
         )
 
+        self.crashloop_auto_rollback_enabled = (
+            load_system_paasta_config().get_enable_crashloop_auto_rollback()
+        )
+
         # Keep track of each wait_for_deployment task so we can cancel it.
         self.wait_for_deployment_tasks: Dict[DeploymentVersion, asyncio.Task] = {}
+
+        # this is maybe slightly funky, but we keep track of what instances are crashlooping
+        # (even though we rollback at the deploy group granularity)
+        # and we consider an instance crashlooping if it's been seeing crashing N times
+        # in a row (at the time of writing, N=2).
+        # we do this with a per-instance counter rather than just relying on the state machine
+        # since (atm, at least) we don't have data on how long diagnosis can take - i.e., for
+        # our large monoliths, will the PaaSTA API always return a response fast enough for us
+        # to actually have probed for failures N times?
+        # NOTE: the key here is (cluster, instance_name)
+        self._crashloop_checks_by_instance: Dict[Tuple[str, str], int] = defaultdict(
+            int
+        )
 
         self.human_readable_status = "Waiting on mark-for-deployment to initialize..."
         self.progress = Progress()
@@ -988,6 +1007,17 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
                 "before": self.log_metric_rollback,
             }
             yield {
+                "source": self.rollforward_states,
+                "dest": "start_rollback",
+                "trigger": "rollback_crashloop_failure",
+                "before": self.log_crashloop_rollback,
+            }
+            yield {
+                "source": self.rollback_states,
+                "dest": None,
+                "trigger": "rollback_crashloop_failure",
+            }
+            yield {
                 "source": self.rollback_states,
                 "dest": "start_deploy",
                 "trigger": "forward_button_clicked",
@@ -1074,6 +1104,23 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
             "trigger": "metrics_stopped_failing",
             "before": functools.partial(
                 self.cancel_auto_rollback_countdown, "rollback_metric_failure"
+            ),
+        }
+        yield {
+            "source": "*",
+            "dest": None,
+            "trigger": "crashloops_started_failing",
+            "unless": [self.already_rolling_back],
+            "before": functools.partial(
+                self.start_auto_rollback_countdown, "rollback_crashloop_failure"
+            ),
+        }
+        yield {
+            "source": "*",
+            "dest": None,
+            "trigger": "crashloops_stopped_failing",
+            "before": functools.partial(
+                self.cancel_auto_rollback_countdown, "rollback_crashloop_failure"
             ),
         }
         yield {
@@ -1271,6 +1318,13 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
                     notify_fn=self.ping_authors,
                     metrics_interface=self.metrics_interface,
                     rollback_type=rollback_type,
+                    # NOTE: we pass this as an arg 'cause wait_for_deployment() is not an instance method and therefore
+                    # doesn't have access to on_crashloop_detected()
+                    # ...and we can't easily make wait_for_deployment() an instance method 'cause we reuse that in places
+                    # where we don't want a MarkForDeploymentProcess (e.g., the `wait-for-deployment` CLI :p)
+                    crashloop_fn=self.on_crashloop_detected
+                    if self.crashloop_auto_rollback_enabled
+                    else None,
                 )
             )
             self.wait_for_deployment_tasks[target_version] = wait_for_deployment_task
@@ -1320,6 +1374,10 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         elif self.any_metric_failing() and self.auto_rollbacks_enabled():
             self.ping_authors(
                 "Because a rollback-triggering metric for this service is currently failing, we will not automatically certify. Instead, we will wait indefinitely until you click one of the buttons above."
+            )
+        elif self.any_crashloop_failing():
+            self.ping_authors(
+                "Because the new deployment has replicas that are repeatedly crashing, we will not automatically certify. Instead, we will wait indefinitely until you click one of the buttons above."
             )
         else:
             if self.get_auto_certify_delay() > 0:
@@ -1457,6 +1515,38 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         )
         self._log_rollback(rollback_details)
 
+    def log_crashloop_rollback(self) -> None:
+        self.rollback_type = RollbackTypes.AUTOMATIC_CRASHLOOP_ROLLBACK
+        rollback_details = self.__build_rollback_audit_details(
+            RollbackTypes.AUTOMATIC_CRASHLOOP_ROLLBACK
+        )
+        self._log_rollback(rollback_details)
+
+    def any_crashloop_failing(self) -> bool:
+        return any(
+            # XXX: make this configureable in deploy.yaml?
+            count >= MIN_CONSECUTIVE_CRASHES_FOR_ROLLBACK
+            for count in self._crashloop_checks_by_instance.values()
+        )
+
+    def on_crashloop_detected(
+        self, cluster: str, instance: str, is_crashlooping: bool
+    ) -> None:
+        key = (cluster, instance)
+        was_any = self.any_crashloop_failing()
+
+        if is_crashlooping:
+            self._crashloop_checks_by_instance[key] += 1
+        else:
+            self._crashloop_checks_by_instance.pop(key, None)
+
+        is_any = self.any_crashloop_failing()
+
+        if is_any and not was_any:
+            self.trigger("crashloops_started_failing")
+        elif not is_any and was_any:
+            self.trigger("crashloops_stopped_failing")
+
     def log_user_rollback(self) -> None:
         self.rollback_type = RollbackTypes.USER_INITIATED_ROLLBACK
         rollback_details = self.__build_rollback_audit_details(
@@ -1502,6 +1592,7 @@ async def wait_until_instance_is_done(
     time_before_first_diagnosis: float,
     should_ping_for_unhealthy_pods: bool,
     notify_fn: Optional[Callable[[str], None]] = None,
+    crashloop_fn: Optional[Callable[[str, str, bool], None]] = None,
 ) -> Tuple[str, str]:
     loop = asyncio.get_running_loop()
     diagnosis_task = asyncio.create_task(
@@ -1516,6 +1607,7 @@ async def wait_until_instance_is_done(
             time_before_first_diagnosis,
             should_ping_for_unhealthy_pods,
             notify_fn,
+            crashloop_fn,
         )
     )
     try:
@@ -1550,12 +1642,15 @@ async def periodically_diagnose_instance(
     time_before_first_diagnosis: float,
     should_ping_for_unhealthy_pods: bool,
     notify_fn: Optional[Callable[[str], None]] = None,
+    crashloop_fn: Optional[Callable[[str, str, bool], None]] = None,
 ) -> None:
     await asyncio.sleep(time_before_first_diagnosis)
     loop = asyncio.get_running_loop()
     while True:
         try:
-            await loop.run_in_executor(
+            # XXX: might be worth extracting the status call so that we don't have to return a value from here
+            # to prevent making multiple potentially expensive status calls
+            is_currently_crashing = await loop.run_in_executor(
                 executor,
                 functools.partial(
                     diagnose_why_instance_is_stuck,
@@ -1568,6 +1663,11 @@ async def periodically_diagnose_instance(
                     notify_fn,
                 ),
             )
+            # i am sorry, but it was either pass through a callback function or do some funky global shenanigans
+            # to be able to store some state here :(
+            if crashloop_fn and is_currently_crashing is not None:
+                # NOTE: this should always be the on_crashloop_detected() function from MarkForDeploymentProcess
+                crashloop_fn(cluster, instance, is_currently_crashing)
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -1584,7 +1684,16 @@ def diagnose_why_instance_is_stuck(
     instance_config: LongRunningServiceConfig,
     should_ping_for_unhealthy_pods: bool,
     notify_fn: Optional[Callable[[str], None]] = None,
-) -> None:
+) -> Optional[bool]:
+    """
+    Periodically check instance health state. Has 3 possible return values:
+    * None: unable to talk to the PaaSTA API
+    * True: all pods are crashlooping and the instance is definitely stuck
+    * False: all pods are healthy (or only a subset are failing)
+
+    ... if we refactor this a tad so that periodically_diagnose_instance()
+    calls status_instance() once and passes that down, we can remove this retval :p
+    """
     api = client.get_paasta_oapi_client(
         cluster=get_paasta_oapi_api_clustername(
             cluster=cluster,
@@ -1604,7 +1713,7 @@ def diagnose_why_instance_is_stuck(
             "Error getting service status from PaaSTA API for "
             f"{cluster}: {e.status} {e.reason}"
         )
-        return
+        return None
 
     print(f"  Status for {service}.{instance} in {cluster}:")
     for active_version in status.kubernetes_v2.versions:
@@ -1630,6 +1739,10 @@ def diagnose_why_instance_is_stuck(
         maybe_ping_for_unhealthy_pods(
             service, instance, cluster, version, status, notify_fn
         )
+
+    # XXX: make this configurable in deploy.yaml so that you can pick a different % than 100%?
+    # that said...normally code is either broken or not ime
+    return all_pods_crashlooping(version, status)
 
 
 already_pinged = False
@@ -1665,6 +1778,21 @@ def maybe_ping_for_unhealthy_pods(
 
 def should_ping_for_pod(pod: KubernetesPodV2) -> bool:
     return recent_container_restart(get_main_container(pod))
+
+
+def all_pods_crashlooping(
+    version: DeploymentVersion,
+    status: InstanceStatusKubernetesV2,
+) -> bool:
+    pods = [
+        pod
+        for v in status.kubernetes_v2.versions
+        if v.git_sha == version.sha and v.image_version == version.image_version
+        for pod in v.pods
+    ]
+    return len(pods) > 0 and all(
+        recent_container_restart(get_main_container(pod)) for pod in pods
+    )
 
 
 def ping_for_pods(
@@ -1924,6 +2052,7 @@ async def wait_for_deployment(
     notify_fn: Optional[Callable[[str], None]] = None,
     metrics_interface: Optional[metrics_lib.BaseMetrics] = None,
     rollback_type: Optional[RollbackTypes] = None,
+    crashloop_fn: Optional[Callable[[str, str, bool], None]] = None,
 ) -> Optional[int]:
     if not instance_configs_per_cluster:
         instance_configs_per_cluster = (
@@ -1992,6 +2121,7 @@ async def wait_for_deployment(
                                     system_paasta_config.get_mark_for_deployment_should_ping_for_unhealthy_pods()
                                 ),
                                 notify_fn=notify_fn,
+                                crashloop_fn=crashloop_fn,
                             ),
                         )
                     )

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -1524,7 +1524,7 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
 
     def any_crashloop_failing(self) -> bool:
         return any(
-            # XXX: make this configureable in deploy.yaml?
+            # XXX: make this configurable in deploy.yaml?
             count >= MIN_CONSECUTIVE_CRASHES_FOR_ROLLBACK
             for count in self._crashloop_checks_by_instance.values()
         )

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -29,7 +29,6 @@ import socket
 import sys
 import time
 import traceback
-from collections import defaultdict
 from enum import Enum
 from threading import Thread
 from typing import Any
@@ -710,28 +709,25 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         )
 
         system_paasta_config = load_system_paasta_config()
-        self.crashloop_auto_rollback_enabled = (
-            system_paasta_config.get_enable_crashloop_auto_rollback()
+        self.crashloop_auto_rollback_enabled = self._get_deploy_group_config(
+            "enable_crashloop_auto_rollback",
+            system_paasta_config.get_enable_crashloop_auto_rollback(),
         )
-        self.min_consecutive_crashes_for_rollback = (
-            system_paasta_config.get_min_consecutive_crashes_for_rollback()
+        self.min_restarts_for_crashloop_rollback = self._get_deploy_group_config(
+            "min_restarts_for_crashloop_rollback",
+            system_paasta_config.get_min_restarts_for_crashloop_rollback(),
+        )
+        self.crashloop_rollback_percentage_threshold = self._get_deploy_group_config(
+            "crashloop_rollback_percentage_threshold",
+            system_paasta_config.get_crashloop_rollback_percentage_threshold(),
         )
 
         # Keep track of each wait_for_deployment task so we can cancel it.
         self.wait_for_deployment_tasks: Dict[DeploymentVersion, asyncio.Task] = {}
 
-        # this is maybe slightly funky, but we keep track of what instances are crashlooping
-        # (even though we rollback at the deploy group granularity)
-        # and we consider an instance crashlooping if it's been seeing crashing N times
-        # in a row (at the time of writing, N=2).
-        # we do this with a per-instance counter rather than just relying on the state machine
-        # since (atm, at least) we don't have data on how long diagnosis can take - i.e., for
-        # our large monoliths, will the PaaSTA API always return a response fast enough for us
-        # to actually have probed for failures N times?
-        # NOTE: the key here is (cluster, instance_name)
-        self._crashloop_checks_by_instance: Dict[Tuple[str, str], int] = defaultdict(
-            int
-        )
+        # Track which instances are currently crashlooping (by (cluster, instance) key).
+        # We trigger rollback as soon as any instance reports all pods crashlooping.
+        self._crashlooping_instances: Set[Tuple[str, str]] = set()
 
         self.human_readable_status = "Waiting on mark-for-deployment to initialize..."
         self.progress = Progress()
@@ -1121,14 +1117,6 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         yield {
             "source": "*",
             "dest": None,
-            "trigger": "crashloops_stopped_failing",
-            "before": functools.partial(
-                self.cancel_auto_rollback_countdown, "rollback_crashloop_failure"
-            ),
-        }
-        yield {
-            "source": "*",
-            "dest": None,
             "trigger": "snooze_button_clicked",
             "before": self.restart_timer,
             "conditions": [self.is_timer_running],
@@ -1328,6 +1316,8 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
                     crashloop_fn=self.on_crashloop_detected
                     if self.crashloop_auto_rollback_enabled
                     else None,
+                    min_restarts_for_crashloop_rollback=self.min_restarts_for_crashloop_rollback,
+                    crashloop_rollback_percentage_threshold=self.crashloop_rollback_percentage_threshold,
                 )
             )
             self.wait_for_deployment_tasks[target_version] = wait_for_deployment_task
@@ -1494,6 +1484,12 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
             self.deploy_info, self.deploy_group, notify_type
         )
 
+    def _get_deploy_group_config(self, key: str, default: Any) -> Any:
+        for step in self.deploy_info.get("pipeline", []):
+            if step.get("step", "") == self.deploy_group:
+                return step.get(key, default)
+        return default
+
     def __build_rollback_audit_details(
         self, rollback_type: RollbackTypes
     ) -> Dict[str, str]:
@@ -1526,29 +1522,20 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         self._log_rollback(rollback_details)
 
     def any_crashloop_failing(self) -> bool:
-        return any(
-            # XXX: make this configureable in deploy.yaml?
-            count >= self.min_consecutive_crashes_for_rollback
-            for count in self._crashloop_checks_by_instance.values()
-        )
+        return len(self._crashlooping_instances) > 0
 
     def on_crashloop_detected(
         self, cluster: str, instance: str, is_crashlooping: bool
     ) -> None:
+        if not is_crashlooping:
+            return
+
         key = (cluster, instance)
         was_any = self.any_crashloop_failing()
+        self._crashlooping_instances.add(key)
 
-        if is_crashlooping:
-            self._crashloop_checks_by_instance[key] += 1
-        else:
-            self._crashloop_checks_by_instance.pop(key, None)
-
-        is_any = self.any_crashloop_failing()
-
-        if is_any and not was_any:
+        if not was_any:
             self.trigger("crashloops_started_failing")
-        elif not is_any and was_any:
-            self.trigger("crashloops_stopped_failing")
 
     def log_user_rollback(self) -> None:
         self.rollback_type = RollbackTypes.USER_INITIATED_ROLLBACK
@@ -1596,6 +1583,8 @@ async def wait_until_instance_is_done(
     should_ping_for_unhealthy_pods: bool,
     notify_fn: Optional[Callable[[str], None]] = None,
     crashloop_fn: Optional[Callable[[str, str, bool], None]] = None,
+    min_restarts_for_crashloop_rollback: int = 2,
+    crashloop_rollback_percentage_threshold: float = 1.0,
 ) -> Tuple[str, str]:
     loop = asyncio.get_running_loop()
     diagnosis_task = asyncio.create_task(
@@ -1611,6 +1600,8 @@ async def wait_until_instance_is_done(
             should_ping_for_unhealthy_pods,
             notify_fn,
             crashloop_fn,
+            min_restarts_for_crashloop_rollback,
+            crashloop_rollback_percentage_threshold,
         )
     )
     try:
@@ -1646,14 +1637,19 @@ async def periodically_diagnose_instance(
     should_ping_for_unhealthy_pods: bool,
     notify_fn: Optional[Callable[[str], None]] = None,
     crashloop_fn: Optional[Callable[[str, str, bool], None]] = None,
+    min_restarts_for_crashloop_rollback: int = 2,
+    crashloop_rollback_percentage_threshold: float = 1.0,
 ) -> None:
     await asyncio.sleep(time_before_first_diagnosis)
     loop = asyncio.get_running_loop()
+    # None means "first probe hasn't happened yet" — we can't use an empty dict because
+    # that would make every pod look like it increased from 0, triggering on the first probe.
+    baseline_restart_counts: Optional[Dict[str, int]] = None
     while True:
         try:
             # XXX: might be worth extracting the status call so that we don't have to return a value from here
             # to prevent making multiple potentially expensive status calls
-            is_currently_crashing = await loop.run_in_executor(
+            restart_counts = await loop.run_in_executor(
                 executor,
                 functools.partial(
                     diagnose_why_instance_is_stuck,
@@ -1668,9 +1664,18 @@ async def periodically_diagnose_instance(
             )
             # i am sorry, but it was either pass through a callback function or do some funky global shenanigans
             # to be able to store some state here :(
-            if crashloop_fn and is_currently_crashing is not None:
-                # NOTE: this should always be the on_crashloop_detected() function from MarkForDeploymentProcess
-                crashloop_fn(cluster, instance, is_currently_crashing)
+            if crashloop_fn and restart_counts is not None:
+                if baseline_restart_counts is None:
+                    baseline_restart_counts = restart_counts
+                else:
+                    is_crashlooping = pods_above_crashloop_threshold(
+                        restart_counts,
+                        baseline_restart_counts,
+                        min_restarts=min_restarts_for_crashloop_rollback,
+                        percentage_threshold=crashloop_rollback_percentage_threshold,
+                    )
+                    # NOTE: this should always be the on_crashloop_detected() function from MarkForDeploymentProcess
+                    crashloop_fn(cluster, instance, is_crashlooping)
         except asyncio.CancelledError:
             raise
         except Exception:
@@ -1687,15 +1692,11 @@ def diagnose_why_instance_is_stuck(
     instance_config: LongRunningServiceConfig,
     should_ping_for_unhealthy_pods: bool,
     notify_fn: Optional[Callable[[str], None]] = None,
-) -> Optional[bool]:
+) -> Optional[Dict[str, int]]:
     """
-    Periodically check instance health state. Has 3 possible return values:
+    Periodically check instance health state. Returns:
     * None: unable to talk to the PaaSTA API
-    * True: all pods are crashlooping and the instance is definitely stuck
-    * False: all pods are healthy (or only a subset are failing)
-
-    ... if we refactor this a tad so that periodically_diagnose_instance()
-    calls status_instance() once and passes that down, we can remove this retval :p
+    * Dict[str, int]: pod_name → restart_count for pods of the target version
     """
     api = client.get_paasta_oapi_client(
         cluster=get_paasta_oapi_api_clustername(
@@ -1743,9 +1744,7 @@ def diagnose_why_instance_is_stuck(
             service, instance, cluster, version, status, notify_fn
         )
 
-    # XXX: make this configurable in deploy.yaml so that you can pick a different % than 100%?
-    # that said...normally code is either broken or not ime
-    return all_pods_crashlooping(version, status)
+    return get_pod_restart_counts(version, status)
 
 
 already_pinged = False
@@ -1783,19 +1782,39 @@ def should_ping_for_pod(pod: KubernetesPodV2) -> bool:
     return recent_container_restart(get_main_container(pod))
 
 
-def all_pods_crashlooping(
+def get_pod_restart_counts(
     version: DeploymentVersion,
     status: InstanceStatusKubernetesV2,
-) -> bool:
+) -> Dict[str, int]:
     pods = [
         pod
         for v in status.kubernetes_v2.versions
         if v.git_sha == version.sha and v.image_version == version.image_version
         for pod in v.pods
     ]
-    return len(pods) > 0 and all(
-        recent_container_restart(get_main_container(pod)) for pod in pods
+    result: Dict[str, int] = {}
+    for pod in pods:
+        container = get_main_container(pod)
+        if container is not None:
+            result[pod.name] = container.restart_count
+    return result
+
+
+def pods_above_crashloop_threshold(
+    current_counts: Dict[str, int],
+    baseline_counts: Dict[str, int],
+    min_restarts: int = 2,
+    percentage_threshold: float = 1.0,
+) -> bool:
+    if not current_counts:
+        return False
+
+    crashlooping_count = sum(
+        1
+        for pod_name, count in current_counts.items()
+        if count >= min_restarts and count > baseline_counts.get(pod_name, 0)
     )
+    return (crashlooping_count / len(current_counts)) >= percentage_threshold
 
 
 def ping_for_pods(
@@ -2056,6 +2075,8 @@ async def wait_for_deployment(
     metrics_interface: Optional[metrics_lib.BaseMetrics] = None,
     rollback_type: Optional[RollbackTypes] = None,
     crashloop_fn: Optional[Callable[[str, str, bool], None]] = None,
+    min_restarts_for_crashloop_rollback: int = 2,
+    crashloop_rollback_percentage_threshold: float = 1.0,
 ) -> Optional[int]:
     if not instance_configs_per_cluster:
         instance_configs_per_cluster = (
@@ -2125,6 +2146,8 @@ async def wait_for_deployment(
                                 ),
                                 notify_fn=notify_fn,
                                 crashloop_fn=crashloop_fn,
+                                min_restarts_for_crashloop_rollback=min_restarts_for_crashloop_rollback,
+                                crashloop_rollback_percentage_threshold=crashloop_rollback_percentage_threshold,
                             ),
                         )
                     )

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -1534,6 +1534,9 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         was_any = self.any_crashloop_failing()
         self._crashlooping_instances.add(key)
 
+        # Only fire on the first instance that reports crashlooping — if multiple instances
+        # are in the deploy group, subsequent True reports won't re-trigger (preventing the
+        # rollback countdown from restarting multiple times).
         if not was_any:
             self.trigger("crashloops_started_failing")
 

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -110,7 +110,6 @@ DEFAULT_WARN_PERCENT = 17  # ~30min for default timeout
 DEFAULT_AUTO_CERTIFY_DELAY = 600  # seconds
 DEFAULT_SLACK_CHANNEL = "#deploy"
 DEFAULT_STUCK_BOUNCE_RUNBOOK = "y/stuckbounce"
-MIN_CONSECUTIVE_CRASHES_FOR_ROLLBACK = 2
 
 
 log = logging.getLogger(__name__)
@@ -710,8 +709,12 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
             service, deploy_group, soa_dir
         )
 
+        system_paasta_config = load_system_paasta_config()
         self.crashloop_auto_rollback_enabled = (
-            load_system_paasta_config().get_enable_crashloop_auto_rollback()
+            system_paasta_config.get_enable_crashloop_auto_rollback()
+        )
+        self.min_consecutive_crashes_for_rollback = (
+            system_paasta_config.get_min_consecutive_crashes_for_rollback()
         )
 
         # Keep track of each wait_for_deployment task so we can cancel it.
@@ -1524,8 +1527,8 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
 
     def any_crashloop_failing(self) -> bool:
         return any(
-            # XXX: make this configurable in deploy.yaml?
-            count >= MIN_CONSECUTIVE_CRASHES_FOR_ROLLBACK
+            # XXX: make this configureable in deploy.yaml?
+            count >= self.min_consecutive_crashes_for_rollback
             for count in self._crashloop_checks_by_instance.values()
         )
 

--- a/paasta_tools/cli/schemas/deploy_schema.json
+++ b/paasta_tools/cli/schemas/deploy_schema.json
@@ -105,6 +105,17 @@
                 "enable_automated_redeploys": {
                     "type": "boolean"
                 },
+                "enable_crashloop_auto_rollback": {
+                    "type": "boolean"
+                },
+                "min_restarts_for_crashloop_rollback": {
+                    "type": "integer"
+                },
+                "crashloop_rollback_percentage_threshold": {
+                    "type": "number",
+                    "minimum": 0,
+                    "maximum": 1
+                },
                 "service_account": {
                     "type": "string"
                 }

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1960,6 +1960,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     mark_for_deployment_default_default_time_before_first_diagnosis: float
     mark_for_deployment_should_ping_for_unhealthy_pods: bool
     enable_crashloop_auto_rollback: bool
+    min_consecutive_crashes_for_rollback: int
     mesos_config: Dict
     metrics_provider: str
     monitoring_config: Dict
@@ -2657,6 +2658,9 @@ class SystemPaastaConfig:
 
     def get_enable_crashloop_auto_rollback(self) -> bool:
         return self.config_dict.get("enable_crashloop_auto_rollback", False)
+
+    def get_min_consecutive_crashes_for_rollback(self) -> int:
+        return self.config_dict.get("min_consecutive_crashes_for_rollback", 2)
 
     def get_spark_k8s_role(self) -> str:
         return self.config_dict.get("spark_k8s_role", "spark")

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1960,7 +1960,8 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     mark_for_deployment_default_default_time_before_first_diagnosis: float
     mark_for_deployment_should_ping_for_unhealthy_pods: bool
     enable_crashloop_auto_rollback: bool
-    min_consecutive_crashes_for_rollback: int
+    min_restarts_for_crashloop_rollback: int
+    crashloop_rollback_percentage_threshold: float
     mesos_config: Dict
     metrics_provider: str
     monitoring_config: Dict
@@ -2659,8 +2660,11 @@ class SystemPaastaConfig:
     def get_enable_crashloop_auto_rollback(self) -> bool:
         return self.config_dict.get("enable_crashloop_auto_rollback", False)
 
-    def get_min_consecutive_crashes_for_rollback(self) -> int:
-        return self.config_dict.get("min_consecutive_crashes_for_rollback", 2)
+    def get_min_restarts_for_crashloop_rollback(self) -> int:
+        return self.config_dict.get("min_restarts_for_crashloop_rollback", 2)
+
+    def get_crashloop_rollback_percentage_threshold(self) -> float:
+        return self.config_dict.get("crashloop_rollback_percentage_threshold", 1.0)
 
     def get_spark_k8s_role(self) -> str:
         return self.config_dict.get("spark_k8s_role", "spark")

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -190,6 +190,7 @@ CAPS_DROP = [
 class RollbackTypes(Enum):
     AUTOMATIC_SLO_ROLLBACK = "automatic_slo_rollback"
     AUTOMATIC_METRIC_ROLLBACK = "automatic_metric_rollback"
+    AUTOMATIC_CRASHLOOP_ROLLBACK = "automatic_crashloop_rollback"
     USER_INITIATED_ROLLBACK = "user_initiated_rollback"
 
 
@@ -1958,6 +1959,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     mark_for_deployment_default_diagnosis_interval: float
     mark_for_deployment_default_default_time_before_first_diagnosis: float
     mark_for_deployment_should_ping_for_unhealthy_pods: bool
+    enable_crashloop_auto_rollback: bool
     mesos_config: Dict
     metrics_provider: str
     monitoring_config: Dict
@@ -2652,6 +2654,9 @@ class SystemPaastaConfig:
         return self.config_dict.get(
             "mark_for_deployment_should_ping_for_unhealthy_pods", True
         )
+
+    def get_enable_crashloop_auto_rollback(self) -> bool:
+        return self.config_dict.get("enable_crashloop_auto_rollback", False)
 
     def get_spark_k8s_role(self) -> str:
         return self.config_dict.get("spark_k8s_role", "spark")

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -1118,7 +1118,6 @@ def test_MarkForDeployProcess_crashloop_triggers_rollback(
     ):
         if target_commit == "commit":
             self.on_crashloop_detected("cluster1", "instance1", True)
-            self.on_crashloop_detected("cluster1", "instance1", True)
         # this case handles the automatic rollback so that we don't loop forever :p
         else:
             self.trigger("deploy_finished")
@@ -1164,10 +1163,10 @@ def test_MarkForDeployProcess_crashloop_triggers_rollback(
         assert "start_rollback" in mfdp.state_history
 
 
-def test_MarkForDeployProcess_crashloop_stopped_cancels_countdown(
+def test_MarkForDeployProcess_crashloop_recovery_does_not_cancel(
     mock_periodically_update_slack,
 ):
-    """When crashloops resolve before the countdown, the cancel trigger fires."""
+    """Once crashlooping is detected, recovery does not cancel the rollback countdown."""
     with patch(
         "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
         autospec=True,
@@ -1190,26 +1189,23 @@ def test_MarkForDeployProcess_crashloop_stopped_cancels_countdown(
             authors=None,
         )
 
+    mfdp.state = "deploying"
     mfdp.trigger_history.clear()
 
-    # First detection — not enough to trigger
-    mfdp.on_crashloop_detected("cluster1", "instance1", True)
-    assert "crashloops_started_failing" not in mfdp.trigger_history
-
-    # Second consecutive detection — triggers
     mfdp.on_crashloop_detected("cluster1", "instance1", True)
     assert "crashloops_started_failing" in mfdp.trigger_history
 
     mfdp.trigger_history.clear()
+    # Recovery reported — should NOT cancel
     mfdp.on_crashloop_detected("cluster1", "instance1", False)
-    assert "crashloops_stopped_failing" in mfdp.trigger_history
-    assert not mfdp.any_crashloop_failing()
+    assert "crashloops_stopped_failing" not in mfdp.trigger_history
+    assert mfdp.any_crashloop_failing()
 
 
 def test_on_crashloop_detected_multi_instance_aggregation(
     mock_periodically_update_slack,
 ):
-    """Only fires trigger on first crashlooping instance, and only stops when all recover."""
+    """Only fires trigger on first crashlooping instance; recovery never clears."""
     with patch(
         "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
         autospec=True,
@@ -1232,33 +1228,29 @@ def test_on_crashloop_detected_multi_instance_aggregation(
             authors=None,
         )
 
+    mfdp.state = "deploying"
     mfdp.trigger_history.clear()
 
-    # inst1: first detection — not yet triggered
-    mfdp.on_crashloop_detected("cluster1", "inst1", True)
-    assert "crashloops_started_failing" not in mfdp.trigger_history
-
-    # inst1: second consecutive detection — triggers
+    # inst1: first detection — triggers immediately
     mfdp.on_crashloop_detected("cluster1", "inst1", True)
     assert "crashloops_started_failing" in mfdp.trigger_history
 
     mfdp.trigger_history.clear()
-    # inst2: first detection — already failing so no new trigger
-    mfdp.on_crashloop_detected("cluster1", "inst2", True)
+    # inst2: also crashlooping — already failing so no new trigger
     mfdp.on_crashloop_detected("cluster1", "inst2", True)
     assert "crashloops_started_failing" not in mfdp.trigger_history
 
     mfdp.trigger_history.clear()
-    # inst1 recovers, but inst2 still failing
+    # inst1 reports recovery — still failing (no recovery logic)
     mfdp.on_crashloop_detected("cluster1", "inst1", False)
     assert "crashloops_stopped_failing" not in mfdp.trigger_history
     assert mfdp.any_crashloop_failing()
 
     mfdp.trigger_history.clear()
-    # inst2 recovers — all clear
+    # inst2 reports recovery — still failing (no recovery logic)
     mfdp.on_crashloop_detected("cluster1", "inst2", False)
-    assert "crashloops_stopped_failing" in mfdp.trigger_history
-    assert not mfdp.any_crashloop_failing()
+    assert "crashloops_stopped_failing" not in mfdp.trigger_history
+    assert mfdp.any_crashloop_failing()
 
 
 def test_crashloop_auto_rollback_disabled_does_not_pass_crashloop_fn(
@@ -1279,7 +1271,7 @@ def test_crashloop_auto_rollback_disabled_does_not_pass_crashloop_fn(
         autospec=True,
         return_value=mock_config,
     ):
-        mfdp = mark_for_deployment.MarkForDeploymentProcess(
+        mfdp = WrappedMarkForDeploymentProcess(
             service="service",
             deploy_info={"pipeline": []},
             deploy_group="deploy_group",
@@ -1300,77 +1292,86 @@ def test_crashloop_auto_rollback_disabled_does_not_pass_crashloop_fn(
     assert mfdp.crashloop_auto_rollback_enabled is False
 
 
-def test_all_pods_crashlooping_returns_true_when_all_crash():
+def test_pods_above_crashloop_threshold_all_crashing():
+    current_counts = {"pod1": 3, "pod2": 4}
+    baseline_counts = {"pod1": 1, "pod2": 1}
+    assert (
+        mark_for_deployment.pods_above_crashloop_threshold(
+            current_counts, baseline_counts, min_restarts=2
+        )
+        is True
+    )
+
+
+def test_pods_above_crashloop_threshold_no_increase():
+    current_counts = {"pod1": 2, "pod2": 2}
+    baseline_counts = {"pod1": 2, "pod2": 2}
+    assert (
+        mark_for_deployment.pods_above_crashloop_threshold(
+            current_counts, baseline_counts, min_restarts=2
+        )
+        is False
+    )
+
+
+def test_pods_above_crashloop_threshold_below_min_restarts():
+    current_counts = {"pod1": 1, "pod2": 1}
+    baseline_counts = {"pod1": 0, "pod2": 0}
+    assert (
+        mark_for_deployment.pods_above_crashloop_threshold(
+            current_counts, baseline_counts, min_restarts=2
+        )
+        is False
+    )
+
+
+def test_pods_above_crashloop_threshold_percentage():
+    current_counts = {"pod1": 3, "pod2": 3, "pod3": 0}
+    baseline_counts = {"pod1": 1, "pod2": 1, "pod3": 0}
+    assert (
+        mark_for_deployment.pods_above_crashloop_threshold(
+            current_counts, baseline_counts, min_restarts=2, percentage_threshold=0.5
+        )
+        is True
+    )
+    assert (
+        mark_for_deployment.pods_above_crashloop_threshold(
+            current_counts, baseline_counts, min_restarts=2, percentage_threshold=1.0
+        )
+        is False
+    )
+
+
+def test_pods_above_crashloop_threshold_new_pods():
+    current_counts = {"pod1": 3, "pod_new": 3}
+    baseline_counts = {"pod1": 1}
+    assert (
+        mark_for_deployment.pods_above_crashloop_threshold(
+            current_counts, baseline_counts, min_restarts=2
+        )
+        is True
+    )
+
+
+def test_get_pod_restart_counts_ignores_old_version():
     version = DeploymentVersion(sha="abc123", image_version=None)
-    pod1 = MagicMock(spec=KubernetesPodV2)
-    pod2 = MagicMock(spec=KubernetesPodV2)
-
-    version_status = MagicMock()
-    version_status.git_sha = "abc123"
-    version_status.image_version = None
-    version_status.pods = [pod1, pod2]
-
-    status = MagicMock()
-    status.kubernetes_v2.versions = [version_status]
-
-    with patch(
-        "paasta_tools.cli.cmds.mark_for_deployment.recent_container_restart",
-        autospec=True,
-        return_value=True,
-    ), patch(
-        "paasta_tools.cli.cmds.mark_for_deployment.get_main_container",
-        autospec=True,
-    ):
-        assert mark_for_deployment.all_pods_crashlooping(version, status) is True
-
-
-def test_all_pods_crashlooping_returns_false_when_healthy():
-    version = DeploymentVersion(sha="abc123", image_version=None)
-    pod_healthy = MagicMock(spec=KubernetesPodV2)
-
-    version_status = MagicMock()
-    version_status.git_sha = "abc123"
-    version_status.image_version = None
-    version_status.pods = [pod_healthy]
-
-    status = MagicMock()
-    status.kubernetes_v2.versions = [version_status]
-
-    with patch(
-        "paasta_tools.cli.cmds.mark_for_deployment.recent_container_restart",
-        autospec=True,
-        return_value=False,
-    ), patch(
-        "paasta_tools.cli.cmds.mark_for_deployment.get_main_container",
-        autospec=True,
-    ):
-        assert mark_for_deployment.all_pods_crashlooping(version, status) is False
-
-
-def test_all_pods_crashlooping_ignores_old_version():
-    version = DeploymentVersion(sha="abc123", image_version=None)
-    pod_crashlooping = MagicMock(spec=KubernetesPodV2)
 
     old_version_status = MagicMock()
     old_version_status.git_sha = "old_sha"
     old_version_status.image_version = None
-    old_version_status.pods = [pod_crashlooping]
+    old_version_status.pods = [MagicMock(spec=KubernetesPodV2)]
 
     status = MagicMock()
     status.kubernetes_v2.versions = [old_version_status]
 
     with patch(
-        "paasta_tools.cli.cmds.mark_for_deployment.recent_container_restart",
-        autospec=True,
-        return_value=True,
-    ), patch(
         "paasta_tools.cli.cmds.mark_for_deployment.get_main_container",
         autospec=True,
     ):
-        assert mark_for_deployment.all_pods_crashlooping(version, status) is False
+        assert mark_for_deployment.get_pod_restart_counts(version, status) == {}
 
 
-def test_diagnose_why_instance_is_stuck_returns_crashloop_status():
+def test_diagnose_why_instance_is_stuck_returns_restart_counts():
     mock_api = MagicMock()
     mock_status = MagicMock()
     mock_status.kubernetes_v2.versions = []
@@ -1389,9 +1390,9 @@ def test_diagnose_why_instance_is_stuck_returns_crashloop_status():
         autospec=True,
         return_value="cluster1",
     ), patch(
-        "paasta_tools.cli.cmds.mark_for_deployment.all_pods_crashlooping",
+        "paasta_tools.cli.cmds.mark_for_deployment.get_pod_restart_counts",
         autospec=True,
-        return_value=True,
+        return_value={"pod1": 3, "pod2": 4},
     ):
         result = mark_for_deployment.diagnose_why_instance_is_stuck(
             service="service",
@@ -1403,7 +1404,7 @@ def test_diagnose_why_instance_is_stuck_returns_crashloop_status():
             notify_fn=None,
         )
 
-    assert result is True
+    assert result == {"pod1": 3, "pod2": 4}
 
 
 def test_log_crashloop_rollback():

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -25,10 +25,34 @@ from pytest import fixture
 from pytest import raises
 from slackclient import SlackClient
 
+from paasta_tools import utils
 from paasta_tools.cli.cmds import mark_for_deployment
+from paasta_tools.long_running_service_tools import LongRunningServiceConfig
+from paasta_tools.paastaapi.models import KubernetesPodV2
 from paasta_tools.utils import DeploymentVersion
 from paasta_tools.utils import RollbackTypes
 from paasta_tools.utils import TimeoutError
+
+MOCK_SYSTEM_PAASTA_CONFIG = utils.SystemPaastaConfig(
+    utils.SystemPaastaConfigDict(
+        # empty for now since we don't really read anything from here atm
+        # ...but this should stop us from writing tests that won't work on
+        # GitHub Actions + should make it so that we have one less super-common mock
+        # in all our tests :D
+        {},
+    ),
+    "/mock/system/configs",
+)
+
+
+@fixture(autouse=True)
+def mock_load_system_paasta_config():
+    with patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config",
+        autospec=True,
+        return_value=MOCK_SYSTEM_PAASTA_CONFIG,
+    ):
+        yield
 
 
 @fixture(autouse=True)
@@ -788,8 +812,8 @@ class WrappedMarkForDeploymentProcess(mark_for_deployment.MarkForDeploymentProce
         }
         return fake_slack_client
 
-    def start_timer(self, timeout, trigger, message_verb):
-        return super().start_timer(0, trigger, message_verb)
+    def start_timer(self, timeout, trigger, message_verb, **kwargs):
+        return super().start_timer(0, trigger, message_verb, **kwargs)
 
     def after_state_change(self, *args, **kwargs):
         self.state_history.append(self.state)
@@ -964,9 +988,6 @@ def test_MarkForDeployProcess_get_available_buttons_failing_slos_show_disable_ro
 def test_MarkForDeployProcess_send_manual_rollback_instructions_with_no_old_git_sha():
     """Test that rollback instructions are not sent when old_git_sha is None (new deploy group)."""
     with mock.patch(
-        "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config",
-        autospec=True,
-    ), mock.patch(
         "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
         autospec=True,
     ):
@@ -1000,9 +1021,6 @@ def test_MarkForDeployProcess_send_manual_rollback_instructions_with_no_old_git_
 def test_MarkForDeployProcess_send_manual_rollback_instructions_with_old_git_sha():
     """Test that rollback instructions are sent when old_git_sha is set."""
     with mock.patch(
-        "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config",
-        autospec=True,
-    ), mock.patch(
         "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
         autospec=True,
     ):
@@ -1037,9 +1055,6 @@ def test_MarkForDeployProcess_send_manual_rollback_instructions_same_version():
     """Test that rollback instructions are not sent when deployment versions are the same."""
     same_sha = "same_commit_sha"
     with mock.patch(
-        "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config",
-        autospec=True,
-    ), mock.patch(
         "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
         autospec=True,
     ):
@@ -1091,3 +1106,340 @@ def test_slo_transcoder_is_importable():
     from sticht.rollbacks.slo import SLO_TRANSCODER_LOADED
 
     assert SLO_TRANSCODER_LOADED is True
+
+
+def test_MarkForDeployProcess_crashloop_triggers_rollback(
+    mock_periodically_update_slack,
+):
+    """When crashloops are detected during deploying, the state machine transitions to rollback."""
+
+    def simulate_crashloop(
+        self, target_commit, target_image_version, rollback_type=None
+    ):
+        if target_commit == "commit":
+            self.on_crashloop_detected("cluster1", "instance1", True)
+            self.on_crashloop_detected("cluster1", "instance1", True)
+        # this case handles the automatic rollback so that we don't loop forever :p
+        else:
+            self.trigger("deploy_finished")
+
+    with patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
+        autospec=True,
+    ), patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.mark_for_deployment",
+        autospec=True,
+        return_value=0,
+    ), patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.MarkForDeploymentProcess.do_wait_for_deployment",
+        autospec=True,
+        # this is slighlty funky, but this is a little easier than really going through do_wait_for_deployment()
+        side_effect=simulate_crashloop,
+    ), patch(
+        "paasta_tools.cli.cmds.mark_for_deployment._log",
+        autospec=True,
+    ):
+        mfdp = WrappedMarkForDeploymentProcess(
+            service="service",
+            deploy_info={"pipeline": []},
+            deploy_group="deploy_group",
+            commit="commit",
+            old_git_sha="old_git_sha",
+            git_url="git_url",
+            auto_rollback=False,
+            block=True,
+            soa_dir="soa_dir",
+            timeout=3600,
+            warn_pct=50,
+            auto_certify_delay=None,
+            auto_abandon_delay=600,
+            auto_rollback_delay=30,
+            authors=None,
+        )
+
+        mfdp.run_timeout = 1
+        assert mfdp.run() == 1
+        assert "crashloops_started_failing" in mfdp.trigger_history
+        assert "rollback_crashloop_failure" in mfdp.trigger_history
+        assert "start_rollback" in mfdp.state_history
+
+
+def test_MarkForDeployProcess_crashloop_stopped_cancels_countdown(
+    mock_periodically_update_slack,
+):
+    """When crashloops resolve before the countdown, the cancel trigger fires."""
+    with patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
+        autospec=True,
+    ):
+        mfdp = WrappedMarkForDeploymentProcess(
+            service="service",
+            deploy_info={"pipeline": []},
+            deploy_group="deploy_group",
+            commit="commit",
+            old_git_sha="old_git_sha",
+            git_url="git_url",
+            auto_rollback=False,
+            block=True,
+            soa_dir="soa_dir",
+            timeout=3600,
+            warn_pct=50,
+            auto_certify_delay=None,
+            auto_abandon_delay=600,
+            auto_rollback_delay=30,
+            authors=None,
+        )
+
+    mfdp.trigger_history.clear()
+
+    # First detection — not enough to trigger
+    mfdp.on_crashloop_detected("cluster1", "instance1", True)
+    assert "crashloops_started_failing" not in mfdp.trigger_history
+
+    # Second consecutive detection — triggers
+    mfdp.on_crashloop_detected("cluster1", "instance1", True)
+    assert "crashloops_started_failing" in mfdp.trigger_history
+
+    mfdp.trigger_history.clear()
+    mfdp.on_crashloop_detected("cluster1", "instance1", False)
+    assert "crashloops_stopped_failing" in mfdp.trigger_history
+    assert not mfdp.any_crashloop_failing()
+
+
+def test_on_crashloop_detected_multi_instance_aggregation(
+    mock_periodically_update_slack,
+):
+    """Only fires trigger on first crashlooping instance, and only stops when all recover."""
+    with patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
+        autospec=True,
+    ):
+        mfdp = WrappedMarkForDeploymentProcess(
+            service="service",
+            deploy_info={"pipeline": []},
+            deploy_group="deploy_group",
+            commit="commit",
+            old_git_sha="old_git_sha",
+            git_url="git_url",
+            auto_rollback=False,
+            block=True,
+            soa_dir="soa_dir",
+            timeout=3600,
+            warn_pct=50,
+            auto_certify_delay=None,
+            auto_abandon_delay=600,
+            auto_rollback_delay=30,
+            authors=None,
+        )
+
+    mfdp.trigger_history.clear()
+
+    # inst1: first detection — not yet triggered
+    mfdp.on_crashloop_detected("cluster1", "inst1", True)
+    assert "crashloops_started_failing" not in mfdp.trigger_history
+
+    # inst1: second consecutive detection — triggers
+    mfdp.on_crashloop_detected("cluster1", "inst1", True)
+    assert "crashloops_started_failing" in mfdp.trigger_history
+
+    mfdp.trigger_history.clear()
+    # inst2: first detection — already failing so no new trigger
+    mfdp.on_crashloop_detected("cluster1", "inst2", True)
+    mfdp.on_crashloop_detected("cluster1", "inst2", True)
+    assert "crashloops_started_failing" not in mfdp.trigger_history
+
+    mfdp.trigger_history.clear()
+    # inst1 recovers, but inst2 still failing
+    mfdp.on_crashloop_detected("cluster1", "inst1", False)
+    assert "crashloops_stopped_failing" not in mfdp.trigger_history
+    assert mfdp.any_crashloop_failing()
+
+    mfdp.trigger_history.clear()
+    # inst2 recovers — all clear
+    mfdp.on_crashloop_detected("cluster1", "inst2", False)
+    assert "crashloops_stopped_failing" in mfdp.trigger_history
+    assert not mfdp.any_crashloop_failing()
+
+
+def test_crashloop_auto_rollback_disabled_does_not_pass_crashloop_fn(
+    mock_periodically_update_slack,
+):
+    # NOTE: we don't have this as the default 'cause we're going to remove this toggle
+    # (and this test) entirely once we're fully rolled out :p
+    mock_config = utils.SystemPaastaConfig(
+        utils.SystemPaastaConfigDict({"enable_crashloop_auto_rollback": False}),
+        "/mock/system/configs",
+    )
+
+    with patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
+        autospec=True,
+    ), patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config",
+        autospec=True,
+        return_value=mock_config,
+    ):
+        mfdp = mark_for_deployment.MarkForDeploymentProcess(
+            service="service",
+            deploy_info={"pipeline": []},
+            deploy_group="deploy_group",
+            commit="commit",
+            old_git_sha="old_git_sha",
+            git_url="git_url",
+            auto_rollback=False,
+            block=True,
+            soa_dir="soa_dir",
+            timeout=3600,
+            warn_pct=50,
+            auto_certify_delay=None,
+            auto_abandon_delay=600,
+            auto_rollback_delay=30,
+            authors=None,
+        )
+
+    assert mfdp.crashloop_auto_rollback_enabled is False
+
+
+def test_all_pods_crashlooping_returns_true_when_all_crash():
+    version = DeploymentVersion(sha="abc123", image_version=None)
+    pod1 = MagicMock(spec=KubernetesPodV2)
+    pod2 = MagicMock(spec=KubernetesPodV2)
+
+    version_status = MagicMock()
+    version_status.git_sha = "abc123"
+    version_status.image_version = None
+    version_status.pods = [pod1, pod2]
+
+    status = MagicMock()
+    status.kubernetes_v2.versions = [version_status]
+
+    with patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.recent_container_restart",
+        autospec=True,
+        return_value=True,
+    ), patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.get_main_container",
+        autospec=True,
+    ):
+        assert mark_for_deployment.all_pods_crashlooping(version, status) is True
+
+
+def test_all_pods_crashlooping_returns_false_when_healthy():
+    version = DeploymentVersion(sha="abc123", image_version=None)
+    pod_healthy = MagicMock(spec=KubernetesPodV2)
+
+    version_status = MagicMock()
+    version_status.git_sha = "abc123"
+    version_status.image_version = None
+    version_status.pods = [pod_healthy]
+
+    status = MagicMock()
+    status.kubernetes_v2.versions = [version_status]
+
+    with patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.recent_container_restart",
+        autospec=True,
+        return_value=False,
+    ), patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.get_main_container",
+        autospec=True,
+    ):
+        assert mark_for_deployment.all_pods_crashlooping(version, status) is False
+
+
+def test_all_pods_crashlooping_ignores_old_version():
+    version = DeploymentVersion(sha="abc123", image_version=None)
+    pod_crashlooping = MagicMock(spec=KubernetesPodV2)
+
+    old_version_status = MagicMock()
+    old_version_status.git_sha = "old_sha"
+    old_version_status.image_version = None
+    old_version_status.pods = [pod_crashlooping]
+
+    status = MagicMock()
+    status.kubernetes_v2.versions = [old_version_status]
+
+    with patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.recent_container_restart",
+        autospec=True,
+        return_value=True,
+    ), patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.get_main_container",
+        autospec=True,
+    ):
+        assert mark_for_deployment.all_pods_crashlooping(version, status) is False
+
+
+def test_diagnose_why_instance_is_stuck_returns_crashloop_status():
+    mock_api = MagicMock()
+    mock_status = MagicMock()
+    mock_status.kubernetes_v2.versions = []
+    mock_api.service.status_instance.return_value = mock_status
+
+    version = DeploymentVersion(sha="abc123", image_version=None)
+    instance_config = MagicMock(spec=LongRunningServiceConfig)
+    instance_config.get_instance_type.return_value = "kubernetes"
+
+    with patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.client.get_paasta_oapi_client",
+        autospec=True,
+        return_value=mock_api,
+    ), patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.get_paasta_oapi_api_clustername",
+        autospec=True,
+        return_value="cluster1",
+    ), patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.all_pods_crashlooping",
+        autospec=True,
+        return_value=True,
+    ):
+        result = mark_for_deployment.diagnose_why_instance_is_stuck(
+            service="service",
+            instance="instance",
+            cluster="cluster1",
+            version=version,
+            instance_config=instance_config,
+            should_ping_for_unhealthy_pods=False,
+            notify_fn=None,
+        )
+
+    assert result is True
+
+
+def test_log_crashloop_rollback():
+    with patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
+        autospec=True,
+        return_value={"cluster1": []},
+    ):
+        mfdp = WrappedMarkForDeploymentProcess(
+            service="service",
+            deploy_info={"pipeline": []},
+            deploy_group="deploy_group",
+            commit="commit",
+            old_git_sha="old_git_sha",
+            git_url="git_url",
+            auto_rollback=False,
+            block=False,
+            soa_dir="soa_dir",
+            timeout=3600,
+            warn_pct=50,
+            auto_certify_delay=None,
+            auto_abandon_delay=600,
+            auto_rollback_delay=30,
+            authors=None,
+        )
+
+    with patch(
+        "paasta_tools.cli.cmds.mark_for_deployment._log_audit",
+        autospec=True,
+    ) as mock_log_audit:
+        mfdp.log_crashloop_rollback()
+
+    mock_log_audit.assert_called_once()
+    call_kwargs = mock_log_audit.call_args[1]
+    assert call_kwargs["action"] == "rollback"
+    assert (
+        call_kwargs["action_details"]["rollback_type"]
+        == RollbackTypes.AUTOMATIC_CRASHLOOP_ROLLBACK.value
+    )


### PR DESCRIPTION
If we're crashing consistently, something has probably gone wrong and we don't want to keep trying to deploy in the interest of not wasting compute on broken code :)

(and also, so that we don't leave a timebomb after the deployment times out if no one is watching: should this happen, the next deployment would skip the broken deploy group and impact prod)

To enable this, I'm ;iggybacking off of our existing code for diagnosing stuck/slow bounces: after `time_before_first_diagnosis` seconds, we start checking pod restart counts. If all pods have:
1. `restart_count >= min_restarts_for_crashloop_rollback` (new config option, default: 2), AND
2. `restart_count > baseline` (i.e., at least one new restart since we started watching)

...then we immediately trigger the autorollback sequence

The baseline comparison prevents false positives from pods that crashed at startup but recovered — we only roll back if crashes are happening during the diagnosis loop

Once triggered, the only way to exit the autorollback state is to click the Slack buttons in the deploy thread: it's not exactly obvious when/if a Pod has recovered for things like OOMKills as those might take a couple minutes but still be prevalent enough to prevent a deployment from completing (and also: if your code crashed N times already during this deployment, it's broken :p)

NOTE: The tests are all `claude`-authored (which is great 'cause mocking some of the paasta api bits would have been kinda annoying by hand atm :p)

that said, I've also done some manual testing in the paasta playground to ensure that the tests aren't providing me a false sense of security:

(note: `cb9e0385` is a "good" SHA and an actual commit in the compute-infra-test-service repo, and `c1413ea9` only exists on my devbox and is an image that always runs `exit 1`)

With crashloop rollback enabled in deploy.yaml and default diagnosis parameters (5min delay, 60s interval) when marking c1413ea9:

```
Would update the slack thread with: Marked `c1413ea9` for prod.main.
Would update the slack thread with: Will automatically roll back in 30 seconds, (at 14:15:42)! Click "Disable auto rollbacks :close_eyes_monkey:" to cancel this!
Would update the slack thread with: Time's up, will now automatically roll back.
Would update the slack thread with: Marked `cb9e0385` for prod.main.
```

Total time from deploy to rollback: ~6.5 minutes (300s first diagnosis delay + 60s second probe + 30s countdown).

With crashloop rollback disabled, diagnosis parameters tuned down so that i didn't have to wait so long, and the m-f-d wrapped with a `timeout 90`: none of the rollback messages showed up and the command was killed after 90 seconds, but i still saw the diagnosis output show up 

NOTE2: I've refactored this quite a bit from the initial version after a conversation with rofe made me realize there were some edge cases I hadn't considered earlier (spurred on by a question about whether or not this would catch OOMKills and rollback on 'em) :p
...which also made me go ahead and add deploy.yaml configs/toggles for things since this is more opinionated now