### PR TITLE
Add rollback filtering for Default PaaSTA Error Alerting

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -376,6 +376,53 @@ def can_user_deploy_service(deploy_info: Dict[str, Any], service: str) -> bool:
     return True
 
 
+def _build_default_error_alert_filter(
+    service: str,
+    instance_configs_per_cluster: Dict[str, List[LongRunningServiceConfig]],
+) -> List[str]:
+    """Build a filter for Default PaaSTA Error Alerts.
+
+    These alerts use a composite `instance` label: {region}.{service}.{server_namespace}
+    (with an optional .{endpoint} suffix for per-endpoint alerts).
+    NOTE: server_namespace above is the same as the PaaSTA mesh registration
+    """
+    kube_clusters = load_system_paasta_config().get_kube_clusters()
+
+    alertmanager_instances: Set[str] = set()
+    for cluster, configs in instance_configs_per_cluster.items():
+        cluster_info = kube_clusters.get(cluster)
+        if not cluster_info:
+            log.warning(
+                f"Cluster {cluster} not found in kube_clusters config; "
+                "skipping default error alert filter for this cluster"
+            )
+            continue
+        region = cluster_info.get("yelp_region")
+        if not region:
+            log.warning(
+                f"Cluster {cluster} has no yelp_region in kube_clusters config; "
+                "skipping default error alert filter for this cluster"
+            )
+            continue
+        for config in configs:
+            # we could also use get_nerve_namespace(), but that doesn't support
+            # instances with multiple registrations
+            # ...which are a lot more common than you'd think :p
+            for registration in config.get_registrations():
+                namespace = registration.split(".")[1]
+                alertmanager_instances.add(f"{region}.{service}.{namespace}")
+
+    if not alertmanager_instances:
+        return []
+
+    instance_regex = "|".join(sorted(alertmanager_instances))
+    return [
+        'paasta_rollback_metric="true"',
+        # NOTE: the group after instance_regex is for capturing per-endpoint alerts
+        f'instance=~"^({instance_regex})($|[.].*)"',
+    ]
+
+
 def build_alertmanager_rollback_filters(
     service: str,
     instance_configs_per_cluster: Dict[str, List[LongRunningServiceConfig]],
@@ -404,10 +451,16 @@ def build_alertmanager_rollback_filters(
             f'paasta_instance=~"^({"|".join(sorted(instances))})$"'
         )
 
-    return [
-        custom_alert_filter,
-        # TODO(PAASTA-18915): add default error alerting filters
-    ]
+    default_error_alert_filter = _build_default_error_alert_filter(
+        service=service,
+        instance_configs_per_cluster=instance_configs_per_cluster,
+    )
+
+    filters = [custom_alert_filter]
+    if default_error_alert_filter:
+        filters.append(default_error_alert_filter)
+
+    return filters
 
 
 def report_waiting_aborted(service: str, deploy_group: str) -> None:
@@ -759,7 +812,6 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
         if self.alertmanager_rollback_enabled and (
             alertmanager_url := system_paasta_config.get_alertmanager_url()
         ):
-            # TODO(PAASTA-18915): add default error alerting filters
             filters = build_alertmanager_rollback_filters(
                 service=self.service,
                 instance_configs_per_cluster=self.instance_configs_per_cluster,

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -1595,9 +1595,10 @@ def test_MarkForDeployProcess_alertmanager_alert_triggers_rollback(
         assert mfdp.rollback_type == RollbackTypes.AUTOMATIC_ALERTMANAGER_ROLLBACK
 
 
-def _make_instance_config(instance: str) -> MagicMock:
+def _make_instance_config(instance: str, registrations=None) -> MagicMock:
     cfg = MagicMock(spec=LongRunningServiceConfig)
     cfg.instance = instance
+    cfg.get_registrations.return_value = registrations or [f"service.{instance}"]
     return cfg
 
 
@@ -1630,20 +1631,40 @@ def test_build_alertmanager_rollback_filters_single_cluster_single_instance():
 
 
 def test_build_alertmanager_rollback_filters_multi_cluster_multi_instance():
-    assert mark_for_deployment.build_alertmanager_rollback_filters(
-        service="my_service",
-        instance_configs_per_cluster={
-            "cluster-a": [_make_instance_config("web")],
-            "cluster-b": [_make_instance_config("worker")],
-        },
-    ) == [
-        [
-            'paasta_rollback_metric="true"',
-            'paasta_service="my_service"',
-            'paasta_cluster=~"^(cluster-a|cluster-b)$"',
-            'paasta_instance=~"^(web|worker)$"',
-        ],
-    ]
+    mock_config = utils.SystemPaastaConfig(
+        utils.SystemPaastaConfigDict(
+            {
+                "kube_clusters": {
+                    "cluster-a": {"yelp_region": "uswest2-prod"},
+                    "cluster-b": {"yelp_region": "useast1-prod"},
+                },
+            }
+        ),
+        "/mock/system/configs",
+    )
+    with patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config",
+        autospec=True,
+        return_value=mock_config,
+    ):
+        assert mark_for_deployment.build_alertmanager_rollback_filters(
+            service="my_service",
+            instance_configs_per_cluster={
+                "cluster-a": [_make_instance_config("web")],
+                "cluster-b": [_make_instance_config("worker")],
+            },
+        ) == [
+            [
+                'paasta_rollback_metric="true"',
+                'paasta_service="my_service"',
+                'paasta_cluster=~"^(cluster-a|cluster-b)$"',
+                'paasta_instance=~"^(web|worker)$"',
+            ],
+            [
+                'paasta_rollback_metric="true"',
+                'instance=~"^(useast1-prod.my_service.worker|uswest2-prod.my_service.web)($|[.].*)"',
+            ],
+        ]
 
 
 def test_build_alertmanager_rollback_filters_empty_cluster_excluded():
@@ -1677,4 +1698,76 @@ def test_build_alertmanager_rollback_filters_duplicate_instances_deduplicated():
             'paasta_cluster=~"^(cluster-a|cluster-b)$"',
             'paasta_instance=~"^(web)$"',
         ],
+    ]
+
+
+def test_default_error_alert_filter_skips_unknown_cluster():
+    mock_config = utils.SystemPaastaConfig(
+        utils.SystemPaastaConfigDict(
+            {
+                "kube_clusters": {
+                    "cluster-a": {"yelp_region": "uswest2-prod"},
+                },
+            }
+        ),
+        "/mock/system/configs",
+    )
+    with patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config",
+        autospec=True,
+        return_value=mock_config,
+    ):
+        result = mark_for_deployment._build_default_error_alert_filter(
+            service="my_service",
+            instance_configs_per_cluster={
+                "cluster-a": [_make_instance_config("main")],
+                "cluster-unknown": [_make_instance_config("canary")],
+            },
+        )
+    assert result == [
+        'paasta_rollback_metric="true"',
+        'instance=~"^(uswest2-prod.my_service.main)($|[.].*)"',
+    ]
+
+
+def test_default_error_alert_filter_returns_empty_when_no_instances():
+    assert (
+        mark_for_deployment._build_default_error_alert_filter(
+            service="my_service",
+            instance_configs_per_cluster={},
+        )
+        == []
+    )
+
+
+def test_default_error_alert_filter_multiple_registrations():
+    mock_config = utils.SystemPaastaConfig(
+        utils.SystemPaastaConfigDict(
+            {
+                "kube_clusters": {
+                    "cluster-a": {"yelp_region": "uswest2-prod"},
+                },
+            }
+        ),
+        "/mock/system/configs",
+    )
+    with patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config",
+        autospec=True,
+        return_value=mock_config,
+    ):
+        result = mark_for_deployment._build_default_error_alert_filter(
+            service="my_service",
+            instance_configs_per_cluster={
+                "cluster-a": [
+                    _make_instance_config(
+                        "main",
+                        registrations=["my_service.main", "my_service.main_alt"],
+                    )
+                ],
+            },
+        )
+    assert result == [
+        'paasta_rollback_metric="true"',
+        'instance=~"^(uswest2-prod.my_service.main|uswest2-prod.my_service.main_alt)($|[.].*)"',
     ]


### PR DESCRIPTION
As mentioned in the CEP, these (pre-existing) alerts have a different
set of labels, so we can't filter in quite the same way as we do for the
"custom" alerts.

However, as (also) mentioned in the CEP, we can still construct a filter
that will match these alerts given the data we have available.

This hopefully isn't too complex (and hopefully my comments are useful),
but it is slightly funky :p - although, imo, mostly due to needing to
figure out the "real" region for a cluster + needing to handle
multi-registration instances :p