### PR TITLE
Add a `verify-image-exists` sub-command

### DIFF
--- a/paasta_tools/cli/cli.py
+++ b/paasta_tools/cli/cli.py
@@ -129,6 +129,7 @@ PAASTA_SUBCOMMANDS = {
     "restart": "start_stop_restart",
     "status": "status",
     "validate": "validate",
+    "verify-image-exists": "verify_image_exists",
     "wait-for-deployment": "wait_for_deployment",
 }
 

--- a/paasta_tools/cli/cmds/verify_image_exists.py
+++ b/paasta_tools/cli/cmds/verify_image_exists.py
@@ -1,0 +1,134 @@
+import argparse
+import sys
+import time
+from typing import Optional
+
+from paasta_tools.cli.cmds.push_to_registry import is_docker_image_already_in_registry
+from paasta_tools.cli.utils import lazy_choices_completer
+from paasta_tools.cli.utils import list_services
+from paasta_tools.utils import DEFAULT_SOA_DIR
+from paasta_tools.utils import PaastaColors
+
+DEFAULT_POLL_PERIOD = 30
+
+
+def add_subparser(subparsers):
+    parser = subparsers.add_parser(
+        "verify-image-exists",
+        help="Check if a docker image exists in the registry for a service and SHA",
+        description=(
+            "Checks the Docker registry for the existence of an image for a given "
+            "service and git SHA. Optionally polls until the image appears."
+        ),
+    )
+    parser.add_argument(
+        "-s",
+        "--service",
+        help="Name of the service",
+        required=True,
+        type=lambda x: x.rstrip("/"),
+    ).completer = lazy_choices_completer(list_services)
+    parser.add_argument(
+        "-c",
+        "--commit",
+        help="Git SHA to check for",
+        required=True,
+    )
+    parser.add_argument(
+        "--image-version",
+        help="Optional image version suffix",
+        default=None,
+    )
+    parser.add_argument(
+        "-d",
+        "--soa-dir",
+        help="Path to yelpsoa-configs directory",
+        default=DEFAULT_SOA_DIR,
+    )
+    parser.add_argument(
+        "--wait",
+        help="Poll until the image is found",
+        action="store_true",
+        default=False,
+    )
+    parser.add_argument(
+        "--poll-period",
+        help="Seconds between poll attempts (default: %(default)s)",
+        type=int,
+        default=DEFAULT_POLL_PERIOD,
+    )
+    parser.add_argument(
+        "--timeout",
+        help="Max seconds to wait; 0 means wait forever (default: %(default)s)",
+        type=int,
+        default=0,
+    )
+    parser.set_defaults(command=paasta_verify_image_exists)
+
+
+def verify_image_exists(
+    service: str,
+    commit: str,
+    soa_dir: str = DEFAULT_SOA_DIR,
+    image_version: Optional[str] = None,
+    wait: bool = False,
+    poll_period: int = DEFAULT_POLL_PERIOD,
+    timeout: int = 0,
+) -> int:
+    if is_docker_image_already_in_registry(
+        service=service, soa_dir=soa_dir, sha=commit, image_version=image_version
+    ):
+        print(
+            PaastaColors.green(
+                f"Image for {service} at {commit} exists in the registry."
+            )
+        )
+        return 0
+
+    if not wait:
+        print(
+            PaastaColors.red(
+                f"Image for {service} at {commit} NOT FOUND in the registry."
+            ),
+            file=sys.stderr,
+        )
+        return 1
+
+    start_time = time.time()
+    print(f"Waiting for image for {service} at {commit} to appear in the registry...")
+    while True:
+        time.sleep(poll_period)
+        print(".", end="", flush=True)
+
+        if timeout > 0 and (time.time() - start_time) >= timeout:
+            print()
+            print(
+                PaastaColors.red(
+                    f"Timed out after {timeout}s waiting for image for {service} at {commit}."
+                ),
+                file=sys.stderr,
+            )
+            return 1
+
+        if is_docker_image_already_in_registry(
+            service=service, soa_dir=soa_dir, sha=commit, image_version=image_version
+        ):
+            print()
+            print(
+                PaastaColors.green(
+                    f"Image for {service} at {commit} exists in the registry."
+                )
+            )
+            return 0
+
+
+def paasta_verify_image_exists(args: argparse.Namespace) -> int:
+    return verify_image_exists(
+        service=args.service,
+        commit=args.commit,
+        soa_dir=args.soa_dir,
+        image_version=args.image_version,
+        wait=args.wait,
+        poll_period=args.poll_period,
+        timeout=args.timeout,
+    )

--- a/tests/cli/test_cmds_verify_image_exists.py
+++ b/tests/cli/test_cmds_verify_image_exists.py
@@ -29,31 +29,11 @@ def test_wait_polls_until_found():
     ), mock.patch(
         "paasta_tools.cli.cmds.verify_image_exists.time.sleep",
         autospec=True,
-    ) as mock_sleep:
+    ):
         assert (
             verify_image_exists(service="fake_service", commit="abc1234", wait=True)
             == 0
         )
-        assert mock_sleep.call_count == 2
-        mock_sleep.assert_called_with(30)
-
-
-def test_poll_period_override():
-    with mock.patch(
-        "paasta_tools.cli.cmds.verify_image_exists.is_docker_image_already_in_registry",
-        autospec=True,
-        side_effect=[False, True],
-    ), mock.patch(
-        "paasta_tools.cli.cmds.verify_image_exists.time.sleep",
-        autospec=True,
-    ) as mock_sleep:
-        assert (
-            verify_image_exists(
-                service="fake_service", commit="abc1234", wait=True, poll_period=10
-            )
-            == 0
-        )
-        mock_sleep.assert_called_with(10)
 
 
 def test_timeout_expires():

--- a/tests/cli/test_cmds_verify_image_exists.py
+++ b/tests/cli/test_cmds_verify_image_exists.py
@@ -1,0 +1,80 @@
+from unittest import mock
+
+from paasta_tools.cli.cmds.verify_image_exists import verify_image_exists
+
+
+def test_image_found():
+    with mock.patch(
+        "paasta_tools.cli.cmds.verify_image_exists.is_docker_image_already_in_registry",
+        autospec=True,
+        return_value=True,
+    ):
+        assert verify_image_exists(service="fake_service", commit="abc1234") == 0
+
+
+def test_image_not_found_no_wait():
+    with mock.patch(
+        "paasta_tools.cli.cmds.verify_image_exists.is_docker_image_already_in_registry",
+        autospec=True,
+        return_value=False,
+    ):
+        assert verify_image_exists(service="fake_service", commit="abc1234") == 1
+
+
+def test_wait_polls_until_found():
+    with mock.patch(
+        "paasta_tools.cli.cmds.verify_image_exists.is_docker_image_already_in_registry",
+        autospec=True,
+        side_effect=[False, False, True],
+    ), mock.patch(
+        "paasta_tools.cli.cmds.verify_image_exists.time.sleep",
+        autospec=True,
+    ) as mock_sleep:
+        assert (
+            verify_image_exists(service="fake_service", commit="abc1234", wait=True)
+            == 0
+        )
+        assert mock_sleep.call_count == 2
+        mock_sleep.assert_called_with(30)
+
+
+def test_poll_period_override():
+    with mock.patch(
+        "paasta_tools.cli.cmds.verify_image_exists.is_docker_image_already_in_registry",
+        autospec=True,
+        side_effect=[False, True],
+    ), mock.patch(
+        "paasta_tools.cli.cmds.verify_image_exists.time.sleep",
+        autospec=True,
+    ) as mock_sleep:
+        assert (
+            verify_image_exists(
+                service="fake_service", commit="abc1234", wait=True, poll_period=10
+            )
+            == 0
+        )
+        mock_sleep.assert_called_with(10)
+
+
+def test_timeout_expires():
+    with mock.patch(
+        "paasta_tools.cli.cmds.verify_image_exists.is_docker_image_already_in_registry",
+        autospec=True,
+        return_value=False,
+    ), mock.patch(
+        "paasta_tools.cli.cmds.verify_image_exists.time.sleep",
+        autospec=True,
+    ), mock.patch(
+        "paasta_tools.cli.cmds.verify_image_exists.time.time",
+        autospec=True,
+        # slightly brittle, but oh well.
+        # first call is for setting the start_time, second one
+        # is after the mocked sleep and is past the timeout
+        side_effect=[0.0, 61.0],
+    ):
+        assert (
+            verify_image_exists(
+                service="fake_service", commit="abc1234", wait=True, timeout=60
+            )
+            == 1
+        )


### PR DESCRIPTION
This will be helpful for some model training adhoc jobs that get images built in a somewhat roundabout way.

Without this, someone has to be watching the build and waiting for it to complete before triggering their adhoc job.
However, with this: they can prefix their adhoc launch command with this and not have to manually do anything :)