### PR TITLE
fix: non worker load autoscaling label selector

### DIFF
--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -972,7 +972,7 @@ def create_shared_uwsgi_v2_scaling_rule(
     metric_name = get_prometheus_metric_name(
         METRICS_PROVIDER_UWSGI_V2, moving_average_window
     )
-    worker_filter_terms = "<<.LabelMatchers>>"
+    worker_filter_terms = f"paasta_cluster='{paasta_cluster}',paasta_service='<<index .LabelValuesByName \"paasta_service\">>',paasta_instance='<<index .LabelValuesByName \"paasta_instance\">>',kube_deployment='<<index .LabelValuesByName \"kube_deployment\">>'"
 
     ready_pods = f"""
         (sum(
@@ -1025,9 +1025,8 @@ def create_shared_uwsgi_scaling_rule(
     metric_name = get_prometheus_metric_name(
         METRICS_PROVIDER_UWSGI, moving_average_window
     )
-    worker_filter_terms = "<<.LabelMatchers>>"
-    # replica_filter_terms uses <<.LabelMatchers>> too since kube_deployment is in the HPA selector
-    replica_filter_terms = "<<.LabelMatchers>>"
+    worker_filter_terms = f"paasta_cluster='{paasta_cluster}',paasta_service='<<index .LabelValuesByName \"paasta_service\">>',paasta_instance='<<index .LabelValuesByName \"paasta_instance\">>',kube_deployment='<<index .LabelValuesByName \"kube_deployment\">>'"
+    replica_filter_terms = f"paasta_cluster='{paasta_cluster}',kube_deployment='<<index .LabelValuesByName \"kube_deployment\">>',namespace='<<index .LabelValuesByName \"kube_namespace\">>'"
 
     ready_pods = f"""
         (sum(
@@ -1092,8 +1091,8 @@ def create_shared_piscina_scaling_rule(
     metric_name = get_prometheus_metric_name(
         METRICS_PROVIDER_PISCINA, moving_average_window
     )
-    worker_filter_terms = "<<.LabelMatchers>>"
-    replica_filter_terms = "<<.LabelMatchers>>"
+    worker_filter_terms = f"paasta_cluster='{paasta_cluster}',paasta_service='<<index .LabelValuesByName \"paasta_service\">>',paasta_instance='<<index .LabelValuesByName \"paasta_instance\">>',kube_deployment='<<index .LabelValuesByName \"kube_deployment\">>'"
+    replica_filter_terms = f"paasta_cluster='{paasta_cluster}',deployment='<<index .LabelValuesByName \"kube_deployment\">>',namespace='<<index .LabelValuesByName \"kube_namespace\">>'"
 
     current_replicas = f"""
         sum(
@@ -1161,8 +1160,8 @@ def create_shared_gunicorn_scaling_rule(
     metric_name = get_prometheus_metric_name(
         METRICS_PROVIDER_GUNICORN, moving_average_window
     )
-    worker_filter_terms = "<<.LabelMatchers>>"
-    replica_filter_terms = "<<.LabelMatchers>>"
+    worker_filter_terms = f"paasta_cluster='{paasta_cluster}',paasta_service='<<index .LabelValuesByName \"paasta_service\">>',paasta_instance='<<index .LabelValuesByName \"paasta_instance\">>',kube_deployment='<<index .LabelValuesByName \"kube_deployment\">>'"
+    replica_filter_terms = f"paasta_cluster='{paasta_cluster}',deployment='<<index .LabelValuesByName \"kube_deployment\">>',namespace='<<index .LabelValuesByName \"kube_namespace\">>'"
 
     current_replicas = f"""
         sum(

--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -434,14 +434,18 @@ def test_create_shared_scaling_rule(
 
     rule = rule_func(paasta_cluster, moving_average_window)
 
-    assert LABEL_MATCHERS in rule["metricsQuery"]
     assert str(moving_average_window) in rule["metricsQuery"]
     assert paasta_cluster in rule["seriesQuery"]
     assert expected_series_metric in rule["seriesQuery"]
     assert rule["name"]["as"] == f"{expected_name_prefix}-{moving_average_window}"
-    # if service/instance are provided, we're not compressing the amount of output :p
-    assert "paasta_service=" not in rule["metricsQuery"]
-    assert "paasta_instance=" not in rule["metricsQuery"]
+    assert (
+        "<<index .LabelValuesByName" in rule["metricsQuery"]
+        or LABEL_MATCHERS in rule["metricsQuery"]
+    )
+    # no hardcoded service/instance values — only template references
+    assert "paasta_service='" not in rule["metricsQuery"].replace(
+        "paasta_service='<<index .LabelValuesByName", ""
+    )
 
 
 def _make_instance_config(


### PR DESCRIPTION
Fix shared adapter rules for uwsgi/piscina/gunicorn: `<<.LabelMatchers>>` includes `kube_namespace` which doesn't exist on `k8s:deployment:pods_status_ready` or `kube_deployment_spec_replicas`, causing empty query results. Use `<<index .LabelValuesByName ...>>` to select only labels each metric actually has.