### PR TITLE
feat: New config to configure CPU limits per cluster per pool

### DIFF
--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -956,7 +956,7 @@ def validate_pool_limits(service_path: str) -> bool:
             cpu = instance_config.get_cpus()
             pool = instance_config.get_pool()
 
-            pool_limits = pool_limits_for_cluster.get(pool, {})
+            pool_limits: Dict[str, Any] = pool_limits_for_cluster.get(pool, {})
             max_cpus_for_pool = pool_limits.get("max_cpus", float("inf"))
             recommended_pool = pool_limits.get("recommended_pool")
 

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -938,13 +938,15 @@ def validate_min_max_instances(service_path):
 
 
 def validate_pool_limits(service_path: str) -> bool:
-    # We need to validate pool.
-    # If it does, we need to print a warning message.
+    """
+    Validate that services in specific pools won't exceed per-node capacities.
+    For the most part, this isn't normally an issue - but there are several pools where
+    folks tend to want to run extra-large workloads that won't fit (e.g., large single-node batches).
+    """
     soa_dir, service = path_to_soa_dir_service(service_path)
     returncode = True
 
     for cluster in list_clusters(service, soa_dir):
-
         pool_limits_for_cluster = (
             load_system_paasta_config().get_pool_limits().get(cluster, {})
         )

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -937,6 +937,30 @@ def validate_min_max_instances(service_path):
     return returncode
 
 
+def validate_stable_pool_workloads(service_path: str) -> bool:
+    soa_dir, service = path_to_soa_dir_service(service_path)
+    returncode = True
+
+    for cluster in list_clusters(service, soa_dir):
+        for instance, instance_config in load_all_instance_configs_for_service(
+            service=service, cluster=cluster, soa_dir=soa_dir
+        ):
+            cpu = instance_config.get_cpus()
+            pool = instance_config.get_pool()
+
+            if pool == "stable" and cpu >= 16:
+                returncode = False
+                print(
+                    failure(
+                        f"""Instance {instance} on cluster {cluster} has {cpu} CPUs and is in the stable pool.
+                        The stable pool should not have workloads with more than 15 CPUs.
+                        If you need to run a workload with more than 15 CPUs, consider using the stable-giant pool.""",
+                        "",
+                    )
+                )
+    return returncode
+
+
 def check_secrets_for_instance(
     instance_config_dict: InstanceConfigDict, soa_dir: str, service: str, vault_env: str
 ) -> bool:
@@ -1411,6 +1435,7 @@ def paasta_validate_soa_configs(
         validate_autoscaling_configs,
         validate_secrets,
         validate_min_max_instances,
+        validate_stable_pool_workloads,
         validate_cpu_burst,
         validate_smartstack,
         validate_flink_monitoring_team,

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -82,6 +82,7 @@ from paasta_tools.tron_tools import load_tron_service_config
 from paasta_tools.tron_tools import validate_complete_config
 from paasta_tools.utils import InstanceConfig
 from paasta_tools.utils import InstanceConfigDict
+from paasta_tools.utils import PoolLimits
 from paasta_tools.utils import get_service_instance_list
 from paasta_tools.utils import list_all_instances_for_service
 from paasta_tools.utils import list_clusters
@@ -947,7 +948,7 @@ def validate_pool_limits(service_path: str) -> bool:
     returncode = True
 
     for cluster in list_clusters(service, soa_dir):
-        pool_limits_for_cluster = (
+        pool_limits_for_cluster: Dict[str, PoolLimits] = (
             load_system_paasta_config().get_pool_limits().get(cluster, {})
         )
         for instance, instance_config in load_all_instance_configs_for_service(
@@ -956,16 +957,16 @@ def validate_pool_limits(service_path: str) -> bool:
             cpu = instance_config.get_cpus()
             pool = instance_config.get_pool()
 
-            pool_limits: Dict[str, Any] = pool_limits_for_cluster.get(pool, {})
-            max_cpus_for_pool = pool_limits.get("max_cpus", float("inf"))
-            recommended_pool = pool_limits.get("recommended_pool")
+            pool_limits = pool_limits_for_cluster.get(pool)
+            if pool_limits is None:
+                continue
 
-            if pool in pool_limits_for_cluster and cpu >= max_cpus_for_pool:
+            if cpu >= pool_limits["max_cpus"]:
                 returncode = False
                 print(
                     failure(
-                        f"""{service}.{instance} in {cluster} has {cpu} CPUs, which exceeds the limit of {max_cpus_for_pool} for the {pool} pool.
-                        If you need to run a workload with this many CPUs, consider using the {recommended_pool} pool instead.""",
+                        f"""{service}.{instance} in {cluster} has {cpu} CPUs, which exceeds the limit of {pool_limits['max_cpus']} for the {pool} pool.
+                        If you need to run a workload with this many CPUs, consider using the {pool_limits['recommended_pool']} pool instead.""",
                         "",
                     )
                 )

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -937,24 +937,33 @@ def validate_min_max_instances(service_path):
     return returncode
 
 
-def validate_stable_pool_workloads(service_path: str) -> bool:
+def validate_pool_limits(service_path: str) -> bool:
+    # We need to validate pool.
+    # If it does, we need to print a warning message.
     soa_dir, service = path_to_soa_dir_service(service_path)
     returncode = True
 
     for cluster in list_clusters(service, soa_dir):
+
+        pool_limits_for_cluster = (
+            load_system_paasta_config().get_pool_limits().get(cluster, {})
+        )
         for instance, instance_config in load_all_instance_configs_for_service(
             service=service, cluster=cluster, soa_dir=soa_dir
         ):
             cpu = instance_config.get_cpus()
             pool = instance_config.get_pool()
 
-            if pool == "stable" and cpu >= 16:
+            pool_limits = pool_limits_for_cluster.get(pool, {})
+            max_cpus_for_pool = pool_limits.get("max_cpus", float("inf"))
+            recommended_pool = pool_limits.get("recommended_pool")
+
+            if pool in pool_limits_for_cluster and cpu >= max_cpus_for_pool:
                 returncode = False
                 print(
                     failure(
-                        f"""Instance {instance} on cluster {cluster} has {cpu} CPUs and is in the stable pool.
-                        The stable pool should not have workloads with more than 15 CPUs.
-                        If you need to run a workload with more than 15 CPUs, consider using the stable-giant pool.""",
+                        f"""{service}.{instance} in {cluster} has {cpu} CPUs, which exceeds the limit of {max_cpus_for_pool} for the {pool} pool.
+                        If you need to run a workload with this many CPUs, consider using the {recommended_pool} pool instead.""",
                         "",
                     )
                 )
@@ -1435,7 +1444,7 @@ def paasta_validate_soa_configs(
         validate_autoscaling_configs,
         validate_secrets,
         validate_min_max_instances,
-        validate_stable_pool_workloads,
+        validate_pool_limits,
         validate_cpu_burst,
         validate_smartstack,
         validate_flink_monitoring_team,

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1917,6 +1917,11 @@ class TopologySpreadConstraintDict(TypedDict, total=False):
     match_label_keys: List[str]
 
 
+class PoolLimits(TypedDict):
+    max_cpus: float
+    recommended_pool: str
+
+
 class SystemPaastaConfigDict(TypedDict, total=False):
     allowed_pools: Dict[str, List[str]]
     api_client_timeout: int
@@ -1987,7 +1992,8 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     pki_backend: str
     pod_defaults: Dict[str, Any]
     pool_node_affinities: Dict[str, Dict[str, List[str]]]
-    pool_limits: Dict[str, Dict[str, Dict[str, Any]]]
+    # i.e. {cluster: {pool: PoolLimits}}
+    pool_limits: Dict[str, Dict[str, PoolLimits]]
     topology_spread_constraints: List[TopologySpreadConstraintDict]
     readiness_check_prefix_template: List[str]
     register_k8s_pods: bool
@@ -2546,7 +2552,7 @@ class SystemPaastaConfig:
         """Node selectors that will be applied to all Pods in a pool"""
         return self.config_dict.get("pool_node_affinities", {})
 
-    def get_pool_limits(self) -> Dict[str, Dict[str, Dict[str, Any]]]:
+    def get_pool_limits(self) -> Dict[str, Dict[str, Any]]:
         """Pool limits for each cluster"""
         return self.config_dict.get("pool_limits", {})
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1987,6 +1987,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     pki_backend: str
     pod_defaults: Dict[str, Any]
     pool_node_affinities: Dict[str, Dict[str, List[str]]]
+    pool_limits: Dict[str, Dict[str, Dict[str, Any]]]
     topology_spread_constraints: List[TopologySpreadConstraintDict]
     readiness_check_prefix_template: List[str]
     register_k8s_pods: bool
@@ -2544,6 +2545,10 @@ class SystemPaastaConfig:
     def get_pool_node_affinities(self) -> Dict[str, Dict[str, List[str]]]:
         """Node selectors that will be applied to all Pods in a pool"""
         return self.config_dict.get("pool_node_affinities", {})
+
+    def get_pool_limits(self) -> Dict[str, Dict[str, Dict[str, Any]]]:
+        """Pool limits for each cluster"""
+        return self.config_dict.get("pool_limits", {})
 
     def get_topology_spread_constraints(self) -> List[TopologySpreadConstraintDict]:
         """List of TopologySpreadConstraints that will be applied to all Pods in the cluster"""

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2552,7 +2552,7 @@ class SystemPaastaConfig:
         """Node selectors that will be applied to all Pods in a pool"""
         return self.config_dict.get("pool_node_affinities", {})
 
-    def get_pool_limits(self) -> Dict[str, Dict[str, Any]]:
+    def get_pool_limits(self) -> Dict[str, Dict[str, PoolLimits]]:
         """Pool limits for each cluster"""
         return self.config_dict.get("pool_limits", {})
 

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -45,11 +45,11 @@ from paasta_tools.cli.cmds.validate import validate_flink_monitoring_team
 from paasta_tools.cli.cmds.validate import validate_instance_names
 from paasta_tools.cli.cmds.validate import validate_min_max_instances
 from paasta_tools.cli.cmds.validate import validate_paasta_objects
+from paasta_tools.cli.cmds.validate import validate_pool_limits
 from paasta_tools.cli.cmds.validate import validate_rollback_bounds
 from paasta_tools.cli.cmds.validate import validate_schema
 from paasta_tools.cli.cmds.validate import validate_secrets
 from paasta_tools.cli.cmds.validate import validate_smartstack
-from paasta_tools.cli.cmds.validate import validate_stable_pool_workloads
 from paasta_tools.cli.cmds.validate import validate_tron
 from paasta_tools.cli.cmds.validate import validate_unique_instance_names
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_ACTIVE_REQUESTS
@@ -70,7 +70,7 @@ def clear_get_config_file_dict_cache():
 
 
 @patch("paasta_tools.cli.cmds.validate.validate_cpu_burst", autospec=True)
-@patch("paasta_tools.cli.cmds.validate.validate_stable_pool_workloads", autospec=True)
+@patch("paasta_tools.cli.cmds.validate.validate_pool_limits", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.validate_autoscaling_configs", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.validate_unique_instance_names", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.validate_min_max_instances", autospec=True)
@@ -96,12 +96,12 @@ def test_paasta_validate_calls_everything(
     mock_validate_min_max_instances,
     mock_validate_unique_instance_names,
     mock_validate_autoscaling_configs,
-    mock_validate_stable_pool_workloads,
+    mock_validate_pool_limits,
     mock_validate_cpu_burst,
 ):
     # Ensure each check in 'paasta_validate' is called
     mock_validate_cpu_burst.return_value = True
-    mock_validate_stable_pool_workloads.return_value = True
+    mock_validate_pool_limits.return_value = True
     mock_validate_autoscaling_configs.return_value = True
     mock_validate_secrets.return_value = True
     mock_check_service_path.return_value = True
@@ -127,7 +127,7 @@ def test_paasta_validate_calls_everything(
     assert mock_validate_paasta_objects.called
     assert mock_validate_secrets.called
     assert mock_validate_autoscaling_configs.called
-    assert mock_validate_stable_pool_workloads.called
+    assert mock_validate_pool_limits.called
     assert mock_validate_cpu_burst.called
     assert mock_validate_smartstack.called
     assert mock_validate_service_name.called
@@ -2068,20 +2068,27 @@ def test_check_monitoring_file_exists_non_service(tmp_path):
     assert check_monitoring_file_exists(str(tmp_path)) is True
 
 
+@patch("paasta_tools.cli.cmds.validate.load_system_paasta_config", autospec=True)
 @patch(
     "paasta_tools.cli.cmds.validate.load_all_instance_configs_for_service",
     autospec=True,
 )
 @patch("paasta_tools.cli.cmds.validate.list_clusters", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.path_to_soa_dir_service", autospec=True)
-def test_validate_stable_pool_workloads_fails_for_giant_pod(
+def test_validate_pool_limits_fails_for_giant_pod(
     mock_path_to_soa_dir_service,
     mock_list_clusters,
     mock_load_all_instance_configs_for_service,
+    mock_load_system_paasta_config,
     capsys,
 ):
     mock_path_to_soa_dir_service.return_value = ("fake_soa_dir", "fake_service")
     mock_list_clusters.return_value = ["fake_cluster"]
+    mock_load_system_paasta_config.return_value.get_pool_limits.return_value = {
+        "fake_cluster": {
+            "stable": {"max_cpus": 16, "recommended_pool": "stable-giant"},
+        }
+    }
     mock_load_all_instance_configs_for_service.return_value = [
         (
             "fake_instance",
@@ -2092,26 +2099,34 @@ def test_validate_stable_pool_workloads_fails_for_giant_pod(
         )
     ]
 
-    assert validate_stable_pool_workloads("fake-service-path") is False
+    assert validate_pool_limits("fake-service-path") is False
     output, _ = capsys.readouterr()
     assert "fake_instance" in output
     assert "20" in output
-    assert "stable pool" in output
+    assert "stable" in output
+    assert "stable-giant" in output
 
 
+@patch("paasta_tools.cli.cmds.validate.load_system_paasta_config", autospec=True)
 @patch(
     "paasta_tools.cli.cmds.validate.load_all_instance_configs_for_service",
     autospec=True,
 )
 @patch("paasta_tools.cli.cmds.validate.list_clusters", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.path_to_soa_dir_service", autospec=True)
-def test_validate_stable_pool_workloads_passes_for_small_pod(
+def test_validate_pool_limits_passes_for_small_pod(
     mock_path_to_soa_dir_service,
     mock_list_clusters,
     mock_load_all_instance_configs_for_service,
+    mock_load_system_paasta_config,
 ):
     mock_path_to_soa_dir_service.return_value = ("fake_soa_dir", "fake_service")
     mock_list_clusters.return_value = ["fake_cluster"]
+    mock_load_system_paasta_config.return_value.get_pool_limits.return_value = {
+        "fake_cluster": {
+            "stable": {"max_cpus": 16, "recommended_pool": "stable-giant"},
+        }
+    }
     mock_load_all_instance_configs_for_service.return_value = [
         (
             "fake_instance",
@@ -2122,22 +2137,29 @@ def test_validate_stable_pool_workloads_passes_for_small_pod(
         )
     ]
 
-    assert validate_stable_pool_workloads("fake-service-path") is True
+    assert validate_pool_limits("fake-service-path") is True
 
 
+@patch("paasta_tools.cli.cmds.validate.load_system_paasta_config", autospec=True)
 @patch(
     "paasta_tools.cli.cmds.validate.load_all_instance_configs_for_service",
     autospec=True,
 )
 @patch("paasta_tools.cli.cmds.validate.list_clusters", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.path_to_soa_dir_service", autospec=True)
-def test_validate_stable_pool_workloads_passes_for_non_stable_pool(
+def test_validate_pool_limits_passes_for_unconfigured_pool(
     mock_path_to_soa_dir_service,
     mock_list_clusters,
     mock_load_all_instance_configs_for_service,
+    mock_load_system_paasta_config,
 ):
     mock_path_to_soa_dir_service.return_value = ("fake_soa_dir", "fake_service")
     mock_list_clusters.return_value = ["fake_cluster"]
+    mock_load_system_paasta_config.return_value.get_pool_limits.return_value = {
+        "fake_cluster": {
+            "stable": {"max_cpus": 16, "recommended_pool": "stable-giant"},
+        }
+    }
     mock_load_all_instance_configs_for_service.return_value = [
         (
             "fake_instance",
@@ -2148,4 +2170,4 @@ def test_validate_stable_pool_workloads_passes_for_non_stable_pool(
         )
     ]
 
-    assert validate_stable_pool_workloads("fake-service-path") is True
+    assert validate_pool_limits("fake-service-path") is True

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -49,6 +49,7 @@ from paasta_tools.cli.cmds.validate import validate_rollback_bounds
 from paasta_tools.cli.cmds.validate import validate_schema
 from paasta_tools.cli.cmds.validate import validate_secrets
 from paasta_tools.cli.cmds.validate import validate_smartstack
+from paasta_tools.cli.cmds.validate import validate_stable_pool_workloads
 from paasta_tools.cli.cmds.validate import validate_tron
 from paasta_tools.cli.cmds.validate import validate_unique_instance_names
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_ACTIVE_REQUESTS
@@ -69,6 +70,7 @@ def clear_get_config_file_dict_cache():
 
 
 @patch("paasta_tools.cli.cmds.validate.validate_cpu_burst", autospec=True)
+@patch("paasta_tools.cli.cmds.validate.validate_stable_pool_workloads", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.validate_autoscaling_configs", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.validate_unique_instance_names", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.validate_min_max_instances", autospec=True)
@@ -94,10 +96,12 @@ def test_paasta_validate_calls_everything(
     mock_validate_min_max_instances,
     mock_validate_unique_instance_names,
     mock_validate_autoscaling_configs,
+    mock_validate_stable_pool_workloads,
     mock_validate_cpu_burst,
 ):
     # Ensure each check in 'paasta_validate' is called
     mock_validate_cpu_burst.return_value = True
+    mock_validate_stable_pool_workloads.return_value = True
     mock_validate_autoscaling_configs.return_value = True
     mock_validate_secrets.return_value = True
     mock_check_service_path.return_value = True
@@ -123,6 +127,7 @@ def test_paasta_validate_calls_everything(
     assert mock_validate_paasta_objects.called
     assert mock_validate_secrets.called
     assert mock_validate_autoscaling_configs.called
+    assert mock_validate_stable_pool_workloads.called
     assert mock_validate_cpu_burst.called
     assert mock_validate_smartstack.called
     assert mock_validate_service_name.called
@@ -2061,3 +2066,86 @@ def test_check_monitoring_file_missing(tmp_path):
 
 def test_check_monitoring_file_exists_non_service(tmp_path):
     assert check_monitoring_file_exists(str(tmp_path)) is True
+
+
+@patch(
+    "paasta_tools.cli.cmds.validate.load_all_instance_configs_for_service",
+    autospec=True,
+)
+@patch("paasta_tools.cli.cmds.validate.list_clusters", autospec=True)
+@patch("paasta_tools.cli.cmds.validate.path_to_soa_dir_service", autospec=True)
+def test_validate_stable_pool_workloads_fails_for_giant_pod(
+    mock_path_to_soa_dir_service,
+    mock_list_clusters,
+    mock_load_all_instance_configs_for_service,
+    capsys,
+):
+    mock_path_to_soa_dir_service.return_value = ("fake_soa_dir", "fake_service")
+    mock_list_clusters.return_value = ["fake_cluster"]
+    mock_load_all_instance_configs_for_service.return_value = [
+        (
+            "fake_instance",
+            mock.Mock(
+                get_cpus=mock.Mock(return_value=20),
+                get_pool=mock.Mock(return_value="stable"),
+            ),
+        )
+    ]
+
+    assert validate_stable_pool_workloads("fake-service-path") is False
+    output, _ = capsys.readouterr()
+    assert "fake_instance" in output
+    assert "20" in output
+    assert "stable pool" in output
+
+
+@patch(
+    "paasta_tools.cli.cmds.validate.load_all_instance_configs_for_service",
+    autospec=True,
+)
+@patch("paasta_tools.cli.cmds.validate.list_clusters", autospec=True)
+@patch("paasta_tools.cli.cmds.validate.path_to_soa_dir_service", autospec=True)
+def test_validate_stable_pool_workloads_passes_for_small_pod(
+    mock_path_to_soa_dir_service,
+    mock_list_clusters,
+    mock_load_all_instance_configs_for_service,
+):
+    mock_path_to_soa_dir_service.return_value = ("fake_soa_dir", "fake_service")
+    mock_list_clusters.return_value = ["fake_cluster"]
+    mock_load_all_instance_configs_for_service.return_value = [
+        (
+            "fake_instance",
+            mock.Mock(
+                get_cpus=mock.Mock(return_value=8),
+                get_pool=mock.Mock(return_value="stable"),
+            ),
+        )
+    ]
+
+    assert validate_stable_pool_workloads("fake-service-path") is True
+
+
+@patch(
+    "paasta_tools.cli.cmds.validate.load_all_instance_configs_for_service",
+    autospec=True,
+)
+@patch("paasta_tools.cli.cmds.validate.list_clusters", autospec=True)
+@patch("paasta_tools.cli.cmds.validate.path_to_soa_dir_service", autospec=True)
+def test_validate_stable_pool_workloads_passes_for_non_stable_pool(
+    mock_path_to_soa_dir_service,
+    mock_list_clusters,
+    mock_load_all_instance_configs_for_service,
+):
+    mock_path_to_soa_dir_service.return_value = ("fake_soa_dir", "fake_service")
+    mock_list_clusters.return_value = ["fake_cluster"]
+    mock_load_all_instance_configs_for_service.return_value = [
+        (
+            "fake_instance",
+            mock.Mock(
+                get_cpus=mock.Mock(return_value=32),
+                get_pool=mock.Mock(return_value="default"),
+            ),
+        )
+    ]
+
+    assert validate_stable_pool_workloads("fake-service-path") is True


### PR DESCRIPTION
[PAASTA-18929](https://jira.yelpcorp.com/browse/PAASTA-18929)

We want to prevent large CPU usage services on the stable pool. This is a generic validation that allows configuring cpu limits per cluster per pool. The configuration will be managed through karpenter