### PR TITLE
Flesh out filtering for custom alerts based on deploy group

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -49,8 +49,6 @@ from slackclient import SlackClient
 from sticht import state_machine
 from sticht.rollbacks.base import RollbackSlackDeploymentProcess
 from sticht.rollbacks.slo import SLOWatcher
-from sticht.rollbacks.types import MetricWatcher
-from sticht.rollbacks.types import SplunkAuth
 
 from paasta_tools import remote_git
 from paasta_tools.api import client
@@ -88,7 +86,6 @@ from paasta_tools.utils import TimeoutError
 from paasta_tools.utils import _log
 from paasta_tools.utils import _log_audit
 from paasta_tools.utils import format_tag
-from paasta_tools.utils import get_files_of_type_in_dir
 from paasta_tools.utils import get_git_url
 from paasta_tools.utils import get_paasta_tag_from_deploy_group
 from paasta_tools.utils import get_rollback_tags_for_sha
@@ -379,22 +376,17 @@ def can_user_deploy_service(deploy_info: Dict[str, Any], service: str) -> bool:
     return True
 
 
-def can_run_metric_watcher_threads(
+def build_alertmanager_rollback_filters(
     service: str,
-    soa_dir: str,
-) -> bool:
-    """
-    Cannot run slo and metric watcher threads together for now.
-    SLO Watcher Threads take precedence over metric watcher threads.
-    Metric Watcher Threads can run if there are no SLOs available.
-    """
-    slo_files = get_files_of_type_in_dir(
-        file_type="slo", service=service, soa_dir=soa_dir
-    )
-    rollback_files = get_files_of_type_in_dir(
-        file_type="rollback", service=service, soa_dir=soa_dir
-    )
-    return bool(not slo_files and rollback_files)
+) -> List[List[str]]:
+    return [
+        # TODO(PAASTA-18914): find clusters/instances based on deploy group
+        [
+            'paasta_rollback_metric="true"',
+            f'paasta_service="{service}"',
+        ],
+        # TODO(PAASTA-18915): add default error alerting filters
+    ]
 
 
 def report_waiting_aborted(service: str, deploy_group: str) -> None:
@@ -721,6 +713,14 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
             "crashloop_rollback_percentage_threshold",
             system_paasta_config.get_crashloop_rollback_percentage_threshold(),
         )
+        self.alertmanager_rollback_enabled = self._get_deploy_group_config(
+            "alertmanager_rollback",
+            system_paasta_config.get_enable_alertmanager_rollback(),
+        )
+        self.alertmanager_poll_interval_s = self._get_deploy_group_config(
+            "alertmanager_poll_interval_s",
+            system_paasta_config.get_alertmanager_poll_interval_s(),
+        )
 
         # Keep track of each wait_for_deployment task so we can cancel it.
         self.wait_for_deployment_tasks: Dict[DeploymentVersion, asyncio.Task] = {}
@@ -733,12 +733,20 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         self.progress = Progress()
         self.last_action = None
         self.slo_watchers: List[SLOWatcher] = []
-        self.metric_watchers: List[MetricWatcher] = []
         self.start_slo_watcher_threads(self.service, self.soa_dir)
 
-        # TODO: Allow both metric and slo watcher threads to run together in the future
-        if can_run_metric_watcher_threads(service=self.service, soa_dir=self.soa_dir):
-            self.start_metric_watcher_threads(self.service, self.soa_dir)
+        if self.alertmanager_rollback_enabled and (
+            alertmanager_url := system_paasta_config.get_alertmanager_url()
+        ):
+            # TODO(PAASTA-18914, PAASTA-18915): filter by instance/cluster based on deploy group + default error alerts
+            filters = build_alertmanager_rollback_filters(
+                service=self.service,
+            )
+            self.start_alertmanager_watcher_threads(
+                alertmanager_url=alertmanager_url,
+                filters=filters,
+                check_interval_s=self.alertmanager_poll_interval_s,
+            )
 
         # Initialize Slack threads and send the first message
         super().__init__()
@@ -1002,8 +1010,13 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
             yield {
                 "source": self.rollforward_states,
                 "dest": "start_rollback",
-                "trigger": "rollback_metric_failure",
-                "before": self.log_metric_rollback,
+                "trigger": "rollback_alertmanager_failure",
+                "before": self.log_alertmanager_rollback,
+            }
+            yield {
+                "source": self.rollback_states,
+                "dest": None,
+                "trigger": "rollback_alertmanager_failure",
             }
             yield {
                 "source": self.rollforward_states,
@@ -1090,19 +1103,19 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         yield {
             "source": "*",
             "dest": None,
-            "trigger": "metrics_started_failing",
+            "trigger": "alertmanager_started_failing",
             "conditions": [self.auto_rollbacks_enabled],
             "unless": [self.already_rolling_back],
             "before": functools.partial(
-                self.start_auto_rollback_countdown, "rollback_metric_failure"
+                self.start_auto_rollback_countdown, "rollback_alertmanager_failure"
             ),
         }
         yield {
             "source": "*",
             "dest": None,
-            "trigger": "metrics_stopped_failing",
+            "trigger": "alertmanager_stopped_failing",
             "before": functools.partial(
-                self.cancel_auto_rollback_countdown, "rollback_metric_failure"
+                self.cancel_auto_rollback_countdown, "rollback_alertmanager_failure"
             ),
         }
         yield {
@@ -1364,9 +1377,9 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
             self.ping_authors(
                 "Because an SLO is currently failing, we will not automatically certify. Instead, we will wait indefinitely until you click one of the buttons above."
             )
-        elif self.any_metric_failing() and self.auto_rollbacks_enabled():
+        elif self.any_alertmanager_failing() and self.auto_rollbacks_enabled():
             self.ping_authors(
-                "Because a rollback-triggering metric for this service is currently failing, we will not automatically certify. Instead, we will wait indefinitely until you click one of the buttons above."
+                "Because an AlertManager alert for this service is currently firing, we will not automatically certify. Instead, we will wait indefinitely until you click one of the buttons above."
             )
         elif self.any_crashloop_failing():
             self.ping_authors(
@@ -1416,21 +1429,6 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
             load_system_paasta_config()
             .get_monitoring_config()
             .get("signalfx_api_key", None)
-        )
-
-    def get_splunk_api_token(self) -> SplunkAuth:
-        auth_token = os.environ["SPLUNK_MFD_TOKEN"]
-        auth_data = (
-            load_system_paasta_config()
-            .get_monitoring_config()
-            .get("splunk_mfd_authentication")
-        )
-
-        return SplunkAuth(
-            host=auth_data["host"],
-            port=auth_data["port"],
-            username=auth_data["username"],
-            password=auth_token,
         )
 
     def get_button_text(self, button: str, is_active: bool) -> str:
@@ -1507,10 +1505,10 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         )
         self._log_rollback(rollback_details)
 
-    def log_metric_rollback(self) -> None:
-        self.rollback_type = RollbackTypes.AUTOMATIC_METRIC_ROLLBACK
+    def log_alertmanager_rollback(self) -> None:
+        self.rollback_type = RollbackTypes.AUTOMATIC_ALERTMANAGER_ROLLBACK
         rollback_details = self.__build_rollback_audit_details(
-            RollbackTypes.AUTOMATIC_METRIC_ROLLBACK
+            RollbackTypes.AUTOMATIC_ALERTMANAGER_ROLLBACK
         )
         self._log_rollback(rollback_details)
 

--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -378,13 +378,34 @@ def can_user_deploy_service(deploy_info: Dict[str, Any], service: str) -> bool:
 
 def build_alertmanager_rollback_filters(
     service: str,
+    instance_configs_per_cluster: Dict[str, List[LongRunningServiceConfig]],
 ) -> List[List[str]]:
+    custom_alert_filter: List[str] = [
+        'paasta_rollback_metric="true"',
+        f'paasta_service="{service}"',
+    ]
+
+    # alertmanager doesn't care about the ordering, but it does make tests slightly easier to write :p
+    clusters = sorted(
+        cluster
+        for cluster, instances in instance_configs_per_cluster.items()
+        if instances
+    )
+    instances = set()
+    for configs in instance_configs_per_cluster.values():
+        for config in configs:
+            instances.add(config.instance)
+
+    if clusters:
+        custom_alert_filter.append(f'paasta_cluster=~"^({"|".join(clusters)})$"')
+
+    if instances:
+        custom_alert_filter.append(
+            f'paasta_instance=~"^({"|".join(sorted(instances))})$"'
+        )
+
     return [
-        # TODO(PAASTA-18914): find clusters/instances based on deploy group
-        [
-            'paasta_rollback_metric="true"',
-            f'paasta_service="{service}"',
-        ],
+        custom_alert_filter,
         # TODO(PAASTA-18915): add default error alerting filters
     ]
 
@@ -738,9 +759,10 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         if self.alertmanager_rollback_enabled and (
             alertmanager_url := system_paasta_config.get_alertmanager_url()
         ):
-            # TODO(PAASTA-18914, PAASTA-18915): filter by instance/cluster based on deploy group + default error alerts
+            # TODO(PAASTA-18915): add default error alerting filters
             filters = build_alertmanager_rollback_filters(
                 service=self.service,
+                instance_configs_per_cluster=self.instance_configs_per_cluster,
             )
             self.start_alertmanager_watcher_threads(
                 alertmanager_url=alertmanager_url,

--- a/paasta_tools/cli/schemas/deploy_schema.json
+++ b/paasta_tools/cli/schemas/deploy_schema.json
@@ -105,6 +105,13 @@
                 "enable_automated_redeploys": {
                     "type": "boolean"
                 },
+                "alertmanager_rollback": {
+                    "type": "boolean"
+                },
+                "alertmanager_poll_interval_s": {
+                    "type": "integer",
+                    "minimum": 30
+                },
                 "enable_crashloop_auto_rollback": {
                     "type": "boolean"
                 },

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -189,6 +189,7 @@ CAPS_DROP = [
 class RollbackTypes(Enum):
     AUTOMATIC_SLO_ROLLBACK = "automatic_slo_rollback"
     AUTOMATIC_METRIC_ROLLBACK = "automatic_metric_rollback"
+    AUTOMATIC_ALERTMANAGER_ROLLBACK = "automatic_alertmanager_rollback"
     AUTOMATIC_CRASHLOOP_ROLLBACK = "automatic_crashloop_rollback"
     USER_INITIATED_ROLLBACK = "user_initiated_rollback"
 
@@ -1976,6 +1977,9 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     enable_crashloop_auto_rollback: bool
     min_restarts_for_crashloop_rollback: int
     crashloop_rollback_percentage_threshold: float
+    alertmanager_url: str
+    enable_alertmanager_rollback: bool
+    alertmanager_poll_interval_s: int
     mesos_config: Dict
     metrics_provider: str
     monitoring_config: Dict
@@ -2672,6 +2676,15 @@ class SystemPaastaConfig:
         return self.config_dict.get(
             "mark_for_deployment_should_ping_for_unhealthy_pods", True
         )
+
+    def get_alertmanager_url(self) -> Optional[str]:
+        return self.config_dict.get("alertmanager_url", None)
+
+    def get_enable_alertmanager_rollback(self) -> bool:
+        return self.config_dict.get("enable_alertmanager_rollback", False)
+
+    def get_alertmanager_poll_interval_s(self) -> int:
+        return self.config_dict.get("alertmanager_poll_interval_s", 30)
 
     def get_enable_crashloop_auto_rollback(self) -> bool:
         return self.config_dict.get("enable_crashloop_auto_rollback", False)

--- a/requirements.txt
+++ b/requirements.txt
@@ -99,7 +99,7 @@ slackclient==1.2.1
 splunk-sdk==1.7.0
 sseclient-py==1.7
 # make sure you bump sticht in extra_requirements_yelp.txt as well
-sticht==1.2.1
+sticht==1.3.0
 strict-rfc3339==0.7
 swagger-spec-validator==2.1.0
 syslogmp==0.2.2

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -1530,7 +1530,6 @@ def test_alertmanager_rollback_config_from_system_config(
     assert mfdp.alertmanager_poll_interval_s == 60
 
 
-
 def test_MarkForDeployProcess_alertmanager_alert_triggers_rollback(
     mock_periodically_update_slack,
 ):
@@ -1580,7 +1579,9 @@ def test_MarkForDeployProcess_alertmanager_alert_triggers_rollback(
             authors=None,
         )
 
-        mfdp.run_timeout = 1  # fail fast if the state machine gets stuck instead of hanging
+        mfdp.run_timeout = (
+            1  # fail fast if the state machine gets stuck instead of hanging
+        )
         assert mfdp.run() == 1
         assert mfdp.trigger_history == [
             "start_deploy",
@@ -1593,3 +1594,87 @@ def test_MarkForDeployProcess_alertmanager_alert_triggers_rollback(
         ]
         assert mfdp.rollback_type == RollbackTypes.AUTOMATIC_ALERTMANAGER_ROLLBACK
 
+
+def _make_instance_config(instance: str) -> MagicMock:
+    cfg = MagicMock(spec=LongRunningServiceConfig)
+    cfg.instance = instance
+    return cfg
+
+
+def test_build_alertmanager_rollback_filters_empty():
+    assert mark_for_deployment.build_alertmanager_rollback_filters(
+        service="my_service",
+        instance_configs_per_cluster={},
+    ) == [
+        [
+            'paasta_rollback_metric="true"',
+            'paasta_service="my_service"',
+        ],
+    ]
+
+
+def test_build_alertmanager_rollback_filters_single_cluster_single_instance():
+    assert mark_for_deployment.build_alertmanager_rollback_filters(
+        service="my_service",
+        instance_configs_per_cluster={
+            "cluster-a": [_make_instance_config("web")],
+        },
+    ) == [
+        [
+            'paasta_rollback_metric="true"',
+            'paasta_service="my_service"',
+            'paasta_cluster=~"^(cluster-a)$"',
+            'paasta_instance=~"^(web)$"',
+        ],
+    ]
+
+
+def test_build_alertmanager_rollback_filters_multi_cluster_multi_instance():
+    assert mark_for_deployment.build_alertmanager_rollback_filters(
+        service="my_service",
+        instance_configs_per_cluster={
+            "cluster-a": [_make_instance_config("web")],
+            "cluster-b": [_make_instance_config("worker")],
+        },
+    ) == [
+        [
+            'paasta_rollback_metric="true"',
+            'paasta_service="my_service"',
+            'paasta_cluster=~"^(cluster-a|cluster-b)$"',
+            'paasta_instance=~"^(web|worker)$"',
+        ],
+    ]
+
+
+def test_build_alertmanager_rollback_filters_empty_cluster_excluded():
+    assert mark_for_deployment.build_alertmanager_rollback_filters(
+        service="my_service",
+        instance_configs_per_cluster={
+            "cluster-a": [_make_instance_config("web")],
+            "cluster-b": [],
+        },
+    ) == [
+        [
+            'paasta_rollback_metric="true"',
+            'paasta_service="my_service"',
+            'paasta_cluster=~"^(cluster-a)$"',
+            'paasta_instance=~"^(web)$"',
+        ],
+    ]
+
+
+def test_build_alertmanager_rollback_filters_duplicate_instances_deduplicated():
+    assert mark_for_deployment.build_alertmanager_rollback_filters(
+        service="my_service",
+        instance_configs_per_cluster={
+            "cluster-a": [_make_instance_config("web")],
+            "cluster-b": [_make_instance_config("web")],
+        },
+    ) == [
+        [
+            'paasta_rollback_metric="true"',
+            'paasta_service="my_service"',
+            'paasta_cluster=~"^(cluster-a|cluster-b)$"',
+            'paasta_instance=~"^(web)$"',
+        ],
+    ]

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -80,6 +80,15 @@ def ensure_default_event_loop():
         yield
 
 
+@fixture(autouse=True)
+def mock_alertmanager_watcher_threads():
+    with patch(
+        "sticht.rollbacks.base.RollbackSlackDeploymentProcess.start_alertmanager_watcher_threads",
+        autospec=True,
+    ):
+        yield
+
+
 class FakeArgs:
     deploy_group = "test_deploy_group"
     service = "test_service"
@@ -257,6 +266,9 @@ def test_paasta_mark_for_deployment_with_good_rollback(
     mock_list_deploy_groups.return_value = ["test_deploy_groups"]
     config_mock = mock.Mock()
     config_mock.get_default_push_groups.return_value = None
+    config_mock.get_enable_alertmanager_rollback.return_value = False
+    config_mock.get_alertmanager_url.return_value = None
+    config_mock.get_alertmanager_poll_interval_s.return_value = 30
     mock_load_system_paasta_config.return_value = config_mock
     mock_get_instance_configs.return_value = {"fake_cluster": [], "fake_cluster2": []}
     mock_mark_for_deployment.return_value = 0
@@ -441,6 +453,7 @@ def test_MarkForDeployProcess_handles_wait_for_deployment_failure(
     mock_get_instance_configs,
 ):
     mock_get_authors.return_value = 0, "fakeuser1 fakeuser2"
+    mock_load_system_paasta_config.return_value = MOCK_SYSTEM_PAASTA_CONFIG
     mfdp = mark_for_deployment.MarkForDeploymentProcess(
         service="service",
         block=True,
@@ -1444,3 +1457,139 @@ def test_log_crashloop_rollback():
         call_kwargs["action_details"]["rollback_type"]
         == RollbackTypes.AUTOMATIC_CRASHLOOP_ROLLBACK.value
     )
+
+
+def test_alertmanager_rollback_config_defaults(
+    mock_periodically_update_slack,
+):
+    with patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
+        autospec=True,
+    ):
+        mfdp = WrappedMarkForDeploymentProcess(
+            service="service",
+            deploy_info={"pipeline": []},
+            deploy_group="deploy_group",
+            commit="commit",
+            old_git_sha="old_git_sha",
+            git_url="git_url",
+            auto_rollback=False,
+            block=False,
+            soa_dir="soa_dir",
+            timeout=3600,
+            warn_pct=50,
+            auto_certify_delay=None,
+            auto_abandon_delay=600,
+            auto_rollback_delay=30,
+            authors=None,
+        )
+
+    assert mfdp.alertmanager_rollback_enabled is False
+
+
+def test_alertmanager_rollback_config_from_system_config(
+    mock_periodically_update_slack,
+):
+    mock_config = utils.SystemPaastaConfig(
+        utils.SystemPaastaConfigDict(
+            {
+                "enable_alertmanager_rollback": True,
+                "alertmanager_poll_interval_s": 60,
+            }
+        ),
+        "/mock/system/configs",
+    )
+
+    with patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
+        autospec=True,
+    ), patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config",
+        autospec=True,
+        return_value=mock_config,
+    ):
+        mfdp = WrappedMarkForDeploymentProcess(
+            service="service",
+            deploy_info={"pipeline": []},
+            deploy_group="deploy_group",
+            commit="commit",
+            old_git_sha="old_git_sha",
+            git_url="git_url",
+            auto_rollback=False,
+            block=False,
+            soa_dir="soa_dir",
+            timeout=3600,
+            warn_pct=50,
+            auto_certify_delay=None,
+            auto_abandon_delay=600,
+            auto_rollback_delay=30,
+            authors=None,
+        )
+
+    assert mfdp.alertmanager_rollback_enabled is True
+    assert mfdp.alertmanager_poll_interval_s == 60
+
+
+
+def test_MarkForDeployProcess_alertmanager_alert_triggers_rollback(
+    mock_periodically_update_slack,
+):
+    """When an alertmanager alert fires during deploying, the state machine transitions to rollback.
+
+    NOTE: we don't need alertmanager_rollback_enabled here because the test fires the trigger directly
+    via simulate_alert (bypassing the real AlertManager watcher). The state machine transition only
+    requires auto_rollback=True, not the alertmanager-specific config.
+    """
+
+    def simulate_alert(self, target_commit, target_image_version, rollback_type=None):
+        if target_commit == "commit":
+            self.trigger("alertmanager_started_failing")
+        else:
+            self.trigger("deploy_finished")
+
+    with patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
+        autospec=True,
+    ), patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.mark_for_deployment",
+        autospec=True,
+        return_value=0,
+    ), patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.MarkForDeploymentProcess.do_wait_for_deployment",
+        autospec=True,
+        side_effect=simulate_alert,
+    ), patch(
+        "paasta_tools.cli.cmds.mark_for_deployment._log",
+        autospec=True,
+    ):
+        mfdp = WrappedMarkForDeploymentProcess(
+            service="service",
+            deploy_info={"pipeline": []},
+            deploy_group="deploy_group",
+            commit="commit",
+            old_git_sha="old_git_sha",
+            git_url="git_url",
+            auto_rollback=True,
+            block=True,
+            soa_dir="soa_dir",
+            timeout=3600,
+            warn_pct=50,
+            auto_certify_delay=None,
+            auto_abandon_delay=600,
+            auto_rollback_delay=30,
+            authors=None,
+        )
+
+        mfdp.run_timeout = 1  # fail fast if the state machine gets stuck instead of hanging
+        assert mfdp.run() == 1
+        assert mfdp.trigger_history == [
+            "start_deploy",
+            "mfd_succeeded",
+            "alertmanager_started_failing",
+            "rollback_alertmanager_failure",
+            "mfd_succeeded",
+            "deploy_finished",
+            "auto_abandon",
+        ]
+        assert mfdp.rollback_type == RollbackTypes.AUTOMATIC_ALERTMANAGER_ROLLBACK
+

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -28,9 +28,8 @@ scribereader==1.1.1
 signalform-tools==0.0.16            # slo-transcoder dependency
 slo-transcoder==3.3.0
 smmap2==2.0.3                       # slo-transcoder, vault-tools dependency
-splunk-sdk==1.7.0                   # sticht dependency
 srv-configs==1.1.0                  # yelp-profiling dependency
-sticht[yelp_internal]==1.2.1
+sticht[yelp_internal]==1.3.0
 tenacity==8.3.0                     # yelp-clog dependency
 vault-tools==2.3.1
 yelp-cgeom==1.3.1                   # scribereader dependency


### PR DESCRIPTION
We can't just filter by service name since an instance in a
cluster/deploy group with no changes might be encountering issues, and
those are (likely) unrelated to our current deployment