### PR TITLE
Add support for ppl to set `fsGroupChangePolicy`

### DIFF
--- a/docs/source/yelpsoa_configs.rst
+++ b/docs/source/yelpsoa_configs.rst
@@ -375,6 +375,23 @@ instance MAY have:
 
       "cap_add": ["IPC_LOCK", "SYS_PTRACE"]
 
+  * ``fs_group``: An integer specifying the GID that will own all volumes in
+    the pod. Kubernetes will change ownership of all files in volumes to this
+    GID before they are exposed to the pod. This is only relevant for pods
+    that mount RW volumes (e.g. persistent volumes, secret volumes with RW
+    access).
+
+  * ``fs_group_change_policy``: Controls how Kubernetes applies ``fs_group``
+    ownership changes to volumes. Must be one of:
+
+    * ``Always`` (default if unset): always change ownership and permissions on every mount.
+    * ``OnRootMismatch``: only change ownership if the root directory's permissions/ownership
+      do not match the expected GID. This can significantly speed up pod startup for
+      large volumes.
+
+    Requires ``fs_group`` to be set. Has no effect if the instance does not declare
+    any RW volumes.
+
   * ``instances``: Kubernetes will attempt to run this many instances of the Service
 
   * ``min_instances``: When autoscaling, the minimum number of instances that

--- a/paasta_tools/cli/schemas/adhoc_schema.json
+++ b/paasta_tools/cli/schemas/adhoc_schema.json
@@ -381,6 +381,11 @@
                         }
                     }
                 }
+            },
+            "dependencies": {
+                "fs_group_change_policy": [
+                    "fs_group"
+                ]
             }
         }
     }

--- a/paasta_tools/cli/schemas/adhoc_schema.json
+++ b/paasta_tools/cli/schemas/adhoc_schema.json
@@ -72,6 +72,12 @@
                 "fs_group": {
                     "type": "integer"
                 },
+                "fs_group_change_policy": {
+                    "enum": [
+                        "Always",
+                        "OnRootMismatch"
+                    ]
+                },
                 "crypto_keys": {
                     "type": "object",
                     "additionalProperties": false,

--- a/paasta_tools/cli/schemas/eks_schema.json
+++ b/paasta_tools/cli/schemas/eks_schema.json
@@ -685,6 +685,12 @@
                 "fs_group": {
                     "type": "integer"
                 },
+                "fs_group_change_policy": {
+                    "enum": [
+                        "Always",
+                        "OnRootMismatch"
+                    ]
+                },
                 "healthcheck_mode": {
                     "enum": [
                         "cmd",

--- a/paasta_tools/cli/schemas/eks_schema.json
+++ b/paasta_tools/cli/schemas/eks_schema.json
@@ -1017,6 +1017,11 @@
                     "type": "boolean",
                     "default": true
                 }
+            },
+            "dependencies": {
+                "fs_group_change_policy": [
+                    "fs_group"
+                ]
             }
         }
     }

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -650,6 +650,12 @@
                 "fs_group": {
                     "type": "integer"
                 },
+                "fs_group_change_policy": {
+                    "enum": [
+                        "Always",
+                        "OnRootMismatch"
+                    ]
+                },
                 "healthcheck_mode": {
                     "enum": [
                         "cmd",

--- a/paasta_tools/cli/schemas/kubernetes_schema.json
+++ b/paasta_tools/cli/schemas/kubernetes_schema.json
@@ -960,6 +960,11 @@
                     "type": "boolean",
                     "default": true
                 }
+            },
+            "dependencies": {
+                "fs_group_change_policy": [
+                    "fs_group"
+                ]
             }
         }
     }

--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -2487,8 +2487,14 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             annotations["iam.amazonaws.com/role"] = self.get_iam_role()
 
         if fs_group is not None:
+            security_context_kwargs: Dict[str, Any] = {"fs_group": fs_group}
+            fs_group_change_policy = self.get_fs_group_change_policy()
+            if fs_group_change_policy is not None:
+                security_context_kwargs[
+                    "fs_group_change_policy"
+                ] = fs_group_change_policy
             pod_spec_kwargs["security_context"] = V1PodSecurityContext(
-                fs_group=fs_group
+                **security_context_kwargs
             )
 
         # prometheus_path is used to override the default scrape path in Prometheus

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -85,6 +85,7 @@ class LongRunningServiceConfigDict(InstanceConfigDict, total=False):
     autoscaling: AutoscalingParamsDict
     drain_method: str
     fs_group: int
+    fs_group_change_policy: str
     container_port: int
     drain_method_params: Dict
     healthcheck_cmd: str
@@ -283,6 +284,9 @@ class LongRunningServiceConfig(InstanceConfig):
 
     def get_fs_group(self) -> Optional[int]:
         return self.config_dict.get("fs_group")
+
+    def get_fs_group_change_policy(self) -> Optional[str]:
+        return self.config_dict.get("fs_group_change_policy")
 
     def get_healthcheck_uri(
         self, service_namespace_config: ServiceNamespaceConfig

--- a/paasta_tools/long_running_service_tools.py
+++ b/paasta_tools/long_running_service_tools.py
@@ -5,6 +5,7 @@ import socket
 from typing import TYPE_CHECKING
 from typing import Dict
 from typing import List
+from typing import Literal
 from typing import Mapping
 from typing import Optional
 from typing import Sequence
@@ -85,7 +86,7 @@ class LongRunningServiceConfigDict(InstanceConfigDict, total=False):
     autoscaling: AutoscalingParamsDict
     drain_method: str
     fs_group: int
-    fs_group_change_policy: str
+    fs_group_change_policy: Literal["Always", "OnRootMismatch"]
     container_port: int
     drain_method_params: Dict
     healthcheck_cmd: str
@@ -285,7 +286,9 @@ class LongRunningServiceConfig(InstanceConfig):
     def get_fs_group(self) -> Optional[int]:
         return self.config_dict.get("fs_group")
 
-    def get_fs_group_change_policy(self) -> Optional[str]:
+    def get_fs_group_change_policy(
+        self,
+    ) -> Optional[Literal["Always", "OnRootMismatch"]]:
         return self.config_dict.get("fs_group_change_policy")
 
     def get_healthcheck_uri(

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -1110,6 +1110,13 @@ class TestKubernetesDeploymentConfig:
         )
         assert self.deployment.get_security_context() == expected_security_context
 
+    def test_get_fs_group_change_policy_default(self):
+        assert self.deployment.get_fs_group_change_policy() is None
+
+    def test_get_fs_group_change_policy(self):
+        self.deployment.config_dict["fs_group_change_policy"] = "OnRootMismatch"
+        assert self.deployment.get_fs_group_change_policy() == "OnRootMismatch"
+
     def test_get_pod_volumes(self):
         mock_docker_volumes = [
             DockerVolume(hostPath="/nail/blah", containerPath="/nail/foo", mode="RO"),


### PR DESCRIPTION
Looks like with PVs that have accumulated a large set of files, we can be hit with extra slowness when starting the pods that are attached to those PVs due to kubelet needing to perform a recursive `chown` over all files in the volume at mount, before the containers are even started. 

This can lead to extremely slow pod start times, and kubelet even includes this warning and points to https://github.com/kubernetes/kubernetes/issues/69699 in its [logs](https://github.com/kubernetes/kubernetes/blob/9fde8b453511eeca05f382d10f3ae3a0ce7074f5/pkg/volume/volume_linux.go#L93) . 

One recommendation is to use the `fsGroupChangePolicy: OnRootMismatch` [setting](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#configure-volume-permission-and-ownership-change-policy-for-pods) which will skip the recursive chown if the root of the filesystem already matches the pod's specified `fs_group`. 
From offical docs:
> `OnRootMismatch`: Only change permissions and ownership if the permission and the ownership of root directory does not match with expected permissions of the volume. This could help shorten the time it takes to change ownership and permission of a volume.

This PR just allows folks to set this manually in yelpsoa-configs so we can try it out at a per-instance level, but i think if this seems to work well, we may want to do something fancier later to set this by default whenever an instance has any pv's e.g.