### PR TITLE
Stop overriding user-specified podTemplateFile in Tron Spark jobs

### DIFF
--- a/paasta_tools/tron_tools.py
+++ b/paasta_tools/tron_tools.py
@@ -380,16 +380,10 @@ class TronActionConfig(InstanceConfig):
                 else stringified_spark_args["spark.app.name"]
             )
 
-        # TODO(MLCOMPUTE-1220): Remove this once dynamic pod template is generated inside the driver using spark-submit wrapper
-        if "spark.kubernetes.executor.podTemplateFile" in spark_conf:
-            log.info(
-                f"Replacing spark.kubernetes.executor.podTemplateFile="
-                f"{spark_conf['spark.kubernetes.executor.podTemplateFile']} with "
-                f"spark.kubernetes.executor.podTemplateFile={spark_tools.SPARK_DNS_POD_TEMPLATE}"
-            )
-        spark_conf[
-            "spark.kubernetes.executor.podTemplateFile"
-        ] = spark_tools.SPARK_DNS_POD_TEMPLATE
+        spark_conf.setdefault(
+            "spark.kubernetes.executor.podTemplateFile",
+            spark_tools.SPARK_DNS_POD_TEMPLATE,
+        )
 
         spark_conf.update(
             {


### PR DESCRIPTION
Use setdefault instead of unconditionally overwriting, so users who explicitly set spark.kubernetes.executor.podTemplateFile keep their value while the DNS pod template remains the default.