### PR TITLE
Added --hostname to docker run command for spark-run

### DIFF
--- a/paasta_tools/cli/cmds/spark_run.py
+++ b/paasta_tools/cli/cmds/spark_run.py
@@ -537,6 +537,7 @@ def get_docker_run_cmd(
     cmd.append(f"--cpus={docker_cpu_limit}")
     cmd.append("--rm")
     cmd.append("--net=host")
+    cmd.append(f"--hostname={socket.getfqdn()}")
 
     non_interactive_cmd = ["spark-submit", "history-server"]
     if not any(c in docker_cmd for c in non_interactive_cmd):


### PR DESCRIPTION
For spark-run to work properly on yelp's internal dev-boxes, hostname needs to be fqdn instead of short name
By adding --hostname to docker run command, spark.driver.host gets the fqdn instead of the short name and fixes the error
```
Caused by: java.net.UnknownHostException:
```