### PR TITLE
PEREL-5643: support Gi/Mi strings in autotune_limits mem/disk clamping

### DIFF
--- a/paasta_tools/config_utils.py
+++ b/paasta_tools/config_utils.py
@@ -9,6 +9,7 @@ from typing import List
 from typing import Optional
 from typing import Set
 from typing import Tuple
+from typing import Union
 
 import ruamel.yaml as yaml
 
@@ -21,7 +22,7 @@ log = logging.getLogger(__name__)
 _RESOURCE_UNIT_TO_MIB = {"Gi": 1024.0, "Mi": 1.0, "Ki": 1.0 / 1024}
 
 
-def _resource_value_to_mib(value: Any) -> float:
+def _resource_value_to_mib(value: Union[int, float, str]) -> float:
     if isinstance(value, (int, float)):
         return float(value)
     if isinstance(value, str):
@@ -313,18 +314,15 @@ class AutoConfigUpdater:
 
             # otherwise, we can do some pretty rote clamping of resource values
             elif unclamped_resource_value is not None:
-                if min_value and _resource_value_to_mib(
-                    unclamped_resource_value
-                ) < _resource_value_to_mib(min_value):
+                unclamped_mib = _resource_value_to_mib(unclamped_resource_value)
+                if min_value and unclamped_mib < _resource_value_to_mib(min_value):
                     log.debug(
                         f"{limit_type} autotune config under configured limit ({min_value}), using autotune limit lower bound."
                     )
                     clamped_recomendation[limit_type] = min_value
-                if max_value and _resource_value_to_mib(
-                    unclamped_resource_value
-                ) > _resource_value_to_mib(max_value):
+                if max_value and unclamped_mib > _resource_value_to_mib(max_value):
                     log.debug(
-                        f"{limit_type} autotune config over configured limit ({min_value}), using autotune limit upper bound."
+                        f"{limit_type} autotune config over configured limit ({max_value}), using autotune limit upper bound."
                     )
                     clamped_recomendation[limit_type] = max_value
             else:

--- a/paasta_tools/config_utils.py
+++ b/paasta_tools/config_utils.py
@@ -19,14 +19,13 @@ from paasta_tools.utils import DEFAULT_SOA_DIR
 log = logging.getLogger(__name__)
 
 _RESOURCE_UNIT_TO_MIB = {"Gi": 1024.0, "Mi": 1.0, "Ki": 1.0 / 1024}
+_SUFFIX_RESOURCE_TYPES = {"mem", "disk"}
 
 
-def _resource_value_to_mib(value: int | float | str) -> float:
-    """Normalize a resource value to MiB for comparison. For numeric types
-    (e.g. cpus as float), this is a passthrough cast to float."""
+def _normalize_resource_value(value: int | float | str, resource_type: str) -> float:
     if isinstance(value, (int, float)):
         return float(value)
-    if isinstance(value, str):
+    if isinstance(value, str) and resource_type in _SUFFIX_RESOURCE_TYPES:
         for suffix, factor in _RESOURCE_UNIT_TO_MIB.items():
             if value.endswith(suffix):
                 return float(value.removesuffix(suffix)) * factor
@@ -315,13 +314,13 @@ class AutoConfigUpdater:
 
             # otherwise, we can do some pretty rote clamping of resource values
             elif unclamped_resource_value is not None:
-                unclamped_mib = _resource_value_to_mib(unclamped_resource_value)
-                if min_value and unclamped_mib < _resource_value_to_mib(min_value):
+                unclamped_mib = _normalize_resource_value(unclamped_resource_value, limit_type)
+                if min_value and unclamped_mib < _normalize_resource_value(min_value, limit_type):
                     log.debug(
                         f"{limit_type} autotune config under configured limit ({min_value}), using autotune limit lower bound."
                     )
                     clamped_recomendation[limit_type] = min_value
-                if max_value and unclamped_mib > _resource_value_to_mib(max_value):
+                if max_value and unclamped_mib > _normalize_resource_value(max_value, limit_type):
                     log.debug(
                         f"{limit_type} autotune config over configured limit ({max_value}), using autotune limit upper bound."
                     )

--- a/paasta_tools/config_utils.py
+++ b/paasta_tools/config_utils.py
@@ -9,7 +9,6 @@ from typing import List
 from typing import Optional
 from typing import Set
 from typing import Tuple
-from typing import Union
 
 import ruamel.yaml as yaml
 
@@ -22,13 +21,15 @@ log = logging.getLogger(__name__)
 _RESOURCE_UNIT_TO_MIB = {"Gi": 1024.0, "Mi": 1.0, "Ki": 1.0 / 1024}
 
 
-def _resource_value_to_mib(value: Union[int, float, str]) -> float:
+def _resource_value_to_mib(value: int | float | str) -> float:
+    """Normalize a resource value to MiB for comparison. For numeric types
+    (e.g. cpus as float), this is a passthrough cast to float."""
     if isinstance(value, (int, float)):
         return float(value)
     if isinstance(value, str):
         for suffix, factor in _RESOURCE_UNIT_TO_MIB.items():
             if value.endswith(suffix):
-                return float(value[: -len(suffix)]) * factor
+                return float(value.removesuffix(suffix)) * factor
     raise ValueError(f"Cannot parse resource value: {value!r}")
 
 

--- a/paasta_tools/config_utils.py
+++ b/paasta_tools/config_utils.py
@@ -18,6 +18,19 @@ from paasta_tools.utils import DEFAULT_SOA_DIR
 
 log = logging.getLogger(__name__)
 
+_RESOURCE_UNIT_TO_MIB = {"Gi": 1024.0, "Mi": 1.0, "Ki": 1.0 / 1024}
+
+
+def _resource_value_to_mib(value: Any) -> float:
+    if isinstance(value, (int, float)):
+        return float(value)
+    if isinstance(value, str):
+        for suffix, factor in _RESOURCE_UNIT_TO_MIB.items():
+            if value.endswith(suffix):
+                return float(value[: -len(suffix)]) * factor
+    raise ValueError(f"Cannot parse resource value: {value!r}")
+
+
 # Must have a schema defined
 KNOWN_CONFIG_TYPES = (
     "kubernetes",
@@ -300,12 +313,16 @@ class AutoConfigUpdater:
 
             # otherwise, we can do some pretty rote clamping of resource values
             elif unclamped_resource_value is not None:
-                if min_value and unclamped_resource_value < min_value:
+                if min_value and _resource_value_to_mib(
+                    unclamped_resource_value
+                ) < _resource_value_to_mib(min_value):
                     log.debug(
                         f"{limit_type} autotune config under configured limit ({min_value}), using autotune limit lower bound."
                     )
                     clamped_recomendation[limit_type] = min_value
-                if max_value and unclamped_resource_value > max_value:
+                if max_value and _resource_value_to_mib(
+                    unclamped_resource_value
+                ) > _resource_value_to_mib(max_value):
                     log.debug(
                         f"{limit_type} autotune config over configured limit ({min_value}), using autotune limit upper bound."
                     )

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -5,6 +5,7 @@ import pytest
 
 import paasta_tools.config_utils as config_utils
 from paasta_tools import yaml_tools as yaml
+from paasta_tools.config_utils import _resource_value_to_mib
 from paasta_tools.utils import AUTO_SOACONFIG_SUBDIR
 
 
@@ -383,3 +384,63 @@ def test_auto_config_updater_merge_recommendations_limits(updater):
                 },
             }
         }
+
+
+@pytest.mark.parametrize(
+    "value,expected_mib",
+    [
+        (512, 512.0),
+        (1024.0, 1024.0),
+        ("1Gi", 1024.0),
+        ("2Gi", 2048.0),
+        ("512Mi", 512.0),
+        ("1024Mi", 1024.0),
+        ("1Ki", 1.0 / 1024),
+    ],
+)
+def test_resource_value_to_mib(value, expected_mib):
+    assert _resource_value_to_mib(value) == pytest.approx(expected_mib)
+
+
+def test_resource_value_to_mib_invalid():
+    with pytest.raises(ValueError):
+        _resource_value_to_mib("4GB")
+
+
+def test_auto_config_updater_merge_recommendations_limits_gi_strings(updater):
+    service = "foo"
+    conf_file = "cassandracluster-norcal-devc"
+    instance = "activity-feed"
+    autotune_data = {instance: {"cpus": 1.5, "mem": "2Gi", "disk": "5Gi"}}
+    user_data = {
+        instance: {
+            "autotune_limits": {
+                "cpus": {"min": 1},
+                "mem": {"min": "4Gi"},
+                "disk": {"max": "10Gi"},
+            }
+        }
+    }
+    recs = {
+        (service, conf_file): {
+            instance: {"mem": "2Gi", "disk": "5Gi", "cpus": 0.5},
+        }
+    }
+
+    with mock.patch.object(
+        updater,
+        "get_existing_configs",
+        autospec=True,
+        side_effect=[autotune_data, user_data, {}],
+    ):
+        result = updater.merge_recommendations(recs)
+
+    assert result == {
+        (service, conf_file): {
+            instance: {
+                "mem": "4Gi",
+                "disk": "5Gi",
+                "cpus": 1,
+            }
+        }
+    }

--- a/tests/test_config_utils.py
+++ b/tests/test_config_utils.py
@@ -5,7 +5,7 @@ import pytest
 
 import paasta_tools.config_utils as config_utils
 from paasta_tools import yaml_tools as yaml
-from paasta_tools.config_utils import _resource_value_to_mib
+from paasta_tools.config_utils import _normalize_resource_value
 from paasta_tools.utils import AUTO_SOACONFIG_SUBDIR
 
 
@@ -387,24 +387,29 @@ def test_auto_config_updater_merge_recommendations_limits(updater):
 
 
 @pytest.mark.parametrize(
-    "value,expected_mib",
+    "value,resource_type,expected",
     [
-        (512, 512.0),
-        (1024.0, 1024.0),
-        ("1Gi", 1024.0),
-        ("2Gi", 2048.0),
-        ("512Mi", 512.0),
-        ("1024Mi", 1024.0),
-        ("1Ki", 1.0 / 1024),
+        (512, "cpu", 512.0),
+        (1024.0, "cpu", 1024.0),
+        ("1Gi", "mem", 1024.0),
+        ("2Gi", "mem", 2048.0),
+        ("512Mi", "mem", 512.0),
+        ("1024Mi", "disk", 1024.0),
+        ("1Ki", "disk", 1.0 / 1024),
     ],
 )
-def test_resource_value_to_mib(value, expected_mib):
-    assert _resource_value_to_mib(value) == pytest.approx(expected_mib)
+def test_normalize_resource_value(value, resource_type, expected):
+    assert _normalize_resource_value(value, resource_type) == pytest.approx(expected)
 
 
-def test_resource_value_to_mib_invalid():
+def test_normalize_resource_value_invalid_suffix():
     with pytest.raises(ValueError):
-        _resource_value_to_mib("4GB")
+        _normalize_resource_value("4GB", "mem")
+
+
+def test_normalize_resource_value_string_cpu_raises():
+    with pytest.raises(ValueError):
+        _normalize_resource_value("1Gi", "cpu")
 
 
 def test_auto_config_updater_merge_recommendations_limits_gi_strings(updater):


### PR DESCRIPTION
## Summary

- Add `_resource_value_to_mib()` to normalize resource values (int/float MiB or K8s strings like `"4Gi"`/`"512Mi"`) to a common unit before comparing
- Update `_clamp_recommendations()` to use it so Cassandra clusters can set mem/disk floors via `autotune_limits` without TypeError on string comparisons
- Fix pre-existing log bug: max-clamping branch was logging `min_value` instead of `max_value`

Cassandra autotune recommendations use Gi strings for mem/disk. Direct `<`/`>` comparisons against integer limits would raise TypeError. This is the paasta-side change; a follow-up yelpsoa-configs PR will update the `cassandra_k8s/validate.py` schema from `integer` to `string` pattern once this is deployed.

Jira: https://jira.yelpcorp.com/browse/PEREL-5643

## Test plan

- [ ] `pytest tests/test_config_utils.py` — all 37 tests pass including new parametrized `test_resource_value_to_mib` cases and `test_auto_config_updater_merge_recommendations_limits_gi_strings`
- [ ] pre-commit clean on changed files