### PR TITLE
Build deploy group to AlertManager filter mapping

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -378,13 +378,34 @@ def can_user_deploy_service(deploy_info: Dict[str, Any], service: str) -> bool:
 
 def build_alertmanager_rollback_filters(
     service: str,
+    instance_configs_per_cluster: Dict[str, List[LongRunningServiceConfig]],
 ) -> List[List[str]]:
+    custom_alert_filter: List[str] = [
+        'paasta_rollback_metric="true"',
+        f'paasta_service="{service}"',
+    ]
+
+    # alertmanager doesn't care about the ordering, but it does make tests slightly easier to write :p
+    clusters = sorted(
+        cluster
+        for cluster, instances in instance_configs_per_cluster.items()
+        if instances
+    )
+    instances = set()
+    for configs in instance_configs_per_cluster.values():
+        for config in configs:
+            instances.add(config.instance)
+
+    if clusters:
+        custom_alert_filter.append(f'paasta_cluster=~"^({"|".join(clusters)})$"')
+
+    if instances:
+        custom_alert_filter.append(
+            f'paasta_instance=~"^({"|".join(sorted(instances))})$"'
+        )
+
     return [
-        # TODO(PAASTA-18914): find clusters/instances based on deploy group
-        [
-            'paasta_rollback_metric="true"',
-            f'paasta_service="{service}"',
-        ],
+        custom_alert_filter,
         # TODO(PAASTA-18915): add default error alerting filters
     ]
 
@@ -738,9 +759,10 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         if self.alertmanager_rollback_enabled and (
             alertmanager_url := system_paasta_config.get_alertmanager_url()
         ):
-            # TODO(PAASTA-18914, PAASTA-18915): filter by instance/cluster based on deploy group + default error alerts
+            # TODO(PAASTA-18915): add default error alerting filters
             filters = build_alertmanager_rollback_filters(
                 service=self.service,
+                instance_configs_per_cluster=self.instance_configs_per_cluster,
             )
             self.start_alertmanager_watcher_threads(
                 alertmanager_url=alertmanager_url,

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -1530,7 +1530,6 @@ def test_alertmanager_rollback_config_from_system_config(
     assert mfdp.alertmanager_poll_interval_s == 60
 
 
-
 def test_MarkForDeployProcess_alertmanager_alert_triggers_rollback(
     mock_periodically_update_slack,
 ):
@@ -1580,7 +1579,9 @@ def test_MarkForDeployProcess_alertmanager_alert_triggers_rollback(
             authors=None,
         )
 
-        mfdp.run_timeout = 1  # fail fast if the state machine gets stuck instead of hanging
+        mfdp.run_timeout = (
+            1  # fail fast if the state machine gets stuck instead of hanging
+        )
         assert mfdp.run() == 1
         assert mfdp.trigger_history == [
             "start_deploy",
@@ -1593,3 +1594,87 @@ def test_MarkForDeployProcess_alertmanager_alert_triggers_rollback(
         ]
         assert mfdp.rollback_type == RollbackTypes.AUTOMATIC_ALERTMANAGER_ROLLBACK
 
+
+def _make_instance_config(instance: str) -> MagicMock:
+    cfg = MagicMock(spec=LongRunningServiceConfig)
+    cfg.instance = instance
+    return cfg
+
+
+def test_build_alertmanager_rollback_filters_empty():
+    assert mark_for_deployment.build_alertmanager_rollback_filters(
+        service="my_service",
+        instance_configs_per_cluster={},
+    ) == [
+        [
+            'paasta_rollback_metric="true"',
+            'paasta_service="my_service"',
+        ],
+    ]
+
+
+def test_build_alertmanager_rollback_filters_single_cluster_single_instance():
+    assert mark_for_deployment.build_alertmanager_rollback_filters(
+        service="my_service",
+        instance_configs_per_cluster={
+            "cluster-a": [_make_instance_config("web")],
+        },
+    ) == [
+        [
+            'paasta_rollback_metric="true"',
+            'paasta_service="my_service"',
+            'paasta_cluster=~"^(cluster-a)$"',
+            'paasta_instance=~"^(web)$"',
+        ],
+    ]
+
+
+def test_build_alertmanager_rollback_filters_multi_cluster_multi_instance():
+    assert mark_for_deployment.build_alertmanager_rollback_filters(
+        service="my_service",
+        instance_configs_per_cluster={
+            "cluster-a": [_make_instance_config("web")],
+            "cluster-b": [_make_instance_config("worker")],
+        },
+    ) == [
+        [
+            'paasta_rollback_metric="true"',
+            'paasta_service="my_service"',
+            'paasta_cluster=~"^(cluster-a|cluster-b)$"',
+            'paasta_instance=~"^(web|worker)$"',
+        ],
+    ]
+
+
+def test_build_alertmanager_rollback_filters_empty_cluster_excluded():
+    assert mark_for_deployment.build_alertmanager_rollback_filters(
+        service="my_service",
+        instance_configs_per_cluster={
+            "cluster-a": [_make_instance_config("web")],
+            "cluster-b": [],
+        },
+    ) == [
+        [
+            'paasta_rollback_metric="true"',
+            'paasta_service="my_service"',
+            'paasta_cluster=~"^(cluster-a)$"',
+            'paasta_instance=~"^(web)$"',
+        ],
+    ]
+
+
+def test_build_alertmanager_rollback_filters_duplicate_instances_deduplicated():
+    assert mark_for_deployment.build_alertmanager_rollback_filters(
+        service="my_service",
+        instance_configs_per_cluster={
+            "cluster-a": [_make_instance_config("web")],
+            "cluster-b": [_make_instance_config("web")],
+        },
+    ) == [
+        [
+            'paasta_rollback_metric="true"',
+            'paasta_service="my_service"',
+            'paasta_cluster=~"^(cluster-a|cluster-b)$"',
+            'paasta_instance=~"^(web)$"',
+        ],
+    ]


### PR DESCRIPTION
We can't just filter by service name since an instance in a
cluster/deploy group with no changes might be encountering issues, and
those are (likely) unrelated to our current deployment