### PR TITLE
Add alertmanager rollback dry-run support

### DIFF
--- a/paasta_tools/cli/cmds/mark_for_deployment.py
+++ b/paasta_tools/cli/cmds/mark_for_deployment.py
@@ -795,6 +795,9 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
             "alertmanager_poll_interval_s",
             system_paasta_config.get_alertmanager_poll_interval_s(),
         )
+        self.alertmanager_rollback_dry_run = self._get_deploy_group_config(
+            "alertmanager_rollback_dry_run", False
+        )
 
         # Keep track of each wait_for_deployment task so we can cancel it.
         self.wait_for_deployment_tasks: Dict[DeploymentVersion, asyncio.Task] = {}
@@ -1179,10 +1182,20 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
             "dest": None,
             "trigger": "alertmanager_started_failing",
             "conditions": [self.auto_rollbacks_enabled],
-            "unless": [self.already_rolling_back],
+            "unless": [self.already_rolling_back, self._alertmanager_dry_run],
             "before": functools.partial(
                 self.start_auto_rollback_countdown, "rollback_alertmanager_failure"
             ),
+        }
+        # without this, the trigger would be silently swallowed in dry-run mode
+        # (the above transition is skipped via `unless`).
+        # this ensures we still notify that a rollback would have been triggered
+        yield {
+            "source": "*",
+            "dest": None,
+            "trigger": "alertmanager_started_failing",
+            "conditions": [self._alertmanager_dry_run],
+            "before": self._log_alertmanager_dry_run,
         }
         yield {
             "source": "*",
@@ -1585,6 +1598,16 @@ class MarkForDeploymentProcess(RollbackSlackDeploymentProcess):
             RollbackTypes.AUTOMATIC_ALERTMANAGER_ROLLBACK
         )
         self._log_rollback(rollback_details)
+
+    def _alertmanager_dry_run(self) -> bool:
+        return self.alertmanager_rollback_dry_run
+
+    def _log_alertmanager_dry_run(self) -> None:
+        self.update_slack_thread(
+            "[DRY-RUN] AlertManager alerts are failing — would have triggered "
+            "rollback, but alertmanager_rollback_dry_run is enabled.",
+            color="warning",
+        )
 
     def log_crashloop_rollback(self) -> None:
         self.rollback_type = RollbackTypes.AUTOMATIC_CRASHLOOP_ROLLBACK

--- a/paasta_tools/cli/schemas/deploy_schema.json
+++ b/paasta_tools/cli/schemas/deploy_schema.json
@@ -108,6 +108,9 @@
                 "alertmanager_rollback": {
                     "type": "boolean"
                 },
+                "alertmanager_rollback_dry_run": {
+                    "type": "boolean"
+                },
                 "alertmanager_poll_interval_s": {
                     "type": "integer",
                     "minimum": 30

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -1595,6 +1595,63 @@ def test_MarkForDeployProcess_alertmanager_alert_triggers_rollback(
         assert mfdp.rollback_type == RollbackTypes.AUTOMATIC_ALERTMANAGER_ROLLBACK
 
 
+def test_MarkForDeployProcess_alertmanager_dry_run_does_not_rollback(
+    mock_periodically_update_slack,
+):
+    """When alertmanager_rollback_dry_run is enabled, alerts fire but don't trigger rollback."""
+
+    def simulate_alert(self, target_commit, target_image_version, rollback_type=None):
+        self.trigger("alertmanager_started_failing")
+        self.trigger("deploy_finished")
+
+    with patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.get_instance_configs_for_service_in_deploy_group_all_clusters",
+        autospec=True,
+    ), patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.mark_for_deployment",
+        autospec=True,
+        return_value=0,
+    ), patch(
+        "paasta_tools.cli.cmds.mark_for_deployment.MarkForDeploymentProcess.do_wait_for_deployment",
+        autospec=True,
+        side_effect=simulate_alert,
+    ), patch(
+        "paasta_tools.cli.cmds.mark_for_deployment._log",
+        autospec=True,
+    ):
+        mfdp = WrappedMarkForDeploymentProcess(
+            service="service",
+            deploy_info={
+                "pipeline": [
+                    {"step": "deploy_group", "alertmanager_rollback_dry_run": True}
+                ]
+            },
+            deploy_group="deploy_group",
+            commit="commit",
+            old_git_sha="old_git_sha",
+            git_url="git_url",
+            auto_rollback=True,
+            block=True,
+            soa_dir="soa_dir",
+            timeout=3600,
+            warn_pct=50,
+            auto_certify_delay=None,
+            auto_abandon_delay=600,
+            auto_rollback_delay=30,
+            authors=None,
+        )
+
+        mfdp.run_timeout = 1
+        assert mfdp.run() == 0
+        assert mfdp.trigger_history == [
+            "start_deploy",
+            "mfd_succeeded",
+            "alertmanager_started_failing",
+            "deploy_finished",
+            "auto_certify",
+        ]
+
+
 def _make_instance_config(instance: str, registrations=None) -> MagicMock:
     cfg = MagicMock(spec=LongRunningServiceConfig)
     cfg.instance = instance


### PR DESCRIPTION
This is the PaaSTA side of https://github.com/Yelp/sticht/pull/67 -
i.e,. how we'll allow folks to experiment with alertmanager rollbacks
without needing to fully commit (and/or for testing new rollback alerts)

As usual, config mostly lives in deploy.yaml per-deploy-group :)

That said, this 1000% requires the sticht PR linked above, since that's
essentially where all the logic actually lives