### PR TITLE
Flink restart support - trying out security check

### DIFF
--- a/paasta_tools/cli/cmds/start_stop_restart.py
+++ b/paasta_tools/cli/cmds/start_stop_restart.py
@@ -382,35 +382,40 @@ def paasta_restart(args):
                     affected_non_flinks.append(service_config)
 
     if affected_flinks:
-        flinks_info = ", ".join([f"{f.service}.{f.instance}" for f in affected_flinks])
+        system_paasta_config = load_system_paasta_config()
+        for service_config in affected_flinks:
+            cluster = service_config.cluster
+            service = service_config.service
+            instance = service_config.instance
+            is_eks = isinstance(service_config, FlinkEksDeploymentConfig)
+
+            client = get_paasta_oapi_client(
+                cluster=get_paasta_oapi_api_clustername(cluster=cluster, is_eks=is_eks),
+                system_paasta_config=system_paasta_config,
+            )
+            if not client:
+                print("Cannot get a paasta-api client")
+                return 1
+
+            try:
+                client.service.instance_set_state(
+                    service=service,
+                    instance=instance,
+                    desired_state="restart",
+                )
+            except client.api_error as exc:
+                print(exc.reason)
+                return exc.status
+
         print(
-            f"WARN: paasta restart is currently unsupported for Flink instances ({flinks_info})."
+            "'Restart' will tell the Flink operator to stop and start the cluster. "
+            "This may take some time to complete."
         )
-        print("To restart, please run:", end="\n\n")
-        for flink in affected_flinks:
-            print(
-                f"paasta stop -s {flink.service} -i {flink.instance} -c {flink.cluster}"
-            )
-            print(
-                f"paasta start -s {flink.service} -i {flink.instance} -c {flink.cluster}",
-                end="\n\n",
-            )
 
-        if not affected_non_flinks:
-            return 1
+    if affected_non_flinks:
+        return paasta_start(args)
 
-        non_flinks_info = ", ".join(
-            [f"{f.service}.{f.instance}" for f in affected_non_flinks]
-        )
-        proceed = choice.Binary(
-            f"Would you like to restart the other instances ({non_flinks_info}) anyway?",
-            False,
-        ).ask()
-
-        if not proceed:
-            return 1
-
-    return paasta_start(args)
+    return 0
 
 
 PAASTA_STOP_UNDERSPECIFIED_ARGS_MESSAGE = PaastaColors.red(

--- a/paasta_tools/cli/cmds/status.py
+++ b/paasta_tools/cli/cmds/status.py
@@ -795,11 +795,6 @@ def append_pod_status(pod_status, output: List[str]):
     output.extend([f"      {line}" for line in pods_table])
 
 
-OUTPUT_HORIZONTAL_RULE = (
-    "=================================================================="
-)
-
-
 def _print_flink_status_from_job_manager(
     service: str,
     instance: str,
@@ -822,12 +817,15 @@ def _print_flink_status_from_job_manager(
         return 1
 
     labels = metadata.get("labels", {})
+    annotations = metadata.get("annotations", {})
     config_sha = labels.get(paasta_prefixed("config_sha"), "").removeprefix("config")
+    desired_state = annotations.get(paasta_prefixed("desired_state"))
     output.append(f"    Config SHA: {config_sha}")
 
     # Initialize all vars upfront; populated only when cluster is running
     dashboard_url = None
     overview = None
+    instance_details: Optional[flink_tools.FlinkInstanceDetails] = None
     jobs: List[FlinkJobDetails] = []
     job_ids: List[str] = []
     checkpoint_data: Dict[str, Union[FlinkCheckpointStatus, BaseException]] = {}
@@ -857,22 +855,6 @@ def _print_flink_status_from_job_manager(
 
         if verbose:
             output.extend(flink_tools.format_flink_udf_info(flink_instance_config))
-            output.extend(
-                flink_tools.format_flink_instance_metadata(instance_details, service)
-            )
-            ecosystem = system_paasta_config.get_ecosystem_for_cluster(cluster)
-            output.extend(flink_tools.format_flink_config_links(service, ecosystem))
-            output.append(OUTPUT_HORIZONTAL_RULE)
-            output.extend(
-                flink_tools.format_flink_log_commands(service, instance, cluster)
-            )
-            output.append(OUTPUT_HORIZONTAL_RULE)
-            output.extend(
-                flink_tools.format_flink_monitoring_links(
-                    service, instance, ecosystem, cluster
-                )
-            )
-            output.append(OUTPUT_HORIZONTAL_RULE)
 
         try:
             overview = flink_tools.get_flink_overview_from_paasta_api_client(
@@ -909,7 +891,9 @@ def _print_flink_status_from_job_manager(
             except Exception:
                 pass  # checkpoints are informational, don't fail status
 
-    job_details = flink_tools.collect_flink_job_details(status, overview)
+    job_details = flink_tools.collect_flink_job_details(
+        status, overview, desired_state=desired_state
+    )
     output.extend(flink_tools.format_flink_state_and_pods(job_details))
 
     if not flink_tools.should_job_info_be_shown(status["state"]):
@@ -929,6 +913,20 @@ def _print_flink_status_from_job_manager(
 
     if verbose and len(status["pod_status"]) > 0:
         append_pod_status(status["pod_status"], output)
+
+    if verbose and instance_details is not None:
+        ecosystem = system_paasta_config.get_ecosystem_for_cluster(cluster)
+        output.extend(
+            flink_tools.format_flink_instance_metadata(
+                instance_details, service, ecosystem
+            )
+        )
+        output.extend(
+            flink_tools.format_flink_monitoring_links(
+                service, instance, ecosystem, cluster
+            )
+        )
+        output.extend(flink_tools.format_flink_log_commands(service, instance, cluster))
     return 0
 
 

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -88,6 +88,7 @@ class JobCounts(TypedDict):
 
 class FlinkJobDetailsDict(TypedDict):
     state: str
+    desired_state: Optional[str]
     pod_counts: PodCounts
     job_counts: Optional[JobCounts]
     taskmanagers: Optional[int]
@@ -482,13 +483,16 @@ def format_flink_instance_header(
 
     if verbose:
         output.append(
-            f"    Flink version: {details['version']} {details['version_revision']}"
+            f"    Flink:      {details['version']} {details['version_revision']}"
         )
     else:
-        output.append(f"    Flink version: {details['version']}")
+        output.append(f"    Flink:      {details['version']}")
 
     if details.get("dashboard_url"):
-        output.append(f"    URL: {details['dashboard_url']}/")
+        url = f"{details['dashboard_url']}/"
+        output.append(
+            f"    Dashboard:  {PaastaColors.terminal_link(url, 'y/flink-dashboard')}"
+        )
 
     return output
 
@@ -503,35 +507,54 @@ def format_flink_udf_info(config: FlinkDeploymentConfig) -> List[str]:
 
 
 def format_flink_instance_metadata(
-    details: FlinkInstanceDetails, service: str
+    details: FlinkInstanceDetails, service: str, ecosystem: str
 ) -> List[str]:
-    """Format verbose instance metadata (repo links, pool, owner, runbook)."""
+    """Format verbose instance metadata (repo links, pool, owner, runbook, configs)."""
     output: List[str] = []
-    output.append(f"    Repo(git): https://github.yelpcorp.com/services/{service}")
+    output.append("    Links:")
+    git_url = f"https://github.yelpcorp.com/services/{service}"
+    sg_url = f"https://sourcegraph.yelpcorp.com/services/{service}"
     output.append(
-        f"    Repo(sourcegraph): https://sourcegraph.yelpcorp.com/services/{service}"
+        f"      Repo:       {PaastaColors.terminal_link(git_url, 'y/github')}"
+        f" | {PaastaColors.terminal_link(sg_url, 'sourcegraph')}"
     )
     if details.get("pool"):
-        output.append(f"    Flink Pool: {details['pool']}")
+        output.append(f"      Pool:       {details['pool']}")
     if details.get("team"):
-        output.append(f"    Owner: {details['team']}")
+        output.append(f"      Owner:      {details['team']}")
     if details.get("runbook"):
-        output.append(f"    Flink Runbook: {details['runbook']}")
+        output.append(f"      Runbook:    {details['runbook']}")
+    yelpsoa_url = (
+        f"https://github.yelpcorp.com/sysgit/yelpsoa-configs/tree/master/{service}"
+    )
+    srv_url = f"https://github.yelpcorp.com/sysgit/srv-configs/tree/master/ecosystem/{ecosystem}/{service}"
+    output.append(
+        f"      Configs:    {PaastaColors.terminal_link(yelpsoa_url, 'y/yelpsoa')}"
+        f" | {PaastaColors.terminal_link(srv_url, 'y/srv-configs')}"
+    )
     return output
 
 
 def format_flink_config_links(service: str, ecosystem: str) -> List[str]:
-    """Format configuration repository links."""
+    """Format configuration repository links.
+
+    Deprecated: use format_flink_instance_metadata which now includes config links.
+    Kept for backwards compatibility.
+    """
+    yelpsoa_url = (
+        f"https://github.yelpcorp.com/sysgit/yelpsoa-configs/tree/master/{service}"
+    )
+    srv_url = f"https://github.yelpcorp.com/sysgit/srv-configs/tree/master/ecosystem/{ecosystem}/{service}"
     return [
-        f"    Yelpsoa configs: https://github.yelpcorp.com/sysgit/yelpsoa-configs/tree/master/{service}",
-        f"    Srv configs: https://github.yelpcorp.com/sysgit/srv-configs/tree/master/ecosystem/{ecosystem}/{service}",
+        f"      Configs:    {PaastaColors.terminal_link(yelpsoa_url, 'y/yelpsoa')}"
+        f" | {PaastaColors.terminal_link(srv_url, 'y/srv-configs')}",
     ]
 
 
 def format_flink_log_commands(service: str, instance: str, cluster: str) -> List[str]:
     """Format paasta logs commands."""
     return [
-        "    Flink Log Commands:",
+        "    Logs:",
         f"      Service:     paasta logs -a 1h -c {cluster} -s {service} -i {instance}",
         f"      Taskmanager: paasta logs -a 1h -c {cluster} -s {service} -i {instance}.TASKMANAGER",
         f"      Jobmanager:  paasta logs -a 1h -c {cluster} -s {service} -i {instance}.JOBMANAGER",
@@ -542,19 +565,24 @@ def format_flink_log_commands(service: str, instance: str, cluster: str) -> List
 def format_flink_monitoring_links(
     service: str, instance: str, ecosystem: str, cluster: str
 ) -> List[str]:
-    """Format Grafana and cost monitoring links."""
+    """Format Grafana and cost monitoring links as OSC 8 terminal hyperlinks."""
+    job_url = f"https://grafana.yelpcorp.com/d/flink-metrics/flink-job-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-{ecosystem}&var-service={service}&var-instance={instance}&var-job=All&from=now-24h&to=now"
+    container_url = f"https://grafana.yelpcorp.com/d/flink-container-metrics/flink-container-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-{ecosystem}&var-service={service}&var-instance={instance}&from=now-24h&to=now"
+    jvm_url = f"https://grafana.yelpcorp.com/d/flink-jvm-metrics/flink-jvm-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-{ecosystem}&var-service={service}&var-instance={instance}&from=now-24h&to=now"
+    cost_url = f"https://app.cloudzero.com/explorer?activeCostType=invoiced_amortized_cost&partitions=costcontext%3AResource%20Summary&dateRange=Last%2030%20Days&costcontext%3AKube%20Paasta%20Cluster={cluster}&costcontext%3APaasta%20Instance={instance}&costcontext%3APaasta%20Service={service}&showRightFlyout=filters"
     return [
-        "    Flink Monitoring:",
-        f"      Job Metrics: https://grafana.yelpcorp.com/d/flink-metrics/flink-job-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-{ecosystem}&var-service={service}&var-instance={instance}&var-job=All&from=now-24h&to=now",
-        f"      Container Metrics: https://grafana.yelpcorp.com/d/flink-container-metrics/flink-container-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-{ecosystem}&var-service={service}&var-instance={instance}&from=now-24h&to=now",
-        f"      JVM Metrics: https://grafana.yelpcorp.com/d/flink-jvm-metrics/flink-jvm-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-{ecosystem}&var-service={service}&var-instance={instance}&from=now-24h&to=now",
-        f"      Flink Cost: https://app.cloudzero.com/explorer?activeCostType=invoiced_amortized_cost&partitions=costcontext%3AResource%20Summary&dateRange=Last%2030%20Days&costcontext%3AKube%20Paasta%20Cluster={cluster}&costcontext%3APaasta%20Instance={instance}&costcontext%3APaasta%20Service={service}&showRightFlyout=filters",
+        "    Monitoring:",
+        f"      Job Metrics:       {PaastaColors.terminal_link(job_url, 'y/flink-job-metrics')}",
+        f"      Container Metrics: {PaastaColors.terminal_link(container_url, 'y/flink-container-metrics')}",
+        f"      JVM Metrics:       {PaastaColors.terminal_link(jvm_url, 'y/flink-jvm-metrics')}",
+        f"      Cost:              {PaastaColors.terminal_link(cost_url, 'y/flink-on-paasta-cost')}",
     ]
 
 
 def collect_flink_job_details(
     status: FlinkClusterStatusDict,
     overview: Optional[FlinkClusterOverview],
+    desired_state: Optional[str] = None,
 ) -> FlinkJobDetailsDict:
     """Collect job, pod, and resource information from status and overview."""
     pod_running_count = 0
@@ -602,6 +630,7 @@ def collect_flink_job_details(
 
     return {
         "state": status["state"],
+        "desired_state": desired_state,
         "pod_counts": pod_counts,
         "job_counts": job_counts,
         "taskmanagers": taskmanagers,
@@ -616,6 +645,7 @@ def format_flink_state_and_pods(job_details: FlinkJobDetailsDict) -> List[str]:
     output: List[str] = []
 
     state = job_details["state"]
+    desired_state = job_details.get("desired_state")
     pod_counts = job_details["pod_counts"]
     job_counts = job_details.get("job_counts")
     taskmanagers = job_details.get("taskmanagers")
@@ -623,7 +653,10 @@ def format_flink_state_and_pods(job_details: FlinkJobDetailsDict) -> List[str]:
     slots_total = job_details.get("slots_total")
 
     color = PaastaColors.green if state == "running" else PaastaColors.yellow
-    output.append(f"    State: {color(state.title())}")
+    state_str = color(state.title())
+    if desired_state and desired_state != state and desired_state != "start":
+        state_str += f" ({PaastaColors.yellow(f'desired: {desired_state}')})"
+    output.append(f"    State: {state_str}")
 
     formatted_evictions = (
         PaastaColors.red(f"{pod_counts['evicted']}")

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1200,6 +1200,13 @@ class PaastaColors:
     def default(text: str) -> str:
         return PaastaColors.color_text(PaastaColors.DEFAULT, text)
 
+    @staticmethod
+    def terminal_link(url: str, label: str) -> str:
+        """Format an OSC 8 terminal hyperlink (clickable in supported terminals)."""
+        if os.getenv("NO_COLOR", "0") == "1":
+            return f"{label} ({url})"
+        return f"\033]8;;{url}\033\\{label}\033]8;;\033\\"
+
 
 LOG_COMPONENTS: Mapping[str, Mapping[str, Any]] = OrderedDict(
     [

--- a/tests/cli/test_cmds_start_stop_restart.py
+++ b/tests/cli/test_cmds_start_stop_restart.py
@@ -661,8 +661,12 @@ def test_error_if_no_deploy_permissions(
     assert not mock_issue_state_change_for_service.called
 
 
-@mock.patch("choice.basicterm.BasicTermBinaryChoice", autospec=True)
-@mock.patch("choice.Binary", autospec=True)
+@mock.patch(
+    "paasta_tools.cli.cmds.start_stop_restart.get_paasta_oapi_client", autospec=True
+)
+@mock.patch(
+    "paasta_tools.cli.cmds.start_stop_restart.load_system_paasta_config", autospec=True
+)
 @mock.patch("paasta_tools.cli.cmds.start_stop_restart.paasta_start", autospec=True)
 @mock.patch(
     "paasta_tools.cli.cmds.start_stop_restart.get_instance_config", autospec=True
@@ -676,8 +680,8 @@ class TestRestartCmd:
         mock_apply_args_filters,
         mock_get_instance_config,
         mock_paasta_start,
-        mock_binary,
-        mock_binary_choice,
+        mock_load_system_paasta_config,
+        mock_get_paasta_oapi_client,
         capfd,
     ):
         mock_apply_args_filters.return_value = {
@@ -699,9 +703,9 @@ class TestRestartCmd:
                 None,
             ),
         ]
-        mock_paasta_start.return_value = 1
-        mock_binary_choice.ask.return_value = True
-        mock_binary.return_value = mock_binary_choice
+        mock_paasta_start.return_value = 0
+        mock_client = mock.Mock()
+        mock_get_paasta_oapi_client.return_value = mock_client
 
         args, _ = parse_args(
             "restart -s service -c cluster -i flink_instance,cas_instance -d /soa/dir".split(
@@ -709,19 +713,22 @@ class TestRestartCmd:
             )
         )
         ret = args.command(args)
-        out, _ = capfd.readouterr()
 
-        assert ret == 1
+        mock_client.service.instance_set_state.assert_called_once_with(
+            service="service",
+            instance="flink_instance",
+            desired_state="restart",
+        )
         assert mock_paasta_start.called
-        assert "paasta restart is currently unsupported for Flink instances" in out
+        assert ret == 0
 
     def test_only_non_flink_instances(
         self,
         mock_apply_args_filters,
         mock_get_instance_config,
         mock_paasta_start,
-        mock_binary,
-        mock_binary_choice,
+        mock_load_system_paasta_config,
+        mock_get_paasta_oapi_client,
         capfd,
     ):
         mock_apply_args_filters.return_value = {
@@ -742,19 +749,18 @@ class TestRestartCmd:
             "restart -s service -c cluster -i cas_instance -d /soa/dir".split(" ")
         )
         ret = args.command(args)
-        out, _ = capfd.readouterr()
 
         assert ret == 1
         assert mock_paasta_start.called
-        assert "paasta restart is currently unsupported for Flink instances" not in out
+        assert not mock_get_paasta_oapi_client.called
 
     def test_only_flink_instances(
         self,
         mock_apply_args_filters,
         mock_get_instance_config,
         mock_paasta_start,
-        mock_binary,
-        mock_binary_choice,
+        mock_load_system_paasta_config,
+        mock_get_paasta_oapi_client,
         capfd,
     ):
         mock_apply_args_filters.return_value = {
@@ -769,6 +775,8 @@ class TestRestartCmd:
                 None,
             ),
         ]
+        mock_client = mock.Mock()
+        mock_get_paasta_oapi_client.return_value = mock_client
 
         args, _ = parse_args(
             "restart -s service -c cluster -i flink_instance -d /soa/dir".split(" ")
@@ -776,9 +784,14 @@ class TestRestartCmd:
         ret = args.command(args)
         out, _ = capfd.readouterr()
 
-        assert ret == 1
+        assert ret == 0
         assert not mock_paasta_start.called
-        assert "paasta restart is currently unsupported for Flink instances" in out
+        mock_client.service.instance_set_state.assert_called_once_with(
+            service="service",
+            instance="flink_instance",
+            desired_state="restart",
+        )
+        assert "Flink operator" in out
 
 
 @pytest.mark.parametrize("force_flag", [False, True])

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -29,7 +29,6 @@ import paasta_tools.paastaapi.models as paastamodels
 from paasta_tools import kubernetes_tools
 from paasta_tools import utils
 from paasta_tools.cli.cmds import status
-from paasta_tools.cli.cmds.status import OUTPUT_HORIZONTAL_RULE
 from paasta_tools.cli.cmds.status import append_pod_status
 from paasta_tools.cli.cmds.status import apply_args_filters
 from paasta_tools.cli.cmds.status import build_smartstack_backends_table
@@ -2846,18 +2845,27 @@ class TestPrintFlinkStatus:
             verbose=0,
         )
 
-        status = mock_flink_status["status"]
-        metadata = mock_flink_status["metadata"]
-        expected_output = _get_flink_base_status_verbose_0(metadata) + [
-            f"    State: {PaastaColors.green(status['state'].title())}",
-            "    Pods: 3 running, 0 evicted, 0 other, 3 total",
-            "    Jobs: 1 running, 0 finished, 0 failed, 0 cancelled, 1 total",
-            "    1 taskmanagers, 3/4 slots available",
-            "    Jobs:",
-            "      Job Name       State       Started",
-            f"      {get_flink_job_name(job_details_obj)} {PaastaColors.green('Running')} {str(datetime.datetime.fromtimestamp(job_details_obj.start_time // 1000))} ({mock_naturaltime.return_value})",
-        ]
-        assert expected_output == output
+        joined = "\n".join(output)
+
+        # Cluster info
+        assert "Config SHA: 00000" in joined
+        assert config_obj.flink_version in joined
+        assert "Dashboard" in joined
+
+        # State and resources
+        assert "Running" in joined
+        assert "3 running, 0 evicted, 0 other, 3 total" in joined
+        assert "1 running, 0 finished, 0 failed, 0 cancelled, 1 total" in joined
+        assert "1 taskmanagers" in joined
+        assert "3/4 slots available" in joined
+
+        # Jobs table
+        assert get_flink_job_name(job_details_obj) in joined
+
+        # No verbose-only sections in non-verbose mode
+        assert "Links:" not in joined
+        assert "Monitoring:" not in joined
+        assert "Logs:" not in joined
 
     @patch("paasta_tools.cli.cmds.status.load_system_paasta_config", autospec=True)
     @mock.patch("paasta_tools.cli.cmds.status.get_paasta_oapi_client", autospec=True)
@@ -3015,37 +3023,47 @@ class TestPrintFlinkStatus:
             verbose=1,
         )
 
-        status = mock_flink_status["status"]
-        metadata = mock_flink_status["metadata"]
-        job_start_time = str(
-            datetime.datetime.fromtimestamp(int(job_details_obj.start_time) // 1000)
+        joined = "\n".join(output)
+
+        # Cluster info
+        assert "Config SHA: 00000" in joined
+        assert config_obj.flink_version in joined
+        assert config_obj.flink_revision in joined
+        assert "Dashboard" in joined
+
+        # State and resources
+        assert "Running" in joined
+        assert "3 running, 0 evicted, 0 other, 3 total" in joined
+        assert "1 running, 0 finished, 0 failed, 0 cancelled, 1 total" in joined
+        assert "1 taskmanagers" in joined
+        assert "3/4 slots available" in joined
+
+        # Jobs table
+        assert get_flink_job_name(job_details_obj) in joined
+
+        # Links section
+        assert "github.yelpcorp.com/services/fake_service" in joined
+        assert "sourcegraph.yelpcorp.com/services/fake_service" in joined
+        assert "fake_owner" in joined
+        assert "fake_runbook_url" in joined
+        assert "yelpsoa-configs/tree/master/fake_service" in joined
+        assert "srv-configs/tree/master/ecosystem/devc/fake_service" in joined
+
+        # Monitoring links
+        assert "flink-metrics" in joined
+        assert "flink-container-metrics" in joined
+        assert "flink-jvm-metrics" in joined
+        assert "cloudzero" in joined
+        assert "var-service=fake_service" in joined
+
+        # Log commands
+        assert (
+            "paasta logs -a 1h -c fake_cluster -s fake_service -i fake_instance"
+            in joined
         )
-        expected_output = _get_flink_base_status_verbose_1(metadata) + [
-            "    Yelpsoa configs: https://github.yelpcorp.com/sysgit/yelpsoa-configs/tree/master/fake_service",
-            "    Srv configs: https://github.yelpcorp.com/sysgit/srv-configs/tree/master/ecosystem/devc/fake_service",
-            f"{OUTPUT_HORIZONTAL_RULE}",
-            "    Flink Log Commands:",
-            "      Service:     paasta logs -a 1h -c fake_cluster -s fake_service -i fake_instance",
-            "      Taskmanager: paasta logs -a 1h -c fake_cluster -s fake_service -i fake_instance.TASKMANAGER",
-            "      Jobmanager:  paasta logs -a 1h -c fake_cluster -s fake_service -i fake_instance.JOBMANAGER",
-            "      Supervisor:  paasta logs -a 1h -c fake_cluster -s fake_service -i fake_instance.SUPERVISOR",
-            f"{OUTPUT_HORIZONTAL_RULE}",
-            "    Flink Monitoring:",
-            "      Job Metrics: https://grafana.yelpcorp.com/d/flink-metrics/flink-job-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-devc&var-service=fake_service&var-instance=fake_instance&var-job=All&from=now-24h&to=now",
-            "      Container Metrics: https://grafana.yelpcorp.com/d/flink-container-metrics/flink-container-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-devc&var-service=fake_service&var-instance=fake_instance&from=now-24h&to=now",
-            "      JVM Metrics: https://grafana.yelpcorp.com/d/flink-jvm-metrics/flink-jvm-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-devc&var-service=fake_service&var-instance=fake_instance&from=now-24h&to=now",
-            "      Flink Cost: https://app.cloudzero.com/explorer?activeCostType=invoiced_amortized_cost&partitions=costcontext%3AResource%20Summary&dateRange=Last%2030%20Days&costcontext%3AKube%20Paasta%20Cluster=fake_cluster&costcontext%3APaasta%20Instance=fake_instance&costcontext%3APaasta%20Service=fake_service&showRightFlyout=filters",
-            f"{OUTPUT_HORIZONTAL_RULE}",
-            f"    State: {PaastaColors.green(status['state'].title())}",
-            "    Pods: 3 running, 0 evicted, 0 other, 3 total",
-            "    Jobs: 1 running, 0 finished, 0 failed, 0 cancelled, 1 total",
-            "    1 taskmanagers, 3/4 slots available",
-            "    Jobs:",
-            "      Job Name       State       Started",
-            f"      {get_flink_job_name(job_details_obj)} {PaastaColors.green('Running')} {job_start_time} ({mock_naturaltime.return_value})",
-        ]
-        append_pod_status(status["pod_status"], expected_output)
-        assert expected_output == output
+        assert "fake_instance.TASKMANAGER" in joined
+        assert "fake_instance.JOBMANAGER" in joined
+        assert "fake_instance.SUPERVISOR" in joined
 
 
 overview_obj = paastamodels.FlinkClusterOverview(
@@ -3085,27 +3103,6 @@ def _prepare_paasta_api_client_for_flink(mock_get_paasta_oapi_client):
     mock_api.service.get_flink_job_details_from_paasta_api_client.return_value = (
         job_details_obj
     )
-
-
-def _get_flink_base_status_verbose_0(metadata):
-    return [
-        "    Config SHA: 00000",
-        f"    Flink version: {config_obj.flink_version}",
-        f"    URL: {metadata['annotations']['flink.yelp.com/dashboard_url']}/",
-    ]
-
-
-def _get_flink_base_status_verbose_1(metadata):
-    return [
-        "    Config SHA: 00000",
-        f"    Flink version: {config_obj.flink_version} {config_obj.flink_revision}",
-        f"    URL: {metadata['annotations']['flink.yelp.com/dashboard_url']}/",
-        "    Repo(git): https://github.yelpcorp.com/services/fake_service",
-        "    Repo(sourcegraph): https://sourcegraph.yelpcorp.com/services/fake_service",
-        "    Flink Pool: flink",
-        "    Owner: fake_owner",
-        "    Flink Runbook: fake_runbook_url",
-    ]
 
 
 def _formatted_table_to_dict(formatted_table):

--- a/tests/test_flink_tools.py
+++ b/tests/test_flink_tools.py
@@ -466,7 +466,7 @@ class TestFormatFlinkInstanceHeader:
             "runbook": "test_runbook",
         }
         result = flink_tools.format_flink_instance_header(details, verbose=False)
-        assert "    Flink version: 1.13.5" in result
+        assert "    Flink:      1.13.5" in result
         assert "0ff28a7" not in "\n".join(result)
         assert "Config SHA" not in "\n".join(result)
 
@@ -481,11 +481,11 @@ class TestFormatFlinkInstanceHeader:
             "runbook": "test_runbook",
         }
         result = flink_tools.format_flink_instance_header(details, verbose=True)
-        assert "    Flink version: 1.13.5 0ff28a7" in result
-        assert "    URL: http://flink.k8s.test.paasta:31080/app/" in result
+        assert "    Flink:      1.13.5 0ff28a7" in result
+        assert "Dashboard" in "\n".join(result)
+        assert "http://flink.k8s.test.paasta:31080/app/" in "\n".join(result)
 
     def test_no_dashboard_url(self):
-        # Dashboard URL line is omitted when annotation is absent
         details = {
             "config_sha": "00000",
             "version": "1.13.5",
@@ -496,7 +496,7 @@ class TestFormatFlinkInstanceHeader:
             "runbook": "test_runbook",
         }
         result = flink_tools.format_flink_instance_header(details, verbose=True)
-        assert "URL" not in "\n".join(result)
+        assert "Dashboard" not in "\n".join(result)
 
 
 class TestFormatFlinkInstanceMetadata:
@@ -510,36 +510,32 @@ class TestFormatFlinkInstanceMetadata:
             "team": "test_team",
             "runbook": "test_runbook",
         }
-        result = flink_tools.format_flink_instance_metadata(details, "test_service")
-        assert (
-            "    Repo(git): https://github.yelpcorp.com/services/test_service" in result
+        result = flink_tools.format_flink_instance_metadata(
+            details, "test_service", "devc"
         )
-        assert (
-            "    Repo(sourcegraph): https://sourcegraph.yelpcorp.com/services/test_service"
-            in result
-        )
-        assert "    Flink Pool: flink" in result
-        assert "    Owner: test_team" in result
-        assert "    Flink Runbook: test_runbook" in result
+        joined = "\n".join(result)
+        assert "    Links:" in result
+        assert "github.yelpcorp.com/services/test_service" in joined
+        assert "sourcegraph.yelpcorp.com/services/test_service" in joined
+        assert "flink" in joined
+        assert "test_team" in joined
+        assert "test_runbook" in joined
+        assert "yelpsoa-configs/tree/master/test_service" in joined
+        assert "srv-configs/tree/master/ecosystem/devc/test_service" in joined
 
 
 class TestFormatFlinkConfigLinks:
     def test_output(self):
         result = flink_tools.format_flink_config_links("my_service", "devc")
-        assert (
-            "    Yelpsoa configs: https://github.yelpcorp.com/sysgit/yelpsoa-configs/tree/master/my_service"
-            in result
-        )
-        assert (
-            "    Srv configs: https://github.yelpcorp.com/sysgit/srv-configs/tree/master/ecosystem/devc/my_service"
-            in result
-        )
+        joined = "\n".join(result)
+        assert "yelpsoa-configs/tree/master/my_service" in joined
+        assert "srv-configs/tree/master/ecosystem/devc/my_service" in joined
 
 
 class TestFormatFlinkLogCommands:
     def test_output(self):
         result = flink_tools.format_flink_log_commands("my_service", "main", "pnw-devc")
-        assert result[0] == "    Flink Log Commands:"
+        assert result[0] == "    Logs:"
         assert "paasta logs -a 1h -c pnw-devc -s my_service -i main" in result[1]
         assert ".TASKMANAGER" in result[2]
         assert ".JOBMANAGER" in result[3]
@@ -551,11 +547,14 @@ class TestFormatFlinkMonitoringLinks:
         result = flink_tools.format_flink_monitoring_links(
             "my_service", "main", "devc", "pnw-devc"
         )
-        assert result[0] == "    Flink Monitoring:"
-        assert "var-service=my_service" in result[1]
-        assert "var-instance=main" in result[1]
-        assert "uswest2-devc" in result[1]
-        assert "pnw-devc" in result[4]  # Flink Cost link uses cluster name
+        assert result[0] == "    Monitoring:"
+        joined = "\n".join(result)
+        assert "var-service=my_service" in joined
+        assert "var-instance=main" in joined
+        assert "uswest2-devc" in joined
+        assert "pnw-devc" in joined
+        assert "grafana" in joined
+        assert "cloudzero" in joined
 
 
 class TestCollectFlinkJobDetails:
@@ -702,6 +701,30 @@ class TestFormatFlinkStateAndPods:
         slots_line = next(line for line in result if "taskmanagers" in line)
         assert "1 taskmanagers" in slots_line
         assert "2/8 slots available" in slots_line
+
+    def test_restart_desired_state_shown(self):
+        from paasta_tools.utils import PaastaColors
+
+        result = flink_tools.format_flink_state_and_pods(
+            self._make_details(desired_state="restart")
+        )
+        state_line = next(line for line in result if "State:" in line)
+        assert "desired: restart" in state_line
+        assert PaastaColors.yellow("desired: restart") in state_line
+
+    def test_start_desired_state_not_shown(self):
+        result = flink_tools.format_flink_state_and_pods(
+            self._make_details(desired_state="start")
+        )
+        state_line = next(line for line in result if "State:" in line)
+        assert "desired" not in state_line
+
+    def test_stop_desired_state_shown(self):
+        result = flink_tools.format_flink_state_and_pods(
+            self._make_details(desired_state="stop")
+        )
+        state_line = next(line for line in result if "State:" in line)
+        assert "desired: stop" in state_line
 
 
 @mock.patch("paasta_tools.flink_tools.shutil.get_terminal_size")


### PR DESCRIPTION
## Summary
- Removes the "paasta restart is currently unsupported for Flink instances" error
- Sends `desired_state="restart"` via the existing `instance_set_state` API
- The flink-operator handles the full stop→start cycle atomically (no client polling needed)
- Adds 'restart' desired state to paasta status output

Refactors the flink paasta status output to be less verbose:
- Moves long URLs to hyperlinks
- Removes redundant "flink" everywhere
- Updates unit tests to be less brittle, checking for specific functionality rather than exact verbatim output

<img width="413" height="160" alt="image" src="https://github.com/user-attachments/assets/a738a00b-d482-4a3c-b33b-fa1fc1cc9a00" />


## Depends on
- [x] Internal PR for flink operator-side restart support

## Test plan
- [ ] Existing unit tests pass (no behavior change for non-Flink instances)
- [ ] Manual test: `paasta restart -s <flink-service> -i <instance> -c <cluster>` triggers operator restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)