### PR TITLE
PAASTA-17879: Ensure a monitoring.yaml file for all services

### DIFF
--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -1370,6 +1370,10 @@ def check_monitoring_file_exists(service_path: str) -> bool:
 
     returncode = True
 
+    # NOTE: not all directories in soaconfigs are actually services
+    # so we use the presence of a service.yaml to disambiguate
+    # (e.g., `_shared/`, various mysql_*/, etc are top-level directories,
+    # but not actually services)
     if not os.path.exists(os.path.join(service_path, "service.yaml")):
         return returncode
 

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -1365,7 +1365,7 @@ def validate_flink_monitoring_team(service_path: str) -> bool:
     return returncode
 
 
-def validate_monitoring_file(service_path: str) -> bool:
+def check_monitoring_file_exists(service_path: str) -> bool:
     """Check that a monitoring.yaml file exists in the service directory."""
 
     returncode = True
@@ -1407,7 +1407,7 @@ def paasta_validate_soa_configs(
         validate_cpu_burst,
         validate_smartstack,
         validate_flink_monitoring_team,
-        validate_monitoring_file,
+        check_monitoring_file_exists,
     ]
 
     # NOTE: we're explicitly passing a list comprehension to all()

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -1369,12 +1369,15 @@ def check_monitoring_file_exists(service_path: str) -> bool:
     """Check that a monitoring.yaml file exists in the service directory."""
 
     returncode = True
-    monitoring_path = os.path.join(service_path, "monitoring.yaml")
-    if not os.path.isfile(monitoring_path):
+
+    if not os.path.exists(os.path.join(service_path, "service.yaml")):
+        return returncode
+
+    if not os.path.exists(os.path.join(service_path, "monitoring.yaml")):
         print(
             failure(
-                f"No monitoring.yaml found in {service_path}. Every service must have a monitoring.yaml.",
-                "",
+                f"No monitoring.yaml found in {service_path}. Every service must have a monitoring.yaml so that PaaSTA can route alerts to the right place.",
+                "https://paasta.readthedocs.io/en/latest/yelpsoa_configs.html#monitoring-yaml",
             )
         )
         returncode = False

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -1365,6 +1365,24 @@ def validate_flink_monitoring_team(service_path: str) -> bool:
     return returncode
 
 
+def validate_monitoring_file(service_path: str) -> bool:
+    """Check that a monitoring.yaml file exists in the service directory."""
+
+    returncode = True
+    monitoring_path = os.path.join(service_path, "monitoring.yaml")
+    if not os.path.isfile(monitoring_path):
+        print(
+            failure(
+                f"No monitoring.yaml found in {service_path}. Every service must have a monitoring.yaml.",
+                "",
+            )
+        )
+        returncode = False
+    if returncode:
+        print(success("Service has a monitoring.yaml file"))
+    return returncode
+
+
 def paasta_validate_soa_configs(
     service: str, service_path: str, verbose: bool = False
 ) -> bool:
@@ -1389,6 +1407,7 @@ def paasta_validate_soa_configs(
         validate_cpu_burst,
         validate_smartstack,
         validate_flink_monitoring_team,
+        validate_monitoring_file,
     ]
 
     # NOTE: we're explicitly passing a list comprehension to all()

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -2050,10 +2050,14 @@ test_job:
 
 def test_check_monitoring_file_exists_success(tmp_path):
     (tmp_path / "monitoring.yaml").write_text("team: my-team\n")
+    (tmp_path / "service.yaml").write_text("service: my-team\n")
     assert check_monitoring_file_exists(str(tmp_path)) is True
 
 
-def test_check_monitoring_file_missing(tmp_path, capsys):
+def test_check_monitoring_file_missing(tmp_path):
+    (tmp_path / "service.yaml").write_text("service: my-team\n")
     assert check_monitoring_file_exists(str(tmp_path)) is False
-    output, _ = capsys.readouterr()
-    assert "No monitoring.yaml found" in output
+
+
+def test_check_monitoring_file_exists_non_service(tmp_path):
+    assert check_monitoring_file_exists(str(tmp_path)) is True

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -30,6 +30,7 @@ from paasta_tools.cli.cmds.validate import _check_smartstack_proxied_through
 from paasta_tools.cli.cmds.validate import _check_smartstack_valid_proxy
 from paasta_tools.cli.cmds.validate import _get_etc_services
 from paasta_tools.cli.cmds.validate import _get_etc_services_entry
+from paasta_tools.cli.cmds.validate import check_monitoring_file_exists
 from paasta_tools.cli.cmds.validate import check_secrets_for_instance
 from paasta_tools.cli.cmds.validate import check_service_path
 from paasta_tools.cli.cmds.validate import get_config_file_dict
@@ -43,7 +44,6 @@ from paasta_tools.cli.cmds.validate import validate_cpu_burst
 from paasta_tools.cli.cmds.validate import validate_flink_monitoring_team
 from paasta_tools.cli.cmds.validate import validate_instance_names
 from paasta_tools.cli.cmds.validate import validate_min_max_instances
-from paasta_tools.cli.cmds.validate import validate_monitoring_file
 from paasta_tools.cli.cmds.validate import validate_paasta_objects
 from paasta_tools.cli.cmds.validate import validate_rollback_bounds
 from paasta_tools.cli.cmds.validate import validate_schema
@@ -2048,12 +2048,12 @@ test_job:
         assert expected_output in output
 
 
-def test_validate_monitoring_file_exists(tmp_path):
+def test_check_monitoring_file_exists_success(tmp_path):
     (tmp_path / "monitoring.yaml").write_text("team: my-team\n")
-    assert validate_monitoring_file(str(tmp_path)) is True
+    assert check_monitoring_file_exists(str(tmp_path)) is True
 
 
-def test_validate_monitoring_file_missing(tmp_path, capsys):
-    assert validate_monitoring_file(str(tmp_path)) is False
+def test_check_monitoring_file_missing(tmp_path, capsys):
+    assert check_monitoring_file_exists(str(tmp_path)) is False
     output, _ = capsys.readouterr()
     assert "No monitoring.yaml found" in output

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -43,6 +43,7 @@ from paasta_tools.cli.cmds.validate import validate_cpu_burst
 from paasta_tools.cli.cmds.validate import validate_flink_monitoring_team
 from paasta_tools.cli.cmds.validate import validate_instance_names
 from paasta_tools.cli.cmds.validate import validate_min_max_instances
+from paasta_tools.cli.cmds.validate import validate_monitoring_file
 from paasta_tools.cli.cmds.validate import validate_paasta_objects
 from paasta_tools.cli.cmds.validate import validate_rollback_bounds
 from paasta_tools.cli.cmds.validate import validate_schema
@@ -79,7 +80,9 @@ def clear_get_config_file_dict_cache():
 @patch("paasta_tools.cli.cmds.validate.validate_secrets", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.validate_smartstack", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.validate_service_name", autospec=True)
+@patch("paasta_tools.cli.cmds.validate.validate_monitoring_file", autospec=True)
 def test_paasta_validate_calls_everything(
+    mock_validate_monitoring_file,
     mock_validate_service_name,
     mock_validate_smartstack,
     mock_validate_secrets,
@@ -106,6 +109,7 @@ def test_paasta_validate_calls_everything(
     mock_validate_min_max_instances.return_value = True
     mock_validate_smartstack.return_value = True
     mock_validate_service_name.return_value = True
+    mock_validate_monitoring_file.return_value = True
 
     args = mock.MagicMock()
     args.service = "test"
@@ -122,6 +126,7 @@ def test_paasta_validate_calls_everything(
     assert mock_validate_cpu_burst.called
     assert mock_validate_smartstack.called
     assert mock_validate_service_name.called
+    assert mock_validate_monitoring_file.called
 
 
 @patch(
@@ -2041,3 +2046,14 @@ test_job:
         expected_output = SCHEMA_VALID if expected else SCHEMA_INVALID
         output, _ = capsys.readouterr()
         assert expected_output in output
+
+
+def test_validate_monitoring_file_exists(tmp_path):
+    (tmp_path / "monitoring.yaml").write_text("team: my-team\n")
+    assert validate_monitoring_file(str(tmp_path)) is True
+
+
+def test_validate_monitoring_file_missing(tmp_path, capsys):
+    assert validate_monitoring_file(str(tmp_path)) is False
+    output, _ = capsys.readouterr()
+    assert "No monitoring.yaml found" in output

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -80,7 +80,7 @@ def clear_get_config_file_dict_cache():
 @patch("paasta_tools.cli.cmds.validate.validate_secrets", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.validate_smartstack", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.validate_service_name", autospec=True)
-@patch("paasta_tools.cli.cmds.validate.validate_monitoring_file", autospec=True)
+@patch("paasta_tools.cli.cmds.validate.check_monitoring_file_exists", autospec=True)
 def test_paasta_validate_calls_everything(
     mock_validate_monitoring_file,
     mock_validate_service_name,


### PR DESCRIPTION
### Summary

-  Add a function to paasta validate command to ensure a monitoring.yaml file exists for those services
- Update unit tests for new function

JIRA: https://jira.yelpcorp.com/browse/PAASTA-17879

### Verification
- All previous tests pass
- New unit tests pass
