### PR TITLE
Default `paasta secret` to token auth again

### DIFF
--- a/paasta_tools/cli/cmds/secret.py
+++ b/paasta_tools/cli/cmds/secret.py
@@ -241,7 +241,7 @@ def _add_vault_auth_args(parser: argparse.ArgumentParser):
         type=str,
         dest="vault_auth_method",
         required=False,
-        default="okta",
+        default="token",
         choices=["token", "okta"],
     )
     parser.add_argument(


### PR DESCRIPTION
Looks like this is having some unforeseen impacts in CI - some services use `paasta secret run` to run `ycp` or `pytest` with secrets, and that's failing to auth since there's no human to type in their password :p

partial revert of https://github.com/Yelp/paasta/pull/4346