### PR TITLE
Disabling single replica check

### DIFF
--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -1470,7 +1470,7 @@ def paasta_validate_soa_configs(
         validate_cpu_burst,
         validate_smartstack,
         validate_flink_monitoring_team,
-        warn_single_replica_instances,
+        # warn_single_replica_instances,  # disabled: firing on adhoc/non-prod instances (PAASTA-18934)
         check_monitoring_file_exists,
     ]
 


### PR DESCRIPTION
Had an onpoint where it was stopping people from merging because instance hadn't been set for non prod services
https://yelp.slack.com/archives/CA05GTDB9/p1786031902645339