### PR TITLE
paasta-secret: authenticate with Okta by default

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -468,7 +468,7 @@ def add_subparser(subparsers):
         dest="vault_auth_method",
         required=False,
         default="token",
-        choices=["token", "ldap"],
+        choices=["token", "okta"],
     )
     list_parser.add_argument(
         "--vault-token-file",

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -224,11 +224,11 @@ def _add_and_update_args(parser: argparse.ArgumentParser):
 def _add_vault_auth_args(parser: argparse.ArgumentParser):
     parser.add_argument(
         "--vault-auth-method",
-        help="Override how we auth with vault, defaults to token if not present",
+        help="Override how we auth with vault, defaults to Okta if not present",
         type=str,
         dest="vault_auth_method",
         required=False,
-        default="token",
+        default="okta",
         choices=["token", "okta"],
     )
     parser.add_argument(


### PR DESCRIPTION
This is a strong opinion, more than a fix, but encryption via `paasta secret add/update` happens authenticating with Okta by default, so I think decryption should do the same too.
Lately people setting up custom Vault endpoint to protect more sensitive secrets have been having trouble using the `paasta secret` CLI because of the existing default behaviour.
In normal circumstances, `paasta local-run` can already do secret decryption via the token, so I'd want the default behaviour of `paasta secret run` to be authenticating users directly.