### PR TITLE
feat: use_raw_ksm query for all autoscaling types

### DIFF
--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -995,7 +995,7 @@ def create_shared_uwsgi_v2_scaling_rule(
                     "kube_deployment", "$1", "deployment", "(.*)")
                 - on (kube_deployment)
                 count by (kube_deployment) (
-                    uwsgi_worker_busy{{{worker_filter_terms}}}
+                    {load_per_instance}
                 ),
                 0
             ) or on() vector(0))
@@ -1087,7 +1087,7 @@ def create_shared_uwsgi_scaling_rule(
                     "kube_deployment", "$1", "deployment", "(.*)")
                 - on (kube_deployment)
                 count by (kube_deployment) (
-                    uwsgi_worker_busy{{{worker_filter_terms}}}
+                    {load_per_instance}
                 ),
                 0
             ) or on() vector(0))
@@ -1198,7 +1198,7 @@ def create_shared_piscina_scaling_rule(
                     "kube_deployment", "$1", "deployment", "(.*)")
                 - on (kube_deployment)
                 count by (kube_deployment) (
-                    piscina_pool_utilization{{{worker_filter_terms}}}
+                    {load_per_instance}
                 ),
                 0
             ) or on() vector(0))
@@ -1301,7 +1301,7 @@ def create_shared_gunicorn_scaling_rule(
                     "kube_deployment", "$1", "deployment", "(.*)")
                 - on (kube_deployment)
                 count by (kube_deployment) (
-                    gunicorn_worker_busy{{{worker_filter_terms}}}
+                    {load_per_instance}
                 ),
                 0
             ) or on() vector(0))

--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -75,6 +75,7 @@ from paasta_tools.long_running_service_tools import METRICS_PROVIDER_WORKER_LOAD
 from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_services_for_cluster
+from paasta_tools.utils import load_system_paasta_config
 
 log = logging.getLogger(__name__)
 
@@ -973,35 +974,67 @@ def create_shared_uwsgi_v2_scaling_rule(
     )
     worker_filter_terms = f"paasta_cluster='{paasta_cluster}',paasta_service='<<index .LabelValuesByName \"paasta_service\">>',paasta_instance='<<index .LabelValuesByName \"paasta_instance\">>',kube_deployment='<<index .LabelValuesByName \"kube_deployment\">>'"
 
-    ready_pods = f"""
-        (sum(
-            k8s:deployment:pods_status_ready{{{worker_filter_terms}}} >= 0
-            or
-            max_over_time(
-                k8s:deployment:pods_status_ready{{{worker_filter_terms}}}[{DEFAULT_EXTRAPOLATION_TIME}s]
-            )
-        ) by (kube_deployment))
-    """
+    use_raw_ksm_queries = load_system_paasta_config().get_use_raw_ksm_queries()
+
     load_per_instance = f"""
         avg(
             uwsgi_worker_busy{{{worker_filter_terms}}}
         ) by (kube_pod, kube_deployment)
     """
-    missing_instances = f"""
-        clamp_min(
-            {ready_pods} - count({load_per_instance}) by (kube_deployment),
-            0
+    if use_raw_ksm_queries:
+        replicas_filter_terms = (
+            f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)'"
         )
-    """
-    total_load = f"""
-    (
-        sum(
-            {load_per_instance}
-        ) by (kube_deployment)
-        +
-        {missing_instances}
-    )
-    """
+        deployment_labels_filter_terms = f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)',label_paasta_yelp_com_service='<<index .LabelValuesByName \"paasta_service\">>',label_paasta_yelp_com_instance='<<index .LabelValuesByName \"paasta_instance\">>'"
+        missing_instances = f"""
+            (clamp_min(
+                label_replace(
+                    kube_deployment_status_replicas_ready{{{replicas_filter_terms}}}
+                    * on (deployment)
+                    kube_deployment_labels{{{deployment_labels_filter_terms}}},
+                    "kube_deployment", "$1", "deployment", "(.*)")
+                - on (kube_deployment)
+                count by (kube_deployment) (
+                    uwsgi_worker_busy{{{worker_filter_terms}}}
+                ),
+                0
+            ) or on() vector(0))
+        """
+        total_load = f"""
+        (
+            sum(
+                {load_per_instance}
+            ) by (kube_deployment)
+            + ignoring(kube_deployment) group_left()
+            {missing_instances}
+        )
+        """
+    else:
+        ready_pods = f"""
+            (sum(
+                k8s:deployment:pods_status_ready{{{worker_filter_terms}}} >= 0
+                or
+                max_over_time(
+                    k8s:deployment:pods_status_ready{{{worker_filter_terms}}}[{DEFAULT_EXTRAPOLATION_TIME}s]
+                )
+            ) by (kube_deployment))
+        """
+        missing_instances = f"""
+            clamp_min(
+                {ready_pods} - count({load_per_instance}) by (kube_deployment),
+                0
+            )
+        """
+        total_load = f"""
+        (
+            sum(
+                {load_per_instance}
+            ) by (kube_deployment)
+            +
+            {missing_instances}
+        )
+        """
+
     total_load_smoothed = f"""
         avg_over_time(
             (
@@ -1025,46 +1058,85 @@ def create_shared_uwsgi_scaling_rule(
         METRICS_PROVIDER_UWSGI, moving_average_window
     )
     worker_filter_terms = f"paasta_cluster='{paasta_cluster}',paasta_service='<<index .LabelValuesByName \"paasta_service\">>',paasta_instance='<<index .LabelValuesByName \"paasta_instance\">>',kube_deployment='<<index .LabelValuesByName \"kube_deployment\">>'"
-    replica_filter_terms = f"paasta_cluster='{paasta_cluster}',kube_deployment='<<index .LabelValuesByName \"kube_deployment\">>',namespace='<<index .LabelValuesByName \"kube_namespace\">>'"
 
-    ready_pods = f"""
-        (sum(
-            k8s:deployment:pods_status_ready{{{worker_filter_terms}}} >= 0
-            or
-            max_over_time(
-                k8s:deployment:pods_status_ready{{{worker_filter_terms}}}[{DEFAULT_EXTRAPOLATION_TIME}s]
-            )
-        ) by (kube_deployment))
-    """
-    ready_pods_namespaced = f"""
-        (sum(
-            k8s:deployment:pods_status_ready{{{replica_filter_terms}}} >= 0
-            or
-            max_over_time(
-                k8s:deployment:pods_status_ready{{{replica_filter_terms}}}[{DEFAULT_EXTRAPOLATION_TIME}s]
-            )
-        ) by (kube_deployment))
-    """
+    use_raw_ksm_queries = load_system_paasta_config().get_use_raw_ksm_queries()
+
     load_per_instance = f"""
         avg(
             uwsgi_worker_busy{{{worker_filter_terms}}}
         ) by (kube_pod, kube_deployment)
     """
-    missing_instances = f"""
-        clamp_min(
-            {ready_pods} - count({load_per_instance}) by (kube_deployment),
-            0
+    if use_raw_ksm_queries:
+        replicas_filter_terms = (
+            f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)'"
         )
-    """
-    total_load = f"""
-    (
-        sum(
-            {load_per_instance}
-        ) by (kube_deployment)
-        +
-        {missing_instances}
-    )
-    """
+        deployment_labels_filter_terms = f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)',label_paasta_yelp_com_service='<<index .LabelValuesByName \"paasta_service\">>',label_paasta_yelp_com_instance='<<index .LabelValuesByName \"paasta_instance\">>'"
+        ready_replicas = f"""
+            label_replace(
+                kube_deployment_status_replicas_ready{{{replicas_filter_terms}}}
+                * on (deployment)
+                kube_deployment_labels{{{deployment_labels_filter_terms}}},
+                "kube_deployment", "$1", "deployment", "(.*)")
+        """
+        missing_instances = f"""
+            (clamp_min(
+                label_replace(
+                    kube_deployment_status_replicas_ready{{{replicas_filter_terms}}}
+                    * on (deployment)
+                    kube_deployment_labels{{{deployment_labels_filter_terms}}},
+                    "kube_deployment", "$1", "deployment", "(.*)")
+                - on (kube_deployment)
+                count by (kube_deployment) (
+                    uwsgi_worker_busy{{{worker_filter_terms}}}
+                ),
+                0
+            ) or on() vector(0))
+        """
+        total_load = f"""
+        (
+            sum(
+                {load_per_instance}
+            ) by (kube_deployment)
+            + ignoring(kube_deployment) group_left()
+            {missing_instances}
+        )
+        """
+    else:
+        replica_filter_terms = f"paasta_cluster='{paasta_cluster}',kube_deployment='<<index .LabelValuesByName \"kube_deployment\">>',namespace='<<index .LabelValuesByName \"kube_namespace\">>'"
+        ready_pods = f"""
+            (sum(
+                k8s:deployment:pods_status_ready{{{worker_filter_terms}}} >= 0
+                or
+                max_over_time(
+                    k8s:deployment:pods_status_ready{{{worker_filter_terms}}}[{DEFAULT_EXTRAPOLATION_TIME}s]
+                )
+            ) by (kube_deployment))
+        """
+        ready_replicas = f"""
+            (sum(
+                k8s:deployment:pods_status_ready{{{replica_filter_terms}}} >= 0
+                or
+                max_over_time(
+                    k8s:deployment:pods_status_ready{{{replica_filter_terms}}}[{DEFAULT_EXTRAPOLATION_TIME}s]
+                )
+            ) by (kube_deployment))
+        """
+        missing_instances = f"""
+            clamp_min(
+                {ready_pods} - count({load_per_instance}) by (kube_deployment),
+                0
+            )
+        """
+        total_load = f"""
+        (
+            sum(
+                {load_per_instance}
+            ) by (kube_deployment)
+            +
+            {missing_instances}
+        )
+        """
+
     desired_instances = f"""
         avg_over_time(
             (
@@ -1073,7 +1145,7 @@ def create_shared_uwsgi_scaling_rule(
         )
     """
     metrics_query = f"""
-        {desired_instances} / {ready_pods_namespaced}
+        {desired_instances} / {ready_replicas}
     """
     return {
         "name": {"as": metric_name},
@@ -1093,6 +1165,8 @@ def create_shared_piscina_scaling_rule(
     worker_filter_terms = f"paasta_cluster='{paasta_cluster}',paasta_service='<<index .LabelValuesByName \"paasta_service\">>',paasta_instance='<<index .LabelValuesByName \"paasta_instance\">>',kube_deployment='<<index .LabelValuesByName \"kube_deployment\">>'"
     replica_filter_terms = f"paasta_cluster='{paasta_cluster}',deployment='<<index .LabelValuesByName \"kube_deployment\">>',namespace='<<index .LabelValuesByName \"kube_namespace\">>'"
 
+    use_raw_ksm_queries = load_system_paasta_config().get_use_raw_ksm_queries()
+
     current_replicas = f"""
         sum(
             label_join(
@@ -1107,33 +1181,63 @@ def create_shared_piscina_scaling_rule(
             )
         ) by (kube_deployment)
     """
-    ready_pods = f"""
-        (sum(
-            k8s:deployment:pods_status_ready{{{worker_filter_terms}}} >= 0
-            or
-            max_over_time(
-                k8s:deployment:pods_status_ready{{{worker_filter_terms}}}[{DEFAULT_EXTRAPOLATION_TIME}s]
-            )
-        ) by (kube_deployment))
-    """
     load_per_instance = f"""
         (piscina_pool_utilization{{{worker_filter_terms}}})
     """
-    missing_instances = f"""
-        clamp_min(
-            {ready_pods} - count({load_per_instance}) by (kube_deployment),
-            0
+    if use_raw_ksm_queries:
+        replicas_filter_terms = (
+            f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)'"
         )
-    """
-    total_load = f"""
-    (
-        sum(
-            {load_per_instance}
-        ) by (kube_deployment)
-        +
-        {missing_instances}
-    )
-    """
+        deployment_labels_filter_terms = f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)',label_paasta_yelp_com_service='<<index .LabelValuesByName \"paasta_service\">>',label_paasta_yelp_com_instance='<<index .LabelValuesByName \"paasta_instance\">>'"
+        missing_instances = f"""
+            (clamp_min(
+                label_replace(
+                    kube_deployment_status_replicas_ready{{{replicas_filter_terms}}}
+                    * on (deployment)
+                    kube_deployment_labels{{{deployment_labels_filter_terms}}},
+                    "kube_deployment", "$1", "deployment", "(.*)")
+                - on (kube_deployment)
+                count by (kube_deployment) (
+                    piscina_pool_utilization{{{worker_filter_terms}}}
+                ),
+                0
+            ) or on() vector(0))
+        """
+        total_load = f"""
+        (
+            sum(
+                {load_per_instance}
+            ) by (kube_deployment)
+            + ignoring(kube_deployment) group_left()
+            {missing_instances}
+        )
+        """
+    else:
+        ready_pods = f"""
+            (sum(
+                k8s:deployment:pods_status_ready{{{worker_filter_terms}}} >= 0
+                or
+                max_over_time(
+                    k8s:deployment:pods_status_ready{{{worker_filter_terms}}}[{DEFAULT_EXTRAPOLATION_TIME}s]
+                )
+            ) by (kube_deployment))
+        """
+        missing_instances = f"""
+            clamp_min(
+                {ready_pods} - count({load_per_instance}) by (kube_deployment),
+                0
+            )
+        """
+        total_load = f"""
+        (
+            sum(
+                {load_per_instance}
+            ) by (kube_deployment)
+            +
+            {missing_instances}
+        )
+        """
+
     desired_instances = f"""
         avg_over_time(
             (
@@ -1162,6 +1266,8 @@ def create_shared_gunicorn_scaling_rule(
     worker_filter_terms = f"paasta_cluster='{paasta_cluster}',paasta_service='<<index .LabelValuesByName \"paasta_service\">>',paasta_instance='<<index .LabelValuesByName \"paasta_instance\">>',kube_deployment='<<index .LabelValuesByName \"kube_deployment\">>'"
     replica_filter_terms = f"paasta_cluster='{paasta_cluster}',deployment='<<index .LabelValuesByName \"kube_deployment\">>',namespace='<<index .LabelValuesByName \"kube_namespace\">>'"
 
+    use_raw_ksm_queries = load_system_paasta_config().get_use_raw_ksm_queries()
+
     current_replicas = f"""
         sum(
             label_join(
@@ -1176,35 +1282,65 @@ def create_shared_gunicorn_scaling_rule(
             )
         ) by (kube_deployment)
     """
-    ready_pods = f"""
-        (sum(
-            k8s:deployment:pods_status_ready{{{worker_filter_terms}}} >= 0
-            or
-            max_over_time(
-                k8s:deployment:pods_status_ready{{{worker_filter_terms}}}[{DEFAULT_EXTRAPOLATION_TIME}s]
-            )
-        ) by (kube_deployment))
-    """
     load_per_instance = f"""
         avg(
             gunicorn_worker_busy{{{worker_filter_terms}}}
         ) by (kube_pod, kube_deployment)
     """
-    missing_instances = f"""
-        clamp_min(
-            {ready_pods} - count({load_per_instance}) by (kube_deployment),
-            0
+    if use_raw_ksm_queries:
+        replicas_filter_terms = (
+            f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)'"
         )
-    """
-    total_load = f"""
-    (
-        sum(
-            {load_per_instance}
-        ) by (kube_deployment)
-        +
-        {missing_instances}
-    )
-    """
+        deployment_labels_filter_terms = f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)',label_paasta_yelp_com_service='<<index .LabelValuesByName \"paasta_service\">>',label_paasta_yelp_com_instance='<<index .LabelValuesByName \"paasta_instance\">>'"
+        missing_instances = f"""
+            (clamp_min(
+                label_replace(
+                    kube_deployment_status_replicas_ready{{{replicas_filter_terms}}}
+                    * on (deployment)
+                    kube_deployment_labels{{{deployment_labels_filter_terms}}},
+                    "kube_deployment", "$1", "deployment", "(.*)")
+                - on (kube_deployment)
+                count by (kube_deployment) (
+                    gunicorn_worker_busy{{{worker_filter_terms}}}
+                ),
+                0
+            ) or on() vector(0))
+        """
+        total_load = f"""
+        (
+            sum(
+                {load_per_instance}
+            ) by (kube_deployment)
+            + ignoring(kube_deployment) group_left()
+            {missing_instances}
+        )
+        """
+    else:
+        ready_pods = f"""
+            (sum(
+                k8s:deployment:pods_status_ready{{{worker_filter_terms}}} >= 0
+                or
+                max_over_time(
+                    k8s:deployment:pods_status_ready{{{worker_filter_terms}}}[{DEFAULT_EXTRAPOLATION_TIME}s]
+                )
+            ) by (kube_deployment))
+        """
+        missing_instances = f"""
+            clamp_min(
+                {ready_pods} - count({load_per_instance}) by (kube_deployment),
+                0
+            )
+        """
+        total_load = f"""
+        (
+            sum(
+                {load_per_instance}
+            ) by (kube_deployment)
+            +
+            {missing_instances}
+        )
+        """
+
     desired_instances = f"""
         avg_over_time(
             (

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2042,6 +2042,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     readonly_docker_registry_auth_file: str
     private_docker_registries: List[str]
     unhealthy_pod_eviction_policy: str
+    use_raw_ksm_queries: bool
 
 
 def load_system_paasta_config(
@@ -2793,6 +2794,9 @@ class SystemPaastaConfig:
 
     def get_enable_cost_owner_label(self) -> bool:
         return self.config_dict.get("enable_cost_owner_label", False)
+
+    def get_use_raw_ksm_queries(self) -> bool:
+        return self.config_dict.get("use_raw_ksm_queries", False)
 
     def get_remote_run_duration_limit(self, default: int) -> int:
         return self.config_dict.get("remote_run_duration_limit", default)

--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -431,7 +431,12 @@ def test_create_shared_scaling_rule(
     paasta_cluster = "test_cluster"
     moving_average_window = 20120302
 
-    rule = rule_func(paasta_cluster, moving_average_window)
+    with mock.patch(
+        "paasta_tools.setup_prometheus_adapter_config.load_system_paasta_config",
+        autospec=True,
+    ) as mock_config:
+        mock_config.return_value.get_use_raw_ksm_queries.return_value = False
+        rule = rule_func(paasta_cluster, moving_average_window)
 
     assert str(moving_average_window) in rule["metricsQuery"]
     assert paasta_cluster in rule["seriesQuery"]
@@ -445,6 +450,42 @@ def test_create_shared_scaling_rule(
     assert "paasta_service='" not in rule["metricsQuery"].replace(
         "paasta_service='<<index .LabelValuesByName", ""
     )
+
+
+@pytest.mark.parametrize(
+    "rule_func,expected_series_metric,expected_name_prefix",
+    [
+        (create_shared_uwsgi_v2_scaling_rule, "uwsgi_worker_busy", "uwsgi-v2-prom"),
+        (create_shared_uwsgi_scaling_rule, "uwsgi_worker_busy", "uwsgi-prom"),
+        (
+            create_shared_piscina_scaling_rule,
+            "piscina_pool_utilization",
+            "piscina-prom",
+        ),
+        (create_shared_gunicorn_scaling_rule, "gunicorn_worker_busy", "gunicorn-prom"),
+    ],
+)
+def test_create_shared_scaling_rule_with_raw_ksm_queries(
+    rule_func, expected_series_metric, expected_name_prefix
+) -> None:
+    paasta_cluster = "test_cluster"
+    moving_average_window = 20120302
+
+    with mock.patch(
+        "paasta_tools.setup_prometheus_adapter_config.load_system_paasta_config",
+        autospec=True,
+    ) as mock_config:
+        mock_config.return_value.get_use_raw_ksm_queries.return_value = True
+        rule = rule_func(paasta_cluster, moving_average_window)
+
+    assert str(moving_average_window) in rule["metricsQuery"]
+    assert paasta_cluster in rule["seriesQuery"]
+    assert expected_series_metric in rule["seriesQuery"]
+    assert rule["name"]["as"] == f"{expected_name_prefix}-{moving_average_window}"
+    assert "<<index .LabelValuesByName" in rule["metricsQuery"]
+    assert "kube_deployment_status_replicas_ready" in rule["metricsQuery"]
+    assert "kube_deployment_labels" in rule["metricsQuery"]
+    assert "k8s:deployment:pods_status_ready" not in rule["metricsQuery"]
 
 
 def _make_instance_config(


### PR DESCRIPTION
Rollout new autoscaling query to fix HPA behavior for all autoscaling types (prev we only had it for `worker-load`)

[PAASTA-18905](https://jira.yelpcorp.com/browse/PAASTA-18905)

### Verification

[old recording rule vs new KSM vs pod_count (cherami, pnw-prod)](https://grafana.yelpcorp.com/explore?left=%7B%22datasource%22%3A%22P0A14DA14C82905AE%22%2C%22queries%22%3A%5B%7B%22expr%22%3A%22sum+by+%28kube_deployment%29+%28k8s%3Adeployment%3Apods_status_ready%7Bpaasta_cluster%3D%5C%22pnw-prod%5C%22%2Cpaasta_service%3D%5C%22cherami%5C%22%2Cpaasta_instance%3D%5C%22main_uswest2%5C%22%7D%29%22%2C%22legendFormat%22%3A%22old%3A+k8s%3Adeployment%3Apods_status_ready%22%2C%22refId%22%3A%22old_ready_pods%22%7D%2C%7B%22expr%22%3A%22label_replace%28kube_deployment_status_replicas_ready%7Bpaasta_cluster%3D%5C%22pnw-prod%5C%22%2Cnamespace%3D~%5C%22%28paasta%7Cpaastasvc-.%2A%29%5C%22%7D+%2A+on+%28deployment%29+kube_deployment_labels%7Bpaasta_cluster%3D%5C%22pnw-prod%5C%22%2Cnamespace%3D~%5C%22%28paasta%7Cpaastasvc-.%2A%29%5C%22%2Clabel_paasta_yelp_com_service%3D%5C%22cherami%5C%22%2Clabel_paasta_yelp_com_instance%3D%5C%22main_uswest2%5C%22%7D%2C+%5C%22kube_deployment%5C%22%2C+%5C%22%241%5C%22%2C+%5C%22deployment%5C%22%2C+%5C%22%28.%2A%29%5C%22%29%22%2C%22legendFormat%22%3A%22new%3A+kube_deployment_status_replicas_ready+%28KSM%29%22%2C%22refId%22%3A%22new_ready_replicas%22%7D%2C%7B%22expr%22%3A%22count+by+%28kube_deployment%29+%28avg+by+%28kube_pod%2C+kube_deployment%29+%28uwsgi_worker_busy%7Bpaasta_cluster%3D%5C%22pnw-prod%5C%22%2Cpaasta_service%3D%5C%22cherami%5C%22%2Cpaasta_instance%3D%5C%22main_uswest2%5C%22%7D%29%29%22%2C%22legendFormat%22%3A%22pod_count+%28from+uwsgi+metrics%29%22%2C%22refId%22%3A%22pod_count%22%7D%5D%2C%22range%22%3A%7B%22from%22%3A%22now-6h%22%2C%22to%22%3A%22now%22%7D%7D)

[K8s HPA Global View](https://grafana.yelpcorp.com/d/adicdqxccov7kf/k8s-hpa-global-view?orgId=1) — monitor after rollout