### PR TITLE
fix: labels for adapter

### DIFF
--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -926,7 +926,7 @@ def create_shared_worker_load_scaling_rule(
     replicas_filter_terms = (
         f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)'"
     )
-    deployment_labels_filter_terms = f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)',label_paasta_yelp_com_service='<<index .Labels \"paasta_service\">>',label_paasta_yelp_com_instance='<<index .Labels \"paasta_instance\">>'"
+    deployment_labels_filter_terms = f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)',label_paasta_yelp_com_service='<<index .LabelValuesByName \"paasta_service\">>',label_paasta_yelp_com_instance='<<index .LabelValuesByName \"paasta_instance\">>'"
     missing_instances = f"""
         (clamp_min(
             label_replace(


### PR DESCRIPTION
The current templated metrics do not return any metrics from the prometheus adapter. 

<img width="1691" height="784" alt="Screenshot 2026-07-08 at 23 33 09" src="https://github.com/user-attachments/assets/08353ef3-d0be-4ce9-aedb-3d8cc22312bd" />


### Why is this the right label now?

https://sourcegraph.yelpcorp.com/r/misc/k8s-prometheus-adapter/-/blob/pkg/naming/metrics_query.go?L76-78
