### PR TITLE
Add prometheus-adapter rule generation for nrtsearch GPU autoscaling

### DIFF
--- a/paasta_tools/nrtsearchservice_tools.py
+++ b/paasta_tools/nrtsearchservice_tools.py
@@ -10,6 +10,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from typing import Any
+from typing import Dict
 from typing import List
 from typing import Mapping
 from typing import Optional
@@ -28,6 +30,7 @@ from paasta_tools.utils import load_v2_deployments_json
 
 class NrtsearchServiceDeploymentConfigDict(LongRunningServiceConfigDict, total=False):
     replicas: int
+    serverSets: List[Dict[str, Any]]
 
 
 class NrtsearchServiceDeploymentConfig(LongRunningServiceConfig):

--- a/paasta_tools/nrtsearchserviceeks_tools.py
+++ b/paasta_tools/nrtsearchserviceeks_tools.py
@@ -2,6 +2,8 @@ from typing import Optional
 
 import service_configuration_lib
 
+from paasta_tools.autoscaling.utils import MetricsProviderDict
+from paasta_tools.long_running_service_tools import METRICS_PROVIDER_PROMQL
 from paasta_tools.nrtsearchservice_tools import NrtsearchServiceDeploymentConfig
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import BranchDictV2
@@ -12,6 +14,64 @@ from paasta_tools.utils import load_v2_deployments_json
 
 class NrtsearchServiceEksDeploymentConfig(NrtsearchServiceDeploymentConfig):
     config_filename_prefix = "nrtsearchserviceeks"
+
+    def _get_autoscalable_server_set(self) -> Optional[dict]:
+        """Return the non-primary serverSet that has targetGpuUtilization > 0."""
+        server_sets = self.config_dict.get("serverSets", [])
+        for server_set in server_sets:
+            if server_set.get("primary", False):
+                continue
+            autoscaling = server_set.get("autoscaling")
+            if not autoscaling:
+                continue
+            if autoscaling.get("targetGpuUtilization", 0) > 0:
+                return server_set
+        return None
+
+    def get_autoscaling_metrics_provider(
+        self, provider_type: str
+    ) -> Optional[MetricsProviderDict]:
+        if provider_type != METRICS_PROVIDER_PROMQL:
+            return None
+        server_set = self._get_autoscalable_server_set()
+        if server_set is None:
+            return None
+
+        instance_name = "replica"
+        deployment_name = self.get_sanitised_deployment_name()
+        namespace = self.get_namespace()
+        paasta_cluster = self.get_cluster()
+        service = self.get_service()
+
+        metrics_query = (
+            "avg("
+            "DCGM_FI_DEV_GPU_UTIL"
+            " * on(kube_pod, kube_namespace) group_left()"
+            " (kube_pod_labels{"
+            f"label_paasta_yelp_com_service='{service}',"
+            f"label_yelp_com_paasta_instance='{instance_name}',"
+            f"paasta_cluster='{paasta_cluster}'"
+            "})"
+            ")"
+        )
+        return MetricsProviderDict(
+            type=METRICS_PROVIDER_PROMQL,
+            metrics_query=metrics_query,
+            series_query=(
+                f"kube_deployment_labels{{"
+                f"deployment='{deployment_name}',"
+                f"paasta_cluster='{paasta_cluster}',"
+                f"namespace='{namespace}'"
+                f"}}"
+            ),
+            setpoint=1.0,
+        )
+
+    def get_sanitised_deployment_name(self) -> str:
+        return f"{self.instance}-replica-dep"
+
+    def namespace_custom_prometheus_metric_name(self, metric_name: str) -> str:
+        return f"{self.get_sanitised_deployment_name()}-gpu-prom"
 
 
 def load_nrtsearchserviceeks_instance_config(

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -289,7 +289,9 @@ def create_instance_scaling_rule(
 
 def create_instance_active_requests_scaling_rule(
     service: str,
-    instance_config: KubernetesDeploymentConfig,
+    instance_config: Union[
+        KubernetesDeploymentConfig, NrtsearchServiceEksDeploymentConfig
+    ],
     metrics_provider_config: MetricsProviderDict,
     paasta_cluster: str,
     metric_name: str,
@@ -399,7 +401,9 @@ def create_instance_active_requests_scaling_rule(
 
 def create_instance_uwsgi_scaling_rule(
     service: str,
-    instance_config: KubernetesDeploymentConfig,
+    instance_config: Union[
+        KubernetesDeploymentConfig, NrtsearchServiceEksDeploymentConfig
+    ],
     metrics_provider_config: MetricsProviderDict,
     paasta_cluster: str,
     metric_name: str,
@@ -501,7 +505,9 @@ def create_instance_uwsgi_scaling_rule(
 
 def create_instance_uwsgi_v2_scaling_rule(
     service: str,
-    instance_config: KubernetesDeploymentConfig,
+    instance_config: Union[
+        KubernetesDeploymentConfig, NrtsearchServiceEksDeploymentConfig
+    ],
     metrics_provider_config: MetricsProviderDict,
     paasta_cluster: str,
     metric_name: str,
@@ -572,7 +578,9 @@ def create_instance_uwsgi_v2_scaling_rule(
 
 def create_instance_worker_load_scaling_rule(
     service: str,
-    instance_config: KubernetesDeploymentConfig,
+    instance_config: Union[
+        KubernetesDeploymentConfig, NrtsearchServiceEksDeploymentConfig
+    ],
     metrics_provider_config: MetricsProviderDict,
     paasta_cluster: str,
     metric_name: str,
@@ -645,7 +653,9 @@ def create_instance_worker_load_scaling_rule(
 
 def create_instance_piscina_scaling_rule(
     service: str,
-    instance_config: KubernetesDeploymentConfig,
+    instance_config: Union[
+        KubernetesDeploymentConfig, NrtsearchServiceEksDeploymentConfig
+    ],
     metrics_provider_config: MetricsProviderDict,
     paasta_cluster: str,
     metric_name: str,
@@ -742,7 +752,9 @@ def create_instance_piscina_scaling_rule(
 
 def create_instance_gunicorn_scaling_rule(
     service: str,
-    instance_config: KubernetesDeploymentConfig,
+    instance_config: Union[
+        KubernetesDeploymentConfig, NrtsearchServiceEksDeploymentConfig
+    ],
     metrics_provider_config: MetricsProviderDict,
     paasta_cluster: str,
     metric_name: str,
@@ -995,7 +1007,13 @@ def create_prometheus_adapter_config(
                 rules.extend(
                     get_rules_for_service_instance(
                         service_name=service_name,
-                        instance_config=instance_config,
+                        instance_config=cast(
+                            Union[
+                                KubernetesDeploymentConfig,
+                                NrtsearchServiceEksDeploymentConfig,
+                            ],
+                            instance_config,
+                        ),
                         paasta_cluster=paasta_cluster,
                     )
                 )

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -935,6 +935,106 @@ def get_rules_for_service_instance(
     return rules
 
 
+def get_rules_for_nrtsearch_gpu(
+    paasta_cluster: str, soa_dir: Path
+) -> List[PrometheusAdapterRule]:
+    """
+    Reads nrtsearch CRD manifests from yelpsoa-configs and generates
+    prometheus-adapter rules for any serverSet with targetGpuUtilization
+    configured.
+
+    The nrtsearch-operator manages its own HPA (not through PaaSTA's
+    autoscaling framework), so we need to generate adapter rules by
+    reading the CRD manifests directly.
+    """
+    rules: List[PrometheusAdapterRule] = []
+    nrtsearch_crd_file = (
+        soa_dir / "nrtsearch" / f"nrtsearchserviceeks-{paasta_cluster}.yaml"
+    )
+
+    if not nrtsearch_crd_file.exists():
+        log.debug(f"No nrtsearch CRD file found at {nrtsearch_crd_file}")
+        return rules
+
+    with open(nrtsearch_crd_file) as f:
+        crd_configs = yaml.safe_load(f)
+
+    if not crd_configs:
+        return rules
+
+    for cluster_name, cluster_config in crd_configs.items():
+        server_sets = cluster_config.get("serverSets", [])
+        for server_set in server_sets:
+            autoscaling = server_set.get("autoscaling")
+            if not autoscaling:
+                continue
+            target_gpu_utilization = autoscaling.get("targetGpuUtilization", 0)
+            if target_gpu_utilization <= 0:
+                continue
+
+            is_primary = server_set.get("primary", False)
+            instance_name = "primary" if is_primary else "replica"
+            deployment_name = f"{cluster_name}-{instance_name}-dep"
+            namespace = "paastasvc-nrtsearch"
+            metric_name = f"{deployment_name}-arbitrary_promql-prom"
+
+            metrics_query = f"""
+                label_replace(
+                    label_replace(
+                        avg(
+                            DCGM_FI_DEV_GPU_UTIL
+                                * on(kube_pod, kube_namespace)
+                                group_left()
+                            (
+                                kube_pod_labels{{
+                                    label_paasta_yelp_com_service='nrtsearch',
+                                    label_yelp_com_paasta_instance='{instance_name}',
+                                    label_nrtsearch_yelp_com_nrtsearch_cluster='{cluster_name}',
+                                    namespace='{namespace}',
+                                    paasta_cluster='{paasta_cluster}'
+                                }}
+                            )
+                        ) / {target_gpu_utilization},
+                        'deployment',
+                        '{deployment_name}',
+                        '',
+                        ''
+                    ),
+                    'namespace',
+                    '{namespace}',
+                    '',
+                    ''
+                )
+            """
+
+            series_query = f"""
+                kube_deployment_labels{{
+                    deployment='{deployment_name}',
+                    paasta_cluster='{paasta_cluster}',
+                    namespace='{namespace}'
+                }}
+            """
+
+            rules.append(
+                {
+                    "name": {"as": metric_name},
+                    "seriesQuery": _minify_promql(series_query),
+                    "metricsQuery": _minify_promql(metrics_query),
+                    "resources": cast(
+                        PrometheusAdapterResourceConfig,
+                        DEFAULT_ARBITRARY_PROMQL_RESOURCES,
+                    ),
+                }
+            )
+            log.info(
+                f"Generated GPU autoscaling rule for nrtsearch "
+                f"cluster={cluster_name} instance={instance_name} "
+                f"targetGpuUtilization={target_gpu_utilization}"
+            )
+
+    return rules
+
+
 def create_prometheus_adapter_config(
     paasta_cluster: str, soa_dir: Path
 ) -> PrometheusAdapterConfig:
@@ -980,6 +1080,9 @@ def create_prometheus_adapter_config(
                         paasta_cluster=paasta_cluster,
                     )
                 )
+
+    # Generate rules for nrtsearch GPU autoscaling from CRD manifests
+    rules.extend(get_rules_for_nrtsearch_gpu(paasta_cluster, soa_dir))
 
     return {
         # we sort our rules so that we can easily compare between two different configmaps

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -976,7 +976,7 @@ def get_rules_for_nrtsearch_gpu(
             instance_name = "primary" if is_primary else "replica"
             deployment_name = f"{cluster_name}-{instance_name}-dep"
             namespace = "paastasvc-nrtsearch"
-            metric_name = f"{deployment_name}-arbitrary_promql-prom"
+            metric_name = f"{deployment_name}-gpu-prom"
 
             metrics_query = f"""
                 label_replace(
@@ -989,12 +989,10 @@ def get_rules_for_nrtsearch_gpu(
                                 kube_pod_labels{{
                                     label_paasta_yelp_com_service='nrtsearch',
                                     label_yelp_com_paasta_instance='{instance_name}',
-                                    label_nrtsearch_yelp_com_nrtsearch_cluster='{cluster_name}',
-                                    namespace='{namespace}',
                                     paasta_cluster='{paasta_cluster}'
                                 }}
                             )
-                        ) / {target_gpu_utilization},
+                        ),
                         'deployment',
                         '{deployment_name}',
                         '',

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -21,6 +21,7 @@ from pathlib import Path
 from typing import Dict
 from typing import List
 from typing import Optional
+from typing import Union
 from typing import cast
 
 import ruamel.yaml as yaml
@@ -65,6 +66,7 @@ from paasta_tools.long_running_service_tools import METRICS_PROVIDER_PROMQL
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_UWSGI
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_UWSGI_V2
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_WORKER_LOAD
+from paasta_tools.nrtsearchserviceeks_tools import NrtsearchServiceEksDeploymentConfig
 from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_services_for_cluster
@@ -88,6 +90,7 @@ DEFAULT_EXTRAPOLATION_TIME = DEFAULT_SCRAPE_PERIOD_S * DEFAULT_EXTRAPOLATION_PER
 K8S_INSTANCE_TYPE_CLASSES = (
     KubernetesDeploymentConfig,
     EksDeploymentConfig,
+    NrtsearchServiceEksDeploymentConfig,
 )
 
 
@@ -204,7 +207,9 @@ def _minify_promql(query: str) -> str:
 
 def create_instance_scaling_rule(
     service: str,
-    instance_config: KubernetesDeploymentConfig,
+    instance_config: Union[
+        KubernetesDeploymentConfig, NrtsearchServiceEksDeploymentConfig
+    ],
     metrics_provider_config: MetricsProviderDict,
     paasta_cluster: str,
 ) -> Optional[PrometheusAdapterRule]:
@@ -845,7 +850,9 @@ DEFAULT_ARBITRARY_PROMQL_RESOURCES: PrometheusAdapterResourceConfig = {
 
 def create_instance_arbitrary_promql_scaling_rule(
     service: str,
-    instance_config: KubernetesDeploymentConfig,
+    instance_config: Union[
+        KubernetesDeploymentConfig, NrtsearchServiceEksDeploymentConfig
+    ],
     metrics_provider_config: MetricsProviderDict,
     paasta_cluster: str,
     metric_name: str,
@@ -903,7 +910,9 @@ def create_instance_arbitrary_promql_scaling_rule(
 
 def get_rules_for_service_instance(
     service_name: str,
-    instance_config: KubernetesDeploymentConfig,
+    instance_config: Union[
+        KubernetesDeploymentConfig, NrtsearchServiceEksDeploymentConfig
+    ],
     paasta_cluster: str,
 ) -> List[PrometheusAdapterRule]:
     """
@@ -931,104 +940,6 @@ def get_rules_for_service_instance(
         )
         if rule is not None:
             rules.append(rule)
-
-    return rules
-
-
-def get_rules_for_nrtsearch_gpu(
-    paasta_cluster: str, soa_dir: Path
-) -> List[PrometheusAdapterRule]:
-    """
-    Reads nrtsearch CRD manifests from yelpsoa-configs and generates
-    prometheus-adapter rules for any serverSet with targetGpuUtilization
-    configured.
-
-    The nrtsearch-operator manages its own HPA (not through PaaSTA's
-    autoscaling framework), so we need to generate adapter rules by
-    reading the CRD manifests directly.
-    """
-    rules: List[PrometheusAdapterRule] = []
-    nrtsearch_crd_file = (
-        soa_dir / "nrtsearch" / f"nrtsearchserviceeks-{paasta_cluster}.yaml"
-    )
-
-    if not nrtsearch_crd_file.exists():
-        log.debug(f"No nrtsearch CRD file found at {nrtsearch_crd_file}")
-        return rules
-
-    with open(nrtsearch_crd_file) as f:
-        crd_configs = yaml.safe_load(f)
-
-    if not crd_configs:
-        return rules
-
-    for cluster_name, cluster_config in crd_configs.items():
-        server_sets = cluster_config.get("serverSets", [])
-        for server_set in server_sets:
-            autoscaling = server_set.get("autoscaling")
-            if not autoscaling:
-                continue
-            target_gpu_utilization = autoscaling.get("targetGpuUtilization", 0)
-            if target_gpu_utilization <= 0:
-                continue
-
-            is_primary = server_set.get("primary", False)
-            instance_name = "primary" if is_primary else "replica"
-            deployment_name = f"{cluster_name}-{instance_name}-dep"
-            namespace = "paastasvc-nrtsearch"
-            metric_name = f"{deployment_name}-gpu-prom"
-
-            metrics_query = f"""
-                label_replace(
-                    label_replace(
-                        avg(
-                            DCGM_FI_DEV_GPU_UTIL
-                                * on(kube_pod, kube_namespace)
-                                group_left()
-                            (
-                                kube_pod_labels{{
-                                    label_paasta_yelp_com_service='nrtsearch',
-                                    label_yelp_com_paasta_instance='{instance_name}',
-                                    paasta_cluster='{paasta_cluster}'
-                                }}
-                            )
-                        ),
-                        'deployment',
-                        '{deployment_name}',
-                        '',
-                        ''
-                    ),
-                    'namespace',
-                    '{namespace}',
-                    '',
-                    ''
-                )
-            """
-
-            series_query = f"""
-                kube_deployment_labels{{
-                    deployment='{deployment_name}',
-                    paasta_cluster='{paasta_cluster}',
-                    namespace='{namespace}'
-                }}
-            """
-
-            rules.append(
-                {
-                    "name": {"as": metric_name},
-                    "seriesQuery": _minify_promql(series_query),
-                    "metricsQuery": _minify_promql(metrics_query),
-                    "resources": cast(
-                        PrometheusAdapterResourceConfig,
-                        DEFAULT_ARBITRARY_PROMQL_RESOURCES,
-                    ),
-                }
-            )
-            log.info(
-                f"Generated GPU autoscaling rule for nrtsearch "
-                f"cluster={cluster_name} instance={instance_name} "
-                f"targetGpuUtilization={target_gpu_utilization}"
-            )
 
     return rules
 
@@ -1062,6 +973,16 @@ def create_prometheus_adapter_config(
             )
         }
     )
+    services.update(
+        {
+            service_name
+            for service_name, _ in get_services_for_cluster(
+                cluster=paasta_cluster,
+                instance_type="nrtsearchserviceeks",
+                soa_dir=str(soa_dir),
+            )
+        }
+    )
     for service_name in services:
         config_loader = PaastaServiceConfigLoader(
             service=service_name, soa_dir=str(soa_dir)
@@ -1078,9 +999,6 @@ def create_prometheus_adapter_config(
                         paasta_cluster=paasta_cluster,
                     )
                 )
-
-    # Generate rules for nrtsearch GPU autoscaling from CRD manifests
-    rules.extend(get_rules_for_nrtsearch_gpu(paasta_cluster, soa_dir))
 
     return {
         # we sort our rules so that we can easily compare between two different configmaps

--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -11,6 +11,7 @@ from paasta_tools.long_running_service_tools import METRICS_PROVIDER_MEMORY
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_UWSGI
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_UWSGI_V2
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_WORKER_LOAD
+from paasta_tools.nrtsearchserviceeks_tools import NrtsearchServiceEksDeploymentConfig
 from paasta_tools.setup_prometheus_adapter_config import _minify_promql
 from paasta_tools.setup_prometheus_adapter_config import (
     create_instance_active_requests_scaling_rule,
@@ -30,7 +31,6 @@ from paasta_tools.setup_prometheus_adapter_config import (
 from paasta_tools.setup_prometheus_adapter_config import (
     create_instance_worker_load_scaling_rule,
 )
-from paasta_tools.nrtsearchserviceeks_tools import NrtsearchServiceEksDeploymentConfig
 from paasta_tools.setup_prometheus_adapter_config import get_rules_for_service_instance
 
 

--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -30,6 +30,7 @@ from paasta_tools.setup_prometheus_adapter_config import (
 from paasta_tools.setup_prometheus_adapter_config import (
     create_instance_worker_load_scaling_rule,
 )
+from paasta_tools.setup_prometheus_adapter_config import get_rules_for_nrtsearch_gpu
 from paasta_tools.setup_prometheus_adapter_config import get_rules_for_service_instance
 
 
@@ -485,3 +486,71 @@ def test_create_instance_arbitrary_promql_scaling_rule_with_custom_resources():
         "metricsQuery": "foo",
         "seriesQuery": "bar",
     }
+
+
+def test_get_rules_for_nrtsearch_gpu(tmp_path):
+    """Test that nrtsearch CRD manifests with targetGpuUtilization generate adapter rules."""
+    nrtsearch_dir = tmp_path / "nrtsearch"
+    nrtsearch_dir.mkdir()
+    crd_file = nrtsearch_dir / "nrtsearchserviceeks-pnw-prod.yaml"
+    crd_file.write_text(
+        """
+my-cluster:
+  serverSets:
+  - name: indexing
+    primary: true
+    count: 1
+  - name: search
+    primary: false
+    autoscaling:
+      minInstances: 2
+      maxInstances: 10
+      targetCpuUtilization: 80
+      targetGpuUtilization: 70
+      stabilizationWindow: 600
+"""
+    )
+
+    rules = get_rules_for_nrtsearch_gpu(paasta_cluster="pnw-prod", soa_dir=tmp_path)
+
+    assert len(rules) == 1
+    rule = rules[0]
+    assert rule["name"]["as"] == "my-cluster-replica-dep-arbitrary_promql-prom"
+    assert "DCGM_FI_DEV_GPU_UTIL" in rule["metricsQuery"]
+    assert "/ 70" in rule["metricsQuery"]
+    assert "my-cluster-replica-dep" in rule["seriesQuery"]
+    assert "pnw-prod" in rule["seriesQuery"]
+    assert rule["resources"] == {
+        "overrides": {
+            "namespace": {"resource": "namespace"},
+            "deployment": {"group": "apps", "resource": "deployments"},
+        },
+    }
+
+
+def test_get_rules_for_nrtsearch_gpu_no_file(tmp_path):
+    """Test that missing CRD file returns empty rules."""
+    rules = get_rules_for_nrtsearch_gpu(paasta_cluster="pnw-prod", soa_dir=tmp_path)
+    assert rules == []
+
+
+def test_get_rules_for_nrtsearch_gpu_no_gpu_config(tmp_path):
+    """Test that clusters without targetGpuUtilization are skipped."""
+    nrtsearch_dir = tmp_path / "nrtsearch"
+    nrtsearch_dir.mkdir()
+    crd_file = nrtsearch_dir / "nrtsearchserviceeks-pnw-prod.yaml"
+    crd_file.write_text(
+        """
+my-cluster:
+  serverSets:
+  - name: search
+    primary: false
+    autoscaling:
+      minInstances: 2
+      maxInstances: 10
+      targetCpuUtilization: 80
+"""
+    )
+
+    rules = get_rules_for_nrtsearch_gpu(paasta_cluster="pnw-prod", soa_dir=tmp_path)
+    assert rules == []

--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -30,7 +30,7 @@ from paasta_tools.setup_prometheus_adapter_config import (
 from paasta_tools.setup_prometheus_adapter_config import (
     create_instance_worker_load_scaling_rule,
 )
-from paasta_tools.setup_prometheus_adapter_config import get_rules_for_nrtsearch_gpu
+from paasta_tools.nrtsearchserviceeks_tools import NrtsearchServiceEksDeploymentConfig
 from paasta_tools.setup_prometheus_adapter_config import get_rules_for_service_instance
 
 
@@ -488,36 +488,43 @@ def test_create_instance_arbitrary_promql_scaling_rule_with_custom_resources():
     }
 
 
-def test_get_rules_for_nrtsearch_gpu(tmp_path):
-    """Test that nrtsearch CRD manifests with targetGpuUtilization generate adapter rules."""
-    nrtsearch_dir = tmp_path / "nrtsearch"
-    nrtsearch_dir.mkdir()
-    crd_file = nrtsearch_dir / "nrtsearchserviceeks-pnw-prod.yaml"
-    crd_file.write_text(
-        """
-my-cluster:
-  serverSets:
-  - name: indexing
-    primary: true
-    count: 1
-  - name: search
-    primary: false
-    autoscaling:
-      minInstances: 2
-      maxInstances: 10
-      targetCpuUtilization: 80
-      targetGpuUtilization: 70
-      stabilizationWindow: 600
-"""
+def test_nrtsearch_gpu_autoscaling_via_service_instance():
+    """Test that nrtsearch configs with targetGpuUtilization generate adapter rules
+    through the standard get_rules_for_service_instance path."""
+    instance_config = NrtsearchServiceEksDeploymentConfig(
+        service="nrtsearch",
+        cluster="pnw-prod",
+        instance="my-cluster",
+        config_dict={
+            "serverSets": [
+                {"name": "indexing", "primary": True, "count": 1},
+                {
+                    "name": "search",
+                    "primary": False,
+                    "autoscaling": {
+                        "minInstances": 2,
+                        "maxInstances": 10,
+                        "targetCpuUtilization": 80,
+                        "targetGpuUtilization": 70,
+                        "stabilizationWindow": 600,
+                    },
+                },
+            ],
+        },
+        branch_dict=None,
+        soa_dir="/mock/soa",
     )
 
-    rules = get_rules_for_nrtsearch_gpu(paasta_cluster="pnw-prod", soa_dir=tmp_path)
+    rules = get_rules_for_service_instance(
+        service_name="nrtsearch",
+        instance_config=instance_config,
+        paasta_cluster="pnw-prod",
+    )
 
     assert len(rules) == 1
     rule = rules[0]
     assert rule["name"]["as"] == "my-cluster-replica-dep-gpu-prom"
     assert "DCGM_FI_DEV_GPU_UTIL" in rule["metricsQuery"]
-    assert "/ 70" not in rule["metricsQuery"]
     assert "my-cluster-replica-dep" in rule["seriesQuery"]
     assert "pnw-prod" in rule["seriesQuery"]
     assert rule["resources"] == {
@@ -528,29 +535,63 @@ my-cluster:
     }
 
 
-def test_get_rules_for_nrtsearch_gpu_no_file(tmp_path):
-    """Test that missing CRD file returns empty rules."""
-    rules = get_rules_for_nrtsearch_gpu(paasta_cluster="pnw-prod", soa_dir=tmp_path)
+def test_nrtsearch_no_gpu_config_returns_no_rules():
+    """Test that nrtsearch configs without targetGpuUtilization produce no rules."""
+    instance_config = NrtsearchServiceEksDeploymentConfig(
+        service="nrtsearch",
+        cluster="pnw-prod",
+        instance="my-cluster",
+        config_dict={
+            "serverSets": [
+                {
+                    "name": "search",
+                    "primary": False,
+                    "autoscaling": {
+                        "minInstances": 2,
+                        "maxInstances": 10,
+                        "targetCpuUtilization": 80,
+                    },
+                },
+            ],
+        },
+        branch_dict=None,
+        soa_dir="/mock/soa",
+    )
+
+    rules = get_rules_for_service_instance(
+        service_name="nrtsearch",
+        instance_config=instance_config,
+        paasta_cluster="pnw-prod",
+    )
+
     assert rules == []
 
 
-def test_get_rules_for_nrtsearch_gpu_no_gpu_config(tmp_path):
-    """Test that clusters without targetGpuUtilization are skipped."""
-    nrtsearch_dir = tmp_path / "nrtsearch"
-    nrtsearch_dir.mkdir()
-    crd_file = nrtsearch_dir / "nrtsearchserviceeks-pnw-prod.yaml"
-    crd_file.write_text(
-        """
-my-cluster:
-  serverSets:
-  - name: search
-    primary: false
-    autoscaling:
-      minInstances: 2
-      maxInstances: 10
-      targetCpuUtilization: 80
-"""
+def test_nrtsearch_primary_server_set_skipped():
+    """Test that primary serverSets are never used for GPU autoscaling."""
+    instance_config = NrtsearchServiceEksDeploymentConfig(
+        service="nrtsearch",
+        cluster="pnw-prod",
+        instance="my-cluster",
+        config_dict={
+            "serverSets": [
+                {
+                    "name": "indexing",
+                    "primary": True,
+                    "autoscaling": {
+                        "targetGpuUtilization": 70,
+                    },
+                },
+            ],
+        },
+        branch_dict=None,
+        soa_dir="/mock/soa",
     )
 
-    rules = get_rules_for_nrtsearch_gpu(paasta_cluster="pnw-prod", soa_dir=tmp_path)
+    rules = get_rules_for_service_instance(
+        service_name="nrtsearch",
+        instance_config=instance_config,
+        paasta_cluster="pnw-prod",
+    )
+
     assert rules == []

--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -515,9 +515,9 @@ my-cluster:
 
     assert len(rules) == 1
     rule = rules[0]
-    assert rule["name"]["as"] == "my-cluster-replica-dep-arbitrary_promql-prom"
+    assert rule["name"]["as"] == "my-cluster-replica-dep-gpu-prom"
     assert "DCGM_FI_DEV_GPU_UTIL" in rule["metricsQuery"]
-    assert "/ 70" in rule["metricsQuery"]
+    assert "/ 70" not in rule["metricsQuery"]
     assert "my-cluster-replica-dep" in rule["seriesQuery"]
     assert "pnw-prod" in rule["seriesQuery"]
     assert rule["resources"] == {


### PR DESCRIPTION
## Summary

Teaches `setup_prometheus_adapter_config.py` to read nrtsearch CRD manifests and generate prometheus-adapter rules for GPU-based autoscaling.

  ## Context

The nrtsearch-operator manages its own HPA (not through PaaSTA's autoscaling framework), so the existing `get_rules_for_service_instance` path doesn't apply. However, the operator's HPA still needs the prometheus-adapter to serve its custom metric.

 This adds a new function `get_rules_for_nrtsearch_gpu()` that:
  1. Reads `{soa_dir}/nrtsearch/nrtsearchserviceeks-{cluster}.yaml`
  2. Finds any serverSet with `targetGpuUtilization > 0`
  3. Generates an adapter rule that joins `DCGM_FI_DEV_GPU_UTIL` with `kube_pod_labels` to associate GPU utilization with nrtsearch pods
  4. Divides by the target so the HPA sees 1.0 when at target utilization

  The generated metric name follows the existing convention: `{deployment-name}-arbitrary_promql-prom`.



  ## Test plan

  - [x] New unit tests: rule generation, missing file handling, no-gpu-config skip
