### PR TITLE
Handle malformed Flink job details in status output

### DIFF
--- a/paasta_tools/flink_tools.py
+++ b/paasta_tools/flink_tools.py
@@ -724,9 +724,17 @@ def format_flink_jobs_table(
     if checkpoint_data is None:
         checkpoint_data = {}
 
+    # Some job details can be empty objects when the jobs list is stale.
+    # Keep only entries with fields required to render job rows.
+    jobs_with_display_fields = [
+        job for job in jobs if job.get("name") and job.get("start_time")
+    ]
+
     # Avoid cutting job name — use max length of actual job names
-    if jobs:
-        max_job_name_length = max([len(get_flink_job_name(job)) for job in jobs])
+    if jobs_with_display_fields:
+        max_job_name_length = max(
+            [len(get_flink_job_name(job)) for job in jobs_with_display_fields]
+        )
     else:
         max_job_name_length = 10
 
@@ -750,10 +758,7 @@ def format_flink_jobs_table(
     unique_jobs = (
         sorted(job_list, key=lambda j: -j["start_time"])[0]  # type: ignore
         for _, job_list in groupby(
-            sorted(
-                (j for j in jobs if j.get("name") and j.get("start_time")),
-                key=lambda j: j["name"],
-            ),
+            sorted(jobs_with_display_fields, key=lambda j: j["name"]),
             lambda j: j["name"],
         )
     )

--- a/tests/test_flink_tools.py
+++ b/tests/test_flink_tools.py
@@ -821,6 +821,16 @@ class TestFormatFlinkJobsTable:
         output_text = "\n".join(result)
         assert "None" not in output_text
 
+    def test_skips_jobs_missing_required_display_fields(self, mock_terminal_size):
+        mock_terminal_size.return_value = mock.Mock(columns=120)
+        malformed_job = {}
+        valid_job = self._make_job({"jid": "good123", "name": "beam.main.good_job"})
+        result = flink_tools.format_flink_jobs_table(
+            [malformed_job, valid_job], "http://dashboard", 0
+        )
+        output_text = "\n".join(result)
+        assert "good_job" in output_text
+
 
 class TestFormatFlinkUdfInfo:
     def _make_config(self, extra_config: dict) -> FlinkDeploymentConfig:

--- a/tests/test_flink_tools.py
+++ b/tests/test_flink_tools.py
@@ -823,13 +823,17 @@ class TestFormatFlinkJobsTable:
 
     def test_skips_jobs_missing_required_display_fields(self, mock_terminal_size):
         mock_terminal_size.return_value = mock.Mock(columns=120)
-        malformed_job = {}
+        empty_job = {}
+        malformed_job = {"jid": "bad123", "name": "beam.main.bad_job"}
         valid_job = self._make_job({"jid": "good123", "name": "beam.main.good_job"})
         result = flink_tools.format_flink_jobs_table(
-            [malformed_job, valid_job], "http://dashboard", 0
+            [empty_job, malformed_job, valid_job], "http://dashboard", 0
         )
         output_text = "\n".join(result)
+        rendered_job_lines = [line for line in result if "job" in line]
+        assert len(rendered_job_lines) == 1
         assert "good_job" in output_text
+        assert "bad_job" not in output_text
 
 
 class TestFormatFlinkUdfInfo:


### PR DESCRIPTION
## Summary
- skip Flink job detail entries that do not contain required display fields (`name`, `start_time`) before table width and grouping logic
- prevent `paasta status` from crashing when job-details responses deserialize to empty objects
- add a regression test covering a malformed job detail (`{}`) alongside a valid job

## Problem
`paasta status` for Flink can crash with:

```py
ApiAttributeError: FlinkJobDetails has no attribute 'name'
```

This happens when the jobs list includes a stale job id and the job-details endpoint returns an error payload (e.g. 404 wrapper) that deserializes to `{}`.

## Repro
```bash
paasta status -c pnw-prod -s datapipe_s3_flink_processor -i bunsen
```

## Testing
- runtime sanity check of `format_flink_jobs_table([{}, valid_job], ...)` confirms no crash and valid row output
- added unit test: `test_skips_jobs_missing_required_display_fields`
