### PR TITLE
Correctly handle setpoint for Piscina autoscaling

### DIFF
--- a/paasta_tools/kubernetes_tools.py
+++ b/paasta_tools/kubernetes_tools.py
@@ -881,8 +881,26 @@ class KubernetesDeploymentConfig(LongRunningServiceConfig):
             METRICS_PROVIDER_UWSGI,
             METRICS_PROVIDER_PISCINA,
             METRICS_PROVIDER_GUNICORN,
-            METRICS_PROVIDER_ACTIVE_REQUESTS,
         }:
+            return V2MetricSpec(
+                type="Object",
+                object=V2ObjectMetricSource(
+                    metric=V2MetricIdentifier(
+                        name=prometheus_hpa_metric_name,
+                        selector=metric_selector,
+                    ),
+                    described_object=V2CrossVersionObjectReference(
+                        api_version="apps/v1", kind="Deployment", name=name
+                    ),
+                    target=V2MetricTarget(
+                        type="Value",
+                        # shared rules return avg load per replica (total_load / replicas);
+                        # HPA scales when metric > target, so target = setpoint.
+                        value=target,
+                    ),
+                ),
+            )
+        elif provider["type"] == METRICS_PROVIDER_ACTIVE_REQUESTS:
             return V2MetricSpec(
                 type="Object",
                 object=V2ObjectMetricSource(

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -3010,7 +3010,7 @@ class TestKubernetesDeploymentConfig:
                             ),
                             target=V2MetricTarget(
                                 type="Value",
-                                value=1,
+                                value=0.4,
                             ),
                             described_object=V2CrossVersionObjectReference(
                                 api_version="apps/v1",
@@ -3280,7 +3280,7 @@ class TestKubernetesDeploymentConfig:
                             ),
                             target=V2MetricTarget(
                                 type="Value",
-                                value=1,
+                                value=0.5,
                             ),
                             described_object=V2CrossVersionObjectReference(
                                 api_version="apps/v1",


### PR DESCRIPTION
We didn't notice that the Piscina HPA was setting the target to 1 - which, in the shared rules code, means that we're essentially setting the setpoint to 100% utilization.

We should follow this up with moving the 2 remaining services on `type: uwsgi` autoscaling to `type: worker-load` and then deleting the uwsgi/and gunicorn autoscaling code (since those are superseded by worker-load)

NOTE: I think that we've also had broken autoscaling for the 2 type: uwsgi services for this time, but interestingly enough, no one seems to have noticed :p