### PR TITLE
remove secrets_for_teams

### DIFF
--- a/paasta_tools/cli/cmds/local_run.py
+++ b/paasta_tools/cli/cmds/local_run.py
@@ -68,7 +68,6 @@ from paasta_tools.utils import _run
 from paasta_tools.utils import get_docker_client
 from paasta_tools.utils import get_possible_launched_by_user_variable_from_env
 from paasta_tools.utils import get_username
-from paasta_tools.utils import is_secrets_for_teams_enabled
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
@@ -502,6 +501,14 @@ def add_subparser(subparsers):
         default=decrypt_by_default,
     )
     list_parser.add_argument(
+        "--secrets-from-kube",
+        help="Read secrets directly from Kubernetes API",
+        dest="secrets_from_kube",
+        required=False,
+        action="store_true",
+        default=False,
+    )
+    list_parser.add_argument(
         "--assume-role-aws-account",
         "--aws-account",
         "-a",
@@ -884,6 +891,7 @@ def run_docker_container(
     assume_role_aws_account: Optional[str] = None,
     use_service_auth_token: bool = False,
     use_sso_service_auth_token: bool = False,
+    secrets_from_kube: bool = False,
 ):
     """docker-py has issues running a container with a TTY attached, so for
     consistency we execute 'docker run' directly in both interactive and
@@ -910,7 +918,7 @@ def run_docker_container(
     secret_volumes = {}  # type: ignore
     if not skip_secrets:
         # if secrets_for_owner_team enabled in yelpsoa for service
-        if is_secrets_for_teams_enabled(service, soa_dir):
+        if secrets_from_kube:
             try:
                 cluster = instance_config.cluster
                 # Clusters that have both an EKS and non-EKS pair use
@@ -1329,6 +1337,7 @@ def configure_and_run_docker_container(
         use_okta_role=args.use_okta_role,
         use_service_auth_token=args.use_service_auth_token,
         use_sso_service_auth_token=args.use_sso_service_auth_token,
+        secrets_from_kube=args.secrets_from_kube,
     )
 
 

--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -40,7 +40,6 @@ from paasta_tools.secret_tools import decrypt_secret_environment_variables
 from paasta_tools.secret_tools import get_secret_provider
 from paasta_tools.utils import _log_audit
 from paasta_tools.utils import atomic_file_write
-from paasta_tools.utils import is_secrets_for_teams_enabled
 from paasta_tools.utils import list_clusters
 from paasta_tools.utils import list_services
 from paasta_tools.utils import load_system_paasta_config
@@ -102,6 +101,13 @@ def add_decrypt_subparser(subparsers):
         ),
     ).completer = lazy_choices_completer(list_clusters)
 
+    secret_parser_decrypt.add_argument(
+        "--from-kube",
+        required=False,
+        action="store_true",
+        help="Read secrets directly from Kubernetes API",
+    )
+
 
 def _validate_single_cluster(arg: str) -> str:
     if len(arg.split(",")) > 1:
@@ -154,6 +160,13 @@ def add_run_subparser(subparsers):
             "The command to run with the specified PaaSTA secrets. "
             "If not given, starts an interactive bash shell."
         ),
+    )
+
+    secret_parser_run.add_argument(
+        "--from-kube",
+        required=False,
+        action="store_true",
+        help="Read secrets directly from Kubernetes API",
     )
 
 
@@ -507,10 +520,8 @@ def paasta_secret(args):
     else:
         service = args.service
 
-    # Check if "decrypt" and "secrets_for_teams" first to avoid vault auth
-    if args.action == "decrypt" and is_secrets_for_teams_enabled(
-        service, args.yelpsoa_config_root
-    ):
+    # Check if "decrypt" and "from_kube" first to avoid vault auth
+    if args.action == "decrypt" and args.from_kube:
         clusters = (
             args.clusters.split(",")
             if args.clusters
@@ -621,7 +632,7 @@ def paasta_secret(args):
         )
         environment = instance_config.get_env()
 
-        if is_secrets_for_teams_enabled(service, args.yelpsoa_config_root):
+        if args.from_kube:
             cluster = instance_config.cluster
             kube_context = cluster if cluster.startswith("eks-") else f"eks-{cluster}"
             kube_client = KubeClient(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -80,7 +80,6 @@ from docker.utils import kwargs_from_env
 from environment_tools.type_utils import convert_location_type
 from kazoo.client import KazooClient
 from mypy_extensions import TypedDict
-from service_configuration_lib import read_extra_service_information
 from service_configuration_lib import read_service_configuration
 
 import paasta_tools.cli.fsm
@@ -3261,11 +3260,6 @@ def get_production_deploy_group(service: str, soa_dir: str = DEFAULT_SOA_DIR) ->
 def get_pipeline_config(service: str, soa_dir: str = DEFAULT_SOA_DIR) -> List[Dict]:
     service_configuration = read_service_configuration(service, soa_dir)
     return service_configuration.get("deploy", {}).get("pipeline", [])
-
-
-def is_secrets_for_teams_enabled(service: str, soa_dir: str = DEFAULT_SOA_DIR) -> bool:
-    service_yaml_contents = read_extra_service_information(service, "service", soa_dir)
-    return service_yaml_contents.get("secrets_for_owner_team", False)
 
 
 def get_pipeline_deploy_group_configs(

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -403,6 +403,7 @@ def test_configure_and_run_command_uses_cmd_from_config(
     args.use_okta_role = False
     args.use_service_auth_token = False
     args.use_sso_service_auth_token = False
+    args.secrets_from_kube = False
 
     mock_secret_provider_kwargs = {
         "vault_cluster_config": {},
@@ -447,6 +448,7 @@ def test_configure_and_run_command_uses_cmd_from_config(
         use_okta_role=False,
         use_service_auth_token=False,
         use_sso_service_auth_token=False,
+        secrets_from_kube=False,
     )
 
 
@@ -484,6 +486,7 @@ def test_configure_and_run_uses_bash_by_default_when_interactive(
     args.use_okta_role = False
     args.use_service_auth_token = False
     args.use_sso_service_auth_token = False
+    args.secrets_from_kube = False
 
     return_code = configure_and_run_docker_container(
         docker_client=mock_docker_client,
@@ -527,6 +530,7 @@ def test_configure_and_run_uses_bash_by_default_when_interactive(
         use_okta_role=False,
         use_service_auth_token=False,
         use_sso_service_auth_token=False,
+        secrets_from_kube=False,
     )
 
 
@@ -570,6 +574,7 @@ def test_configure_and_run_pulls_image_when_asked(
     args.use_okta_role = False
     args.use_service_auth_token = False
     args.use_sso_service_auth_token = False
+    args.secrets_from_kube = False
 
     return_code = configure_and_run_docker_container(
         docker_client=mock_docker_client,
@@ -617,6 +622,7 @@ def test_configure_and_run_pulls_image_when_asked(
         use_okta_role=False,
         use_service_auth_token=False,
         use_sso_service_auth_token=False,
+        secrets_from_kube=False,
     )
 
 
@@ -656,6 +662,7 @@ def test_configure_and_run_docker_container_defaults_to_interactive_instance(
         args.use_okta_role = False
         args.use_service_auth_token = False
         args.use_sso_service_auth_token = False
+        args.secrets_from_kube = False
 
         mock_config = mock.create_autospec(AdhocJobConfig)
         mock_get_default_interactive_config.return_value = mock_config
@@ -701,6 +708,7 @@ def test_configure_and_run_docker_container_defaults_to_interactive_instance(
             use_okta_role=False,
             use_service_auth_token=False,
             use_sso_service_auth_token=False,
+            secrets_from_kube=False,
         )
 
 
@@ -2311,15 +2319,11 @@ def test_run_docker_container_secret_volumes(
     new_callable=mock.mock_open(),
     autospec=None,
 )
-@mock.patch(
-    "paasta_tools.cli.cmds.local_run.is_secrets_for_teams_enabled", autospec=True
-)
 @mock.patch("paasta_tools.cli.cmds.local_run.KubeClient", autospec=True)
 @mock.patch("os.makedirs", autospec=True)
-def test_run_docker_container_secret_volumes_for_teams(
+def test_run_docker_container_secret_volumes_from_kube(
     mock_os_makedirs,
     mock_kube_client,
-    mock_is_secrets_for_teams_enabled,
     mock_open,
     mock_get_kubernetes_secret_volumes,
     mock_get_healthcheck_for_instance,
@@ -2352,7 +2356,6 @@ def test_run_docker_container_secret_volumes_for_teams(
 
     # For tests that run on github actions, explicitly set this to /tmp which definitely exists
     os.environ["TMPDIR"] = "/tmp/"
-    mock_is_secrets_for_teams_enabled.return_value = True
     return_code = run_docker_container(
         docker_client=mock_docker_client,
         service="fake_service",
@@ -2366,6 +2369,7 @@ def test_run_docker_container_secret_volumes_for_teams(
         user_port=None,
         instance_config=mock_service_manifest,
         secret_provider_name="vault",
+        secrets_from_kube=True,
     )
     assert 1 == mock_get_docker_run_cmd.call_count
 
@@ -2483,13 +2487,9 @@ def test_run_docker_container_secret_volumes_raises(
     new_callable=mock.mock_open(),
     autospec=None,
 )
-@mock.patch(
-    "paasta_tools.cli.cmds.local_run.is_secrets_for_teams_enabled", autospec=True
-)
 @mock.patch("paasta_tools.cli.cmds.local_run.KubeClient", autospec=True)
-def test_run_docker_container_secret_volumes_for_teams_raises(
+def test_run_docker_container_secret_volumes_from_kube_raises(
     mock_kube_client,
-    mock_is_secrets_for_teams_enabled,
     mock_open,
     mock_get_kubernetes_secret_volumes,
     mock_get_healthcheck_for_instance,
@@ -2523,6 +2523,7 @@ def test_run_docker_container_secret_volumes_for_teams_raises(
             user_port=None,
             instance_config=mock_service_manifest,
             secret_provider_name="vault",
+            secrets_from_kube=True,
         )
     assert 0 == mock_get_docker_run_cmd.call_count
     assert 1 == sys_exit.value.code

--- a/tests/cli/test_cmds_secret.py
+++ b/tests/cli/test_cmds_secret.py
@@ -147,8 +147,6 @@ def test_paasta_secret():
     ) as mock_get_plaintext_input, mock.patch(
         "paasta_tools.cli.cmds.secret._log_audit", autospec=True
     ) as mock_log_audit, mock.patch(
-        "paasta_tools.cli.cmds.secret.is_secrets_for_teams_enabled", autospec=True
-    ) as mock_is_secrets_for_teams_enabled, mock.patch(
         "paasta_tools.cli.cmds.secret.get_secret", autospec=True
     ) as mock_get_secret, mock.patch(
         "paasta_tools.cli.cmds.secret.KubeClient", autospec=True
@@ -221,8 +219,8 @@ def test_paasta_secret():
             service="middleearth",
             clusters="mesosstage",
             shared=False,
+            from_kube=False,
         )
-        mock_is_secrets_for_teams_enabled.return_value = False
         secret.paasta_secret(mock_args)
         mock_get_secret_provider_for_service.assert_called_with(
             "middleearth",
@@ -234,7 +232,7 @@ def test_paasta_secret():
             secret_provider=mock_secret_provider, secret_name="theonering"
         )
 
-        # decrypt with secrets_for_teams enabled
+        # decrypt with from_kube enabled
         mock_args = mock.Mock(
             action="decrypt",
             secret_name="theonering",
@@ -242,16 +240,15 @@ def test_paasta_secret():
             clusters="mesosstage",
             yelpsoa_config_root="something",
             shared=False,
+            from_kube=True,
         )
         kube_client = mock.Mock()
-        mock_is_secrets_for_teams_enabled.return_value = True
         mock_get_namespaces_for_secret.return_value = {"paastasvc-middleearth"}
         mock_select_k8s_secret_namespace.return_value = "paastasvc-middleearth"
         mock_kube_client.return_value = kube_client
 
         secret.paasta_secret(mock_args)
 
-        mock_is_secrets_for_teams_enabled.assert_called_with("middleearth", "something")
         mock_kube_client.assert_called_with(
             config_file=KUBE_CONFIG_USER_PATH, context="mesosstage"
         )
@@ -331,10 +328,6 @@ def test_paasta_secret_run():
         "paasta_tools.cli.cmds.secret.get_instance_config",
         autospec=True,
     ), mock.patch(
-        "paasta_tools.cli.cmds.secret.is_secrets_for_teams_enabled",
-        autospec=True,
-        return_value=False,
-    ), mock.patch(
         "paasta_tools.cli.cmds.secret.load_system_paasta_config", autospec=True
     ), mock.patch(
         "os.execvpe",
@@ -349,6 +342,7 @@ def test_paasta_secret_run():
             clusters="mesosstage",
             instance="main",
             cmd=["foo"],
+            from_kube=False,
         )
 
         secret.paasta_secret(mock_args)
@@ -363,15 +357,11 @@ def test_paasta_secret_run():
         )
 
 
-def test_paasta_secret_run_secrets_for_teams():
+def test_paasta_secret_run_secrets_from_kube():
     with mock.patch(
         "paasta_tools.cli.cmds.secret.get_instance_config",
         autospec=True,
     ) as mock_get_instance_config, mock.patch(
-        "paasta_tools.cli.cmds.secret.is_secrets_for_teams_enabled",
-        autospec=True,
-        return_value=True,
-    ), mock.patch(
         "paasta_tools.cli.cmds.secret.KubeClient",
         autospec=True,
     ), mock.patch(
@@ -397,6 +387,7 @@ def test_paasta_secret_run_secrets_for_teams():
             clusters="pnw-devc",
             instance="main",
             cmd=["foo"],
+            from_kube=True,
         )
 
         secret.paasta_secret(mock_args)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -2861,31 +2861,6 @@ def test_filter_templates_from_config():
     }
 
 
-def test_is_secrets_for_teams_enabled():
-    with mock.patch(
-        "paasta_tools.utils.read_extra_service_information", autospec=True
-    ) as mock_read_extra_service_information:
-        service = "example_secrets_for_teams"
-
-        # if enabled
-        mock_read_extra_service_information.return_value = {
-            "description": "something",
-            "secrets_for_owner_team": True,
-        }
-        assert utils.is_secrets_for_teams_enabled(service)
-
-        # if specifically not enabled
-        mock_read_extra_service_information.return_value = {
-            "description": "something",
-            "secrets_for_owner_team": False,
-        }
-        assert not utils.is_secrets_for_teams_enabled(service)
-
-        # if not present
-        mock_read_extra_service_information.return_value = {"description": "something"}
-        assert not utils.is_secrets_for_teams_enabled(service)
-
-
 @pytest.mark.parametrize(
     "cluster,pool,system_paasta_config,expected",
     [


### PR DESCRIPTION
This was a feature powered by our OPA authorization layer, which is dead since the migration to EKS, so worth removing support.

**EDIT:** since apparently there are some people that still relied on the feature, using it wrong though, I introduced a CLI argument that can be used to trigger the same codepath that will query k8s APIs for secrets.