### PR TITLE
Flink: add y/ links and remove dead is_eks branching

### DIFF
--- a/paasta_tools/check_flink_services_health.py
+++ b/paasta_tools/check_flink_services_health.py
@@ -64,7 +64,6 @@ def check_under_registered_taskmanagers(
     instance_config: FlinkDeploymentConfig,
     expected_count: int,
     cr_name: str,
-    is_eks: bool,
 ) -> Tuple[bool, str, str]:
     """Check if not enough taskmanagers have been registered to the jobmanager and
     returns both the result of the check in the form of a boolean and a human-readable
@@ -74,7 +73,7 @@ def check_under_registered_taskmanagers(
     if cr_name != "":
         try:
             overview = flink_tools.get_flink_jobmanager_overview(
-                cr_name, instance_config.cluster, is_eks
+                cr_name, instance_config.cluster
             )
             num_reported = overview.get("taskmanagers", 0)
             crit_threshold = instance_config.get_replication_crit_percentage()
@@ -171,7 +170,6 @@ def check_flink_service_health(
             instance_config=instance_config,
             expected_count=taskmanagers_expected_cnt,
             cr_name=service_cr_name,
-            is_eks=isinstance(instance_config, flinkeks_tools.FlinkEksDeploymentConfig),
         ),
     ]
     output = ", ".join([r[1] for r in results])

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -248,15 +248,12 @@ def cr_id(service: str, instance: str) -> Mapping[str, str]:
     )
 
 
-def get_flink_ingress_url_root(cluster: str, is_eks: bool) -> str:
-    if is_eks:
-        return f"http://flink.eks.{cluster}.paasta:{FLINK_INGRESS_PORT}/"
-    else:
-        return f"http://flink.k8s.{cluster}.paasta:{FLINK_INGRESS_PORT}/"
+def get_flink_ingress_url_root(cluster: str) -> str:
+    return f"http://flink.eks.{cluster}.paasta:{FLINK_INGRESS_PORT}/"
 
 
-def _dashboard_get(cr_name: str, cluster: str, path: str, is_eks: bool) -> str:
-    root = get_flink_ingress_url_root(cluster, is_eks)
+def _dashboard_get(cr_name: str, cluster: str, path: str) -> str:
+    root = get_flink_ingress_url_root(cluster)
     url = f"{root}{cr_name}/{path}"
     response = requests.get(url, timeout=FLINK_DASHBOARD_TIMEOUT_SECONDS)
     response.raise_for_status()
@@ -291,8 +288,7 @@ def _filter_for_endpoint(json_response: Any, endpoint: str) -> Mapping[str, Any]
 def _get_jm_rest_api_base_url(cr: Mapping[str, Any]) -> str:
     metadata = cr["metadata"]
     cluster = metadata["labels"][paasta_prefixed("cluster")]
-    is_eks = metadata["labels"].get("paasta.yelp.com/eks", "False")
-    base_url = get_flink_ingress_url_root(cluster, is_eks == "True")
+    base_url = get_flink_ingress_url_root(cluster)
 
     # this will look something like http://flink-jobmanager-host:port/paasta-service-cr-name
     _, _, service_cr_name, *_ = urlparse(
@@ -332,11 +328,9 @@ def curl_flink_endpoint(cr_id: Mapping[str, str], endpoint: str) -> Mapping[str,
         raise ValueError(f"failed HTTP request to flink API: {e}")
 
 
-def get_flink_jobmanager_overview(
-    cr_name: str, cluster: str, is_eks: bool
-) -> Mapping[str, Any]:
+def get_flink_jobmanager_overview(cr_name: str, cluster: str) -> Mapping[str, Any]:
     try:
-        response = _dashboard_get(cr_name, cluster, "overview", is_eks)
+        response = _dashboard_get(cr_name, cluster, "overview")
         return json.loads(response)
     except requests.RequestException as e:
         url = e.request.url

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -490,9 +490,8 @@ def format_flink_instance_header(
 
     if details.get("dashboard_url"):
         url = f"{details['dashboard_url']}/"
-        output.append(
-            f"    Dashboard:  {PaastaColors.terminal_link(url, 'y/flink-dashboard')}"
-        )
+        text = url if verbose else "y/flink-dashboard"
+        output.append(f"    Dashboard:  {PaastaColors.terminal_link(url, text)}")
 
     return output
 
@@ -512,11 +511,9 @@ def format_flink_instance_metadata(
     """Format verbose instance metadata (repo links, pool, owner, runbook, configs)."""
     output: List[str] = []
     output.append("    Links:")
-    git_url = f"https://github.yelpcorp.com/services/{service}"
-    sg_url = f"https://sourcegraph.yelpcorp.com/services/{service}"
+    sg_url = f"y/service-sg/{service}"
     output.append(
-        f"      Repo:       {PaastaColors.terminal_link(git_url, 'y/github')}"
-        f" | {PaastaColors.terminal_link(sg_url, 'sourcegraph')}"
+        f"      Code:       {PaastaColors.terminal_link('http://'+sg_url, sg_url)}"
     )
     if details.get("pool"):
         output.append(f"      Pool:       {details['pool']}")
@@ -524,13 +521,11 @@ def format_flink_instance_metadata(
         output.append(f"      Owner:      {details['team']}")
     if details.get("runbook"):
         output.append(f"      Runbook:    {details['runbook']}")
-    yelpsoa_url = (
-        f"https://github.yelpcorp.com/sysgit/yelpsoa-configs/tree/master/{service}"
-    )
-    srv_url = f"https://github.yelpcorp.com/sysgit/srv-configs/tree/master/ecosystem/{ecosystem}/{service}"
+    yelpsoa_url = f"y/service-yelpsoa/{service}"
+    srv_url = f"y/service-srv/{ecosystem}/{service}"
     output.append(
-        f"      Configs:    {PaastaColors.terminal_link(yelpsoa_url, 'y/yelpsoa')}"
-        f" | {PaastaColors.terminal_link(srv_url, 'y/srv-configs')}"
+        f"      Configs:    {PaastaColors.terminal_link('http://'+yelpsoa_url, yelpsoa_url)}"
+        f" | {PaastaColors.terminal_link('http://'+srv_url, srv_url)}"
     )
     return output
 
@@ -550,16 +545,16 @@ def format_flink_monitoring_links(
     service: str, instance: str, ecosystem: str, cluster: str
 ) -> List[str]:
     """Format Grafana and cost monitoring links as OSC 8 terminal hyperlinks."""
-    job_url = f"https://grafana.yelpcorp.com/d/flink-metrics/flink-job-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-{ecosystem}&var-service={service}&var-instance={instance}&var-job=All&from=now-24h&to=now"
-    container_url = f"https://grafana.yelpcorp.com/d/flink-container-metrics/flink-container-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-{ecosystem}&var-service={service}&var-instance={instance}&from=now-24h&to=now"
-    jvm_url = f"https://grafana.yelpcorp.com/d/flink-jvm-metrics/flink-jvm-metrics?orgId=1&var-datasource=Prometheus-flink&var-region=uswest2-{ecosystem}&var-service={service}&var-instance={instance}&from=now-24h&to=now"
-    cost_url = f"https://app.cloudzero.com/explorer?activeCostType=invoiced_amortized_cost&partitions=costcontext%3AResource%20Summary&dateRange=Last%2030%20Days&costcontext%3AKube%20Paasta%20Cluster={cluster}&costcontext%3APaasta%20Instance={instance}&costcontext%3APaasta%20Service={service}&showRightFlyout=filters"
+    job_url = f"y/flink-job-metrics/?var-region=uswest2-{ecosystem}&var-service={service}&var-instance={instance}"
+    container_url = f"y/flink-container-metrics?var-region=uswest2-{ecosystem}&var-service={service}&var-instance={instance}"
+    jvm_url = f"y/flink-jvm-metrics?var-region=uswest2-{ecosystem}&var-service={service}&var-instance={instance}"
+    cost_url = f"y/flink-cost-dashboard/?Kube%20Paasta%20Cluster={cluster}&Instance%20Name={instance}&Service%20Name={service}"
     return [
         "    Monitoring:",
-        f"      Job Metrics:       {PaastaColors.terminal_link(job_url, 'y/flink-job-metrics')}",
-        f"      Container Metrics: {PaastaColors.terminal_link(container_url, 'y/flink-container-metrics')}",
-        f"      JVM Metrics:       {PaastaColors.terminal_link(jvm_url, 'y/flink-jvm-metrics')}",
-        f"      Cost:              {PaastaColors.terminal_link(cost_url, 'y/flink-on-paasta-cost')}",
+        f"      Job Metrics:       {PaastaColors.terminal_link('http://'+job_url, job_url)}",
+        f"      Container Metrics: {PaastaColors.terminal_link('http://'+container_url, container_url)}",
+        f"      JVM Metrics:       {PaastaColors.terminal_link('http://'+jvm_url, jvm_url)}",
+        f"      Cost:              {PaastaColors.terminal_link('http://'+cost_url, cost_url)}",
     ]
 
 

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -509,21 +509,19 @@ def format_flink_instance_metadata(
     """Format verbose instance metadata (repo links, pool, owner, runbook, configs)."""
     output: List[str] = []
     output.append("    Links:")
-    sg_url = f"y/service-sg/{service}"
-    output.append(
-        f"      Code:       {PaastaColors.terminal_link('http://'+sg_url, sg_url)}"
-    )
+    sg_url = f"http://y/service-sg/{service}"
+    output.append(f"      Code:       {PaastaColors.terminal_link(sg_url, sg_url)}")
     if details.get("pool"):
         output.append(f"      Pool:       {details['pool']}")
     if details.get("team"):
         output.append(f"      Owner:      {details['team']}")
     if details.get("runbook"):
         output.append(f"      Runbook:    {details['runbook']}")
-    yelpsoa_url = f"y/service-yelpsoa/{service}"
-    srv_url = f"y/service-srv/{ecosystem}/{service}"
+    yelpsoa_url = f"http://y/service-yelpsoa/{service}"
+    srv_url = f"http://y/service-srv/{ecosystem}/{service}"
     output.append(
-        f"      Configs:    {PaastaColors.terminal_link('http://'+yelpsoa_url, yelpsoa_url)}"
-        f" | {PaastaColors.terminal_link('http://'+srv_url, srv_url)}"
+        f"      Configs:    {PaastaColors.terminal_link(yelpsoa_url, yelpsoa_url)}"
+        f" | {PaastaColors.terminal_link(srv_url, srv_url)}"
     )
     return output
 
@@ -543,16 +541,16 @@ def format_flink_monitoring_links(
     service: str, instance: str, ecosystem: str, cluster: str
 ) -> List[str]:
     """Format Grafana and cost monitoring links as OSC 8 terminal hyperlinks."""
-    job_url = f"y/flink-job-metrics/?var-region=uswest2-{ecosystem}&var-service={service}&var-instance={instance}"
-    container_url = f"y/flink-container-metrics?var-region=uswest2-{ecosystem}&var-service={service}&var-instance={instance}"
-    jvm_url = f"y/flink-jvm-metrics?var-region=uswest2-{ecosystem}&var-service={service}&var-instance={instance}"
-    cost_url = f"y/flink-cost-dashboard/?Kube%20Paasta%20Cluster={cluster}&Instance%20Name={instance}&Service%20Name={service}"
+    job_url = f"http://y/flink-job-metrics/?var-region=uswest2-{ecosystem}&var-service={service}&var-instance={instance}"
+    container_url = f"http://y/flink-container-metrics?var-region=uswest2-{ecosystem}&var-service={service}&var-instance={instance}"
+    jvm_url = f"http://y/flink-jvm-metrics?var-region=uswest2-{ecosystem}&var-service={service}&var-instance={instance}"
+    cost_url = f"http://y/flink-cost-dashboard/?Kube%20Paasta%20Cluster={cluster}&Instance%20Name={instance}&Service%20Name={service}"
     return [
         "    Monitoring:",
-        f"      Job Metrics:       {PaastaColors.terminal_link('http://'+job_url, job_url)}",
-        f"      Container Metrics: {PaastaColors.terminal_link('http://'+container_url, container_url)}",
-        f"      JVM Metrics:       {PaastaColors.terminal_link('http://'+jvm_url, jvm_url)}",
-        f"      Cost:              {PaastaColors.terminal_link('http://'+cost_url, cost_url)}",
+        f"      Job Metrics:       {PaastaColors.terminal_link(job_url, job_url)}",
+        f"      Container Metrics: {PaastaColors.terminal_link(container_url, container_url)}",
+        f"      JVM Metrics:       {PaastaColors.terminal_link(jvm_url, jvm_url)}",
+        f"      Cost:              {PaastaColors.terminal_link(cost_url, cost_url)}",
     ]
 
 

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -27,6 +27,7 @@ from urllib.parse import urlparse
 import humanize
 import requests
 import service_configuration_lib
+from kubernetes.client.rest import ApiException as KubeApiException
 from mypy_extensions import TypedDict
 
 from paasta_tools.api import settings
@@ -324,7 +325,11 @@ def curl_flink_endpoint(cr_id: Mapping[str, str], endpoint: str) -> Mapping[str,
         raise ValueError(f"JSON decoding error from flink API: {e}")
     except ConnectionError as e:
         raise ValueError(f"failed HTTP request to flink API: {e}")
-    except ApiException as e:
+    except KeyError as e:
+        raise ValueError(
+            f"missing expected field on Flink CR {cr_id.get('name', cr_id)}: {e}"
+        )
+    except (ApiException, KubeApiException) as e:
         raise ValueError(f"failed HTTP request to flink API: {e}")
 
 

--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -484,8 +484,7 @@ def format_flink_instance_header(
 
     if details.get("dashboard_url"):
         url = f"{details['dashboard_url']}/"
-        text = url if verbose else "y/flink-dashboard"
-        output.append(f"    Dashboard:  {PaastaColors.terminal_link(url, text)}")
+        output.append(f"    Dashboard:  {PaastaColors.terminal_link(url, url)}")
 
     return output
 

--- a/paasta_tools/setup_kubernetes_cr.py
+++ b/paasta_tools/setup_kubernetes_cr.py
@@ -257,7 +257,7 @@ def get_dashboard_base_url(kind: str, cluster: str, is_eks: bool) -> Optional[st
     if kind.lower() == "flink":
         flink_link = dashboard_links.get(cluster, {}).get("Flink")
         if flink_link is None:
-            flink_link = get_flink_ingress_url_root(cluster, is_eks)
+            flink_link = get_flink_ingress_url_root(cluster)
         if flink_link[-1:] != "/":
             flink_link += "/"
         return flink_link

--- a/tests/cli/test_cmds_status.py
+++ b/tests/cli/test_cmds_status.py
@@ -3042,18 +3042,17 @@ class TestPrintFlinkStatus:
         assert get_flink_job_name(job_details_obj) in joined
 
         # Links section
-        assert "github.yelpcorp.com/services/fake_service" in joined
-        assert "sourcegraph.yelpcorp.com/services/fake_service" in joined
+        assert "y/service-sg/fake_service" in joined
         assert "fake_owner" in joined
         assert "fake_runbook_url" in joined
-        assert "yelpsoa-configs/tree/master/fake_service" in joined
-        assert "srv-configs/tree/master/ecosystem/devc/fake_service" in joined
+        assert "y/service-yelpsoa/fake_service" in joined
+        assert "y/service-srv/devc/fake_service" in joined
 
         # Monitoring links
-        assert "flink-metrics" in joined
-        assert "flink-container-metrics" in joined
-        assert "flink-jvm-metrics" in joined
-        assert "cloudzero" in joined
+        assert "y/flink-job-metrics/" in joined
+        assert "y/flink-container-metrics" in joined
+        assert "y/flink-jvm-metrics" in joined
+        assert "y/flink-cost-dashboard/" in joined
         assert "var-service=fake_service" in joined
 
         # Log commands

--- a/tests/test_check_flink_services_health.py
+++ b/tests/test_check_flink_services_health.py
@@ -53,7 +53,6 @@ def test_check_under_registered_taskmanagers_ok(mock_overview, instance_config):
         instance_config,
         expected_count=3,
         cr_name="fake--service-575c857546",
-        is_eks=False,
     )
     assert not under
     assert (
@@ -73,7 +72,6 @@ def test_check_under_registered_taskmanagers_under(mock_overview, instance_confi
         instance_config,
         expected_count=3,
         cr_name="fake--service-575c857546",
-        is_eks=False,
     )
     assert under
     assert (
@@ -96,7 +94,6 @@ def test_check_under_registered_taskmanagers_error(mock_overview, instance_confi
         instance_config,
         expected_count=3,
         cr_name="fake--service-575c857546",
-        is_eks=False,
     )
     assert under
     assert (
@@ -154,7 +151,7 @@ def test_check_flink_service_health_healthy(instance_config):
         ]
         mock_check_under_replication.assert_has_calls(expected)
         mock_check_under_registered_taskmanagers.assert_called_once_with(
-            instance_config=instance_config, expected_count=3, cr_name="", is_eks=False
+            instance_config=instance_config, expected_count=3, cr_name=""
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
@@ -218,7 +215,7 @@ def test_check_flink_service_health_too_few_taskmanagers(instance_config):
         ]
         mock_check_under_replication.assert_has_calls(expected)
         mock_check_under_registered_taskmanagers.assert_called_once_with(
-            instance_config=instance_config, expected_count=3, cr_name="", is_eks=False
+            instance_config=instance_config, expected_count=3, cr_name=""
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,
@@ -277,7 +274,6 @@ def test_check_flink_service_health_under_registered_taskamanagers(instance_conf
             instance_config=instance_config,
             expected_count=3,
             cr_name="",
-            is_eks=False,
         )
         mock_send_replication_event.assert_called_once_with(
             instance_config=instance_config,

--- a/tests/test_flink_tools.py
+++ b/tests/test_flink_tools.py
@@ -291,6 +291,29 @@ def test_curl_flink_endpoint_get_job_checkpoints(
     }
 
 
+@mock.patch("paasta_tools.flink_tools.get_cr", autospec=True)
+def test_curl_flink_endpoint_kube_api_exception(mock_get_cr):
+    from kubernetes.client.rest import ApiException as KubeApiException
+
+    mock_get_cr.side_effect = KubeApiException(status=503, reason="Service Unavailable")
+
+    with pytest.raises(ValueError, match="failed HTTP request to flink API"):
+        flink_tools.curl_flink_endpoint(flink_tools.cr_id("kurupt", "main"), "config")
+
+
+@mock.patch("paasta_tools.flink_tools.get_cr", autospec=True)
+def test_curl_flink_endpoint_missing_annotation(mock_get_cr):
+    mock_get_cr.return_value = {
+        "metadata": {
+            "labels": {"paasta.yelp.com/cluster": "mocked"},
+            "annotations": {},
+        }
+    }
+
+    with pytest.raises(ValueError, match="missing expected field on Flink CR"):
+        flink_tools.curl_flink_endpoint(flink_tools.cr_id("kurupt", "main"), "config")
+
+
 def test_get_flink_jobmanager_overview():
     with mock.patch(
         "paasta_tools.flink_tools._dashboard_get",

--- a/tests/test_flink_tools.py
+++ b/tests/test_flink_tools.py
@@ -14,6 +14,7 @@
 from unittest import mock
 
 import pytest
+from kubernetes.client.rest import ApiException as KubeApiException
 
 import paasta_tools.flink_tools as flink_tools
 from paasta_tools.flink_tools import FlinkDeploymentConfig
@@ -293,8 +294,6 @@ def test_curl_flink_endpoint_get_job_checkpoints(
 
 @mock.patch("paasta_tools.flink_tools.get_cr", autospec=True)
 def test_curl_flink_endpoint_kube_api_exception(mock_get_cr):
-    from kubernetes.client.rest import ApiException as KubeApiException
-
     mock_get_cr.side_effect = KubeApiException(status=503, reason="Service Unavailable")
 
     with pytest.raises(ValueError, match="failed HTTP request to flink API"):

--- a/tests/test_flink_tools.py
+++ b/tests/test_flink_tools.py
@@ -23,8 +23,8 @@ from paasta_tools.utils import PaastaColors
 
 def test_get_flink_ingress_url_root():
     assert (
-        flink_tools.get_flink_ingress_url_root("mycluster", False)
-        == "http://flink.k8s.mycluster.paasta:31080/"
+        flink_tools.get_flink_ingress_url_root("mycluster")
+        == "http://flink.eks.mycluster.paasta:31080/"
     )
 
 
@@ -299,9 +299,9 @@ def test_get_flink_jobmanager_overview():
     ) as mock_dashboard_get:
         cluster = "mycluster"
         cr_name = "kurupt--fm-7c7b459d59"
-        overview = flink_tools.get_flink_jobmanager_overview(cr_name, cluster, False)
+        overview = flink_tools.get_flink_jobmanager_overview(cr_name, cluster)
         mock_dashboard_get.assert_called_once_with(
-            cr_name=cr_name, cluster=cluster, path="overview", is_eks=False
+            cr_name=cr_name, cluster=cluster, path="overview"
         )
         assert overview == {
             "taskmanagers": 10,
@@ -516,13 +516,12 @@ class TestFormatFlinkInstanceMetadata:
         )
         joined = "\n".join(result)
         assert "    Links:" in result
-        assert "github.yelpcorp.com/services/test_service" in joined
-        assert "sourcegraph.yelpcorp.com/services/test_service" in joined
+        assert "y/service-sg/test_service" in joined
         assert "flink" in joined
         assert "test_team" in joined
         assert "test_runbook" in joined
-        assert "yelpsoa-configs/tree/master/test_service" in joined
-        assert "srv-configs/tree/master/ecosystem/devc/test_service" in joined
+        assert "y/service-yelpsoa/test_service" in joined
+        assert "y/service-srv/devc/test_service" in joined
 
 
 class TestFormatFlinkLogCommands:
@@ -546,8 +545,8 @@ class TestFormatFlinkMonitoringLinks:
         assert "var-instance=main" in joined
         assert "uswest2-devc" in joined
         assert "pnw-devc" in joined
-        assert "grafana" in joined
-        assert "cloudzero" in joined
+        assert "y/flink-job-metrics" in joined
+        assert "y/flink-cost-dashboard" in joined
 
 
 class TestCollectFlinkJobDetails:

--- a/tests/test_setup_kubernetes_cr.py
+++ b/tests/test_setup_kubernetes_cr.py
@@ -322,7 +322,7 @@ def test_format_custom_resource():
                 "annotations": {
                     "yelp.com/desired_state": "running",
                     "paasta.yelp.com/desired_state": "running",
-                    "paasta.yelp.com/dashboard_base_url": "http://flink.k8s.mycluster.paasta:31080/",
+                    "paasta.yelp.com/dashboard_base_url": "http://flink.eks.mycluster.paasta:31080/",
                 },
             },
             "spec": {"dummy": "conf"},


### PR DESCRIPTION
## Summary
- Replace verbose GitHub/Grafana/Sourcegraph URLs in Flink status output with shorter `y/` redirect links that work in all terminals
- Remove the `is_eks` parameter from `get_flink_ingress_url_root` and its callers — all Flink clusters run on EKS now, so the k8s/eks URL branching was dead code
- Fix uncaught exceptions in `curl_flink_endpoint` that caused intermittent 500s from the PaaSTA API when fetching Flink config/overview/jobs

## Bug fix details
`curl_flink_endpoint` caught `ApiException` from `paasta_tools.paastaapi.exceptions`, but `get_cr()` raises `kubernetes.client.rest.ApiException` — a completely different class. When the Kubernetes API had transient errors (503, timeouts, rate limiting), the exception propagated unhandled through the Pyramid view, causing a generic HTML 500 response.

Also added a `KeyError` handler for cases where the Flink CR exists but is missing the expected `flink.yelp.com/dashboard_url` annotation or `paasta.yelp.com/cluster` label.

## Test plan
- [x] `make test` passes (pre-commit, mypy, pytest)
- [x] Verify `paasta status` for a Flink instance shows correct y/ links
- [x] Confirm Flink health checks still resolve the ingress URL correctly
- [x] New tests verify KubeApiException and missing annotation are caught

🤖 Generated with [Claude Code](https://claude.com/claude-code)

----

`paasta status`:
<img width="541" height="229" alt="image" src="https://github.com/user-attachments/assets/32683b93-2a64-46a4-ba56-d6b55dc52a4c" />


`paasta status -v`:
<img width="985" height="649" alt="image" src="https://github.com/user-attachments/assets/1c9f8f3c-6814-41a1-9e31-d42a74cc55c5" />