### PR TITLE
DREIMP-11556 Add cassandracluster/cassandraclustereks counterpart mapping

### DIFF
--- a/paasta_tools/config_utils.py
+++ b/paasta_tools/config_utils.py
@@ -30,7 +30,12 @@ KNOWN_CONFIG_TYPES = (
 # this could use a better name - but basically, this is for pairs of instance types
 # where you generally want to check both types (i.e.,g a status-quo and migration
 # instance type)
-INSTANCE_TYPE_COUNTERPARTS = {"eks": "kubernetes", "kubernetes": "eks"}
+INSTANCE_TYPE_COUNTERPARTS = {
+    "eks": "kubernetes",
+    "kubernetes": "eks",
+    "cassandracluster": "cassandraclustereks",
+    "cassandraclustereks": "cassandracluster",
+}
 
 
 def my_represent_none(self, data):


### PR DESCRIPTION
## Problem

After the non-EKS `cassandracluster-*.yaml` files were removed from yelpsoa-configs (TOOL-589), the autotune rightsizer silently skipped all Cassandra recommendations because
  `INSTANCE_TYPE_COUNTERPARTS` had no mapping for `cassandracluster` ↔ `cassandraclustereks`.

`cassandra-paasta-autotune` Jenkins job did not produce changes and reported "No files changed"


## Summary

Add the missing counterpart pair so `merge_recommendations` can find instances in the EKS config files.
