### PR TITLE
creating single replica commit hook

### DIFF
--- a/general_itests/fake_soa_configs_validate/fake_valid_service/kubernetes-test-cluster.yaml
+++ b/general_itests/fake_soa_configs_validate/fake_valid_service/kubernetes-test-cluster.yaml
@@ -3,7 +3,7 @@ main2:
   cpus: .1
   mem: 100
   disk: 200.0
-  instances: 1
+  instances: 2
   env:
     FOO: BAR
   deploy_group: fake_deploy_group

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -45,7 +45,6 @@ from jsonschema import ValidationError
 from jsonschema import exceptions
 from mypy_extensions import TypedDict
 from ruamel.yaml import YAML
-from ruamel.yaml import SafeConstructor
 from ruamel.yaml.comments import CommentedMap
 
 from paasta_tools import yaml_tools as yaml
@@ -58,6 +57,7 @@ from paasta_tools.cli.utils import guess_service_name
 from paasta_tools.cli.utils import info_message
 from paasta_tools.cli.utils import lazy_choices_completer
 from paasta_tools.cli.utils import success
+from paasta_tools.eks_tools import EksDeploymentConfig
 from paasta_tools.kubernetes_tools import sanitise_kubernetes_name
 from paasta_tools.long_running_service_tools import DEFAULT_AUTOSCALING_SETPOINT
 from paasta_tools.long_running_service_tools import DEFAULT_PROMQL_AUTOSCALING_SETPOINT
@@ -72,6 +72,7 @@ from paasta_tools.long_running_service_tools import METRICS_PROVIDER_UWSGI_V2
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_WORKER_LOAD
 from paasta_tools.long_running_service_tools import LongRunningServiceConfig
 from paasta_tools.monitoring_tools import get_sensu_team_data
+from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
 from paasta_tools.secret_tools import get_secret_name_from_ref
 from paasta_tools.secret_tools import is_secret_ref
 from paasta_tools.secret_tools import is_shared_secret
@@ -138,9 +139,11 @@ SCHEMA_TYPES = {
 # comment
 OVERRIDE_CPU_AUTOTUNE_ACK_PATTERN = r"#\s*override-cpu-setting\s+\(.+[A-Z]+-[0-9]+.+\)"
 
-# we expect a comment that looks like # override-cpu-burst PROJ-1234
-# but we don't have a $ anchor in case users want to add an additional
-# comment
+# we expect a comment that looks like # override-single-replica (PROJ-1234)
+OVERRIDE_SINGLE_REPLICA_ACK_PATTERN = (
+    r"#\s*override-single-replica\s+\(.+[A-Z]+-[0-9]+.+\)"
+)
+
 OVERRIDE_CPU_BURST_ACK_PATTERN = r"#\s*override-cpu-burst\s+\(.+[A-Z]+-[0-9]+.+\)"
 # for now, double the autotune cap to give people the benefit of the doubt
 # if we see that people are still misusing this configuration, we can lower
@@ -148,6 +151,11 @@ OVERRIDE_CPU_BURST_ACK_PATTERN = r"#\s*override-cpu-burst\s+\(.+[A-Z]+-[0-9]+.+\
 CPU_BURST_THRESHOLD = 2
 
 K8S_TYPES = {"eks", "kubernetes"}
+
+
+SINGLE_REPLICA_VALIDATED_ECOSYSTEMS = {
+    "prod",
+}
 
 _PROMQL_ONLY_FIELDS = {"metrics_query", "series_query", "target_type", "resources"}
 
@@ -379,9 +387,8 @@ def get_config_file_dict(file_path: str, use_ruamel: bool = False) -> Dict[Any, 
                 # sets disk: 100 -> an instance uses that template and overwrites
                 # it with disk: 1000)
                 ruamel_loader.allow_duplicate_keys = True
-                # Note: we do NOT use flatten_mapping here because it breaks simple
-                # override patterns. For nested merge patterns, we load a flattened
-                # version separately for comment detection only.
+                # Note: we do NOT use flatten_mapping here because it breaks
+                # comment detection on merge-inherited keys.
                 return ruamel_loader.load(config_file)
             else:
                 return yaml.safe_load(config_file)
@@ -652,27 +659,13 @@ def validate_unique_instance_names(service_path):
     return check_passed
 
 
-def _get_config_flattened(file_path: str) -> CommentedMap:
-    """Load config with flatten_mapping enabled (for nested merge pattern comment detection)"""
-    config_file = get_file_contents(file_path)
-    ruamel_loader = YAML(typ="rt")
-    ruamel_loader.allow_duplicate_keys = True
-    ruamel_loader.Constructor.flatten_mapping = SafeConstructor.flatten_mapping
-    return ruamel_loader.load(config_file)
-
-
 def _get_comments_for_key(
     data: CommentedMap,
     key: Any,
-    full_config: Optional[Dict[Any, Any]] = None,
-    key_value: Any = None,
-    full_config_flattened: Optional[Dict[Any, Any]] = None,
 ) -> Optional[str]:
     # this is a little weird, but ruamel is returning a list that looks like:
     # [None, None, CommentToken(...), None] for some reason instead of just a
     # single string
-    # Sometimes ruamel returns a recursive list of CommentTokens as well that looks like
-    # [None, None, [CommentToken(...),CommentToken(...),None], CommentToken(...), None]
     def _flatten_comments(comments):
         for comment in comments:
             if comment is None:
@@ -683,38 +676,31 @@ def _get_comments_for_key(
                 yield comment.value
 
     raw_comments = [*_flatten_comments(data.ca.items.get(key, []))]
-    if not raw_comments:
-        # If we didn't find a comment in the instance itself, check if this key
-        # might be inherited from a template. Look for ANY other instance/template
-        # in the config that has the same key with the same value and a comment.
-        if full_config is not None and key_value is not None:
-            for config_key, config_value in full_config.items():
-                if isinstance(config_value, CommentedMap):
-                    if config_value.get(key) == key_value:
-                        other_comments = [
-                            *_flatten_comments(config_value.ca.items.get(key, []))
-                        ]
-                        if other_comments:
-                            return "".join(other_comments)
+    if raw_comments:
+        return "".join(raw_comments)
 
-        # If still not found and we have a flattened config, check there
-        # (flattened config is needed for nested merges)
-        if full_config_flattened is not None:
-            for config_key, config_value in full_config_flattened.items():
-                if isinstance(config_value, CommentedMap):
-                    if config_value.get(key) == key_value:
-                        flattened_comments = [
-                            *_flatten_comments(config_value.ca.items.get(key, []))
-                        ]
-                        if flattened_comments:
-                            return "".join(flattened_comments)
-
-        # return None so that we don't return an empty string below if there really aren't
-        # any comments
+    # If the instance explicitly sets the key, the comment must be on that
+    # line — don't follow the merge chain.
+    if key in getattr(data, "_ok", set()):
         return None
-    # joining all comments together before returning them
-    comment = "".join(raw_comments)
-    return comment
+
+    # Follow the <<: *anchor merge chain to find comments on inherited keys
+    visited: Set[int] = set()
+    sources = list(getattr(data, "merge", None) or [])
+    while sources:
+        _, src = sources.pop(0)
+        src_id = id(src)
+        if src_id in visited:
+            continue
+        visited.add(src_id)
+        if not isinstance(src, CommentedMap):
+            continue
+        src_comments = [*_flatten_comments(src.ca.items.get(key, []))]
+        if src_comments:
+            return "".join(src_comments)
+        sources.extend(getattr(src, "merge", None) or [])
+
+    return None
 
 
 def __is_templated(service: str, soa_dir: str, cluster: str, workload: str) -> bool:
@@ -854,11 +840,7 @@ def validate_autoscaling_configs(service_path: str) -> bool:
 
                             # we need access to the comments, so we need to read the config with ruamel to be able
                             # to actually get them in a "nice" automated fashion
-                            config_file_path = os.path.join(
-                                soa_dir,
-                                service,
-                                f"{instance_config.get_instance_type()}-{cluster}.yaml",
-                            )
+                            config_file_path = instance_config.get_config_path()
                             config = get_config_file_dict(
                                 config_file_path,
                                 use_ruamel=True,
@@ -875,15 +857,9 @@ def validate_autoscaling_configs(service_path: str) -> bool:
                                 # cpu autoscaled, but using autotuned values - can skip
                                 continue
 
-                            # Load flattened config for comment detection (handles nested merges)
-                            config_flattened = _get_config_flattened(config_file_path)
-
                             cpu_comment = _get_comments_for_key(
                                 data=config[instance],
                                 key="cpus",
-                                full_config=config,
-                                key_value=config[instance].get("cpus"),
-                                full_config_flattened=config_flattened,
                             )
                             # we could probably have a separate error message if there's a comment that doesn't match
                             # the ack pattern, but that seems like overkill - especially for something that could cause
@@ -1004,6 +980,122 @@ def check_secrets_for_instance(
     return return_value
 
 
+def instance_registration_lookup(
+    all_configs: List[EksDeploymentConfig],
+) -> Dict[str, List[EksDeploymentConfig]]:
+    """Build a dict mapping each registration to the list of instance configs that share that registration"""
+    registration_dict: Dict[str, List[EksDeploymentConfig]] = {}
+    for instance_config in all_configs:
+        for registration in instance_config.get_registrations():
+            if registration not in registration_dict:
+                registration_dict[registration] = []
+            registration_dict[registration].append(instance_config)
+    return registration_dict
+
+
+def is_canary(
+    instance_config: EksDeploymentConfig,
+    registration_to_instances: Dict[str, List[EksDeploymentConfig]],
+) -> bool:
+    """Return True if this instance shares a registration with another instance that has more than 1 replica,
+    indicating it is a canary service, otherwise return False"""
+    registrations = instance_config.get_registrations()
+    if not registrations:
+        return False
+    for registration in registrations:
+        for other_instance_config in registration_to_instances[registration]:
+            if other_instance_config.get_instance() == instance_config.get_instance():
+                continue
+            if other_instance_config.is_autoscaling_enabled():
+                other_instance_replicas = other_instance_config.get_max_instances()
+            else:
+                other_instance_replicas = other_instance_config.get_instances()
+            if other_instance_replicas is not None and other_instance_replicas > 1:
+                return True
+    return False
+
+
+def validate_single_replica_instances(service_path: str) -> bool:
+    """Validate that single replica instances have an override comment to acknowledge the risk of SPOF.
+    This is only enforced for certain ecosystems."""
+    soa_dir, service = path_to_soa_dir_service(service_path)
+    returncode = True
+    system_paasta_config = load_system_paasta_config()
+    config_loader = PaastaServiceConfigLoader(
+        service=service, soa_dir=soa_dir, load_deployments=False
+    )
+
+    for cluster in config_loader.clusters:
+        ecosystem = system_paasta_config.get_ecosystem_for_cluster(cluster)
+        if ecosystem not in SINGLE_REPLICA_VALIDATED_ECOSYSTEMS:
+            continue
+
+        all_configs: List[EksDeploymentConfig] = list(
+            config_loader.instance_configs(
+                cluster=cluster, instance_type_class=EksDeploymentConfig
+            )
+        )
+        reg_lookup = instance_registration_lookup(all_configs)
+        canary_allowlist = system_paasta_config.get_common_canary_instance_names()
+
+        for instance_config in all_configs:
+            instance = instance_config.get_instance()
+            if any(pattern in instance for pattern in canary_allowlist):
+                continue
+            if is_canary(instance_config, reg_lookup):
+                continue
+
+            if instance_config.is_autoscaling_enabled():
+                max_instance_count = instance_config.get_max_instances()
+                if max_instance_count is not None and max_instance_count > 1:
+                    continue
+                replicas = instance_config.get_min_instances()
+                replica_key = "min_instances"
+            else:
+                replicas = instance_config.get_instances()
+                replica_key = "instances"
+
+            if replicas == 1:
+                config_file_path = instance_config.get_config_path()
+                config = get_config_file_dict(
+                    config_file_path,
+                    use_ruamel=True,
+                )
+
+                if config[instance].get(replica_key) is None:
+                    print(
+                        info_message(
+                            f"Instance {instance} on cluster {cluster} has only 1 replica (implicit default). "
+                            f"We recommend setting `instances` / `min instances` to a value greater than 1 to avoid SPOF. "
+                            f"We hope to update the default value > 1 in the future"
+                        ),
+                    )
+                    continue
+
+                replica_comment = _get_comments_for_key(
+                    data=config[instance],
+                    key=replica_key,
+                )
+                if (
+                    replica_comment is None
+                    or re.search(
+                        pattern=OVERRIDE_SINGLE_REPLICA_ACK_PATTERN,
+                        string=replica_comment,
+                    )
+                    is None
+                ):
+                    returncode = False
+                    print(
+                        failure(
+                            msg=f"Instance {instance} on cluster {cluster} has only 1 instance / min_instance. "
+                            f"\nSingle replicas are a SPOF and we do not encourage it. "
+                            f"\nAdd a comment like the following to acknowledge: # override-single-replica (PROJ-1234)",
+                            link="y/override-single-replica",
+                        )
+                    )
+    return returncode
+
+
 def list_upcoming_runs(
     cron_schedule: str, starting_from: datetime, num_runs: int = 5
 ) -> List[datetime]:
@@ -1060,11 +1152,7 @@ def validate_cpu_burst(service_path: str) -> bool:
             if is_k8s_service and not should_skip_cpu_burst_validation:
                 # we need access to the comments, so we need to read the config with ruamel to be able
                 # to actually get them in a "nice" automated fashion
-                config_file_path = os.path.join(
-                    soa_dir,
-                    service,
-                    f"{instance_config.get_instance_type()}-{cluster}.yaml",
-                )
+                config_file_path = instance_config.get_config_path()
                 config = get_config_file_dict(
                     config_file_path,
                     use_ruamel=True,
@@ -1077,15 +1165,9 @@ def validate_cpu_burst(service_path: str) -> bool:
                     # under the threshold - can also skip
                     continue
 
-                # Load flattened config for comment detection (handles nested merges)
-                config_flattened = _get_config_flattened(config_file_path)
-
                 burst_comment = _get_comments_for_key(
                     data=config[instance],
                     key="cpu_burst_add",
-                    full_config=config,
-                    key_value=config[instance].get("cpu_burst_add"),
-                    full_config_flattened=config_flattened,
                 )
                 # we could probably have a separate error message if there's a comment that doesn't match
                 # the ack pattern, but that seems like overkill - especially for something that could cause
@@ -1451,6 +1533,7 @@ def paasta_validate_soa_configs(
         validate_cpu_burst,
         validate_smartstack,
         validate_flink_monitoring_team,
+        validate_single_replica_instances,
         check_monitoring_file_exists,
     ]
 

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -460,6 +460,15 @@ class InstanceConfig:
             "service": self.service,
         }
 
+    def get_config_path(self) -> str:
+        instance_type = self.get_instance_type()
+        assert instance_type is not None
+        return os.path.join(
+            self.soa_dir,
+            self.service,
+            f"{instance_type}-{self.cluster}.yaml",
+        )
+
     def get_cluster(self) -> str:
         return self.cluster
 
@@ -2035,6 +2044,7 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     spark_blockmanager_port: int
     skip_cpu_burst_validation: List[str]
     skip_unique_instance_name_validation: List[str]
+    common_canary_instance_names: List[str]
     tron_default_pool_override: str
     spark_kubeconfig: str
     spark_iam_user_kubeconfig: str
@@ -2733,6 +2743,9 @@ class SystemPaastaConfig:
 
     def get_skip_unique_instance_name_validation_services(self) -> List[str]:
         return self.config_dict.get("skip_unique_instance_name_validation", [])
+
+    def get_common_canary_instance_names(self) -> List[str]:
+        return self.config_dict.get("common_canary_instance_names", ["canary"])
 
     def get_cluster_aliases(self) -> Dict[str, str]:
         return self.config_dict.get("cluster_aliases", {})

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -36,6 +36,8 @@ from paasta_tools.cli.cmds.validate import check_service_path
 from paasta_tools.cli.cmds.validate import get_config_file_dict
 from paasta_tools.cli.cmds.validate import get_schema_validator
 from paasta_tools.cli.cmds.validate import get_service_path
+from paasta_tools.cli.cmds.validate import instance_registration_lookup
+from paasta_tools.cli.cmds.validate import is_canary
 from paasta_tools.cli.cmds.validate import list_upcoming_runs
 from paasta_tools.cli.cmds.validate import paasta_validate
 from paasta_tools.cli.cmds.validate import paasta_validate_soa_configs
@@ -49,15 +51,18 @@ from paasta_tools.cli.cmds.validate import validate_pool_limits
 from paasta_tools.cli.cmds.validate import validate_rollback_bounds
 from paasta_tools.cli.cmds.validate import validate_schema
 from paasta_tools.cli.cmds.validate import validate_secrets
+from paasta_tools.cli.cmds.validate import validate_single_replica_instances
 from paasta_tools.cli.cmds.validate import validate_smartstack
 from paasta_tools.cli.cmds.validate import validate_tron
 from paasta_tools.cli.cmds.validate import validate_unique_instance_names
+from paasta_tools.eks_tools import EksDeploymentConfig
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_ACTIVE_REQUESTS
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_CPU
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_MEMORY
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_UWSGI
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_UWSGI_V2
 from paasta_tools.long_running_service_tools import METRICS_PROVIDER_WORKER_LOAD
+from paasta_tools.long_running_service_tools import LongRunningServiceConfig
 from paasta_tools.utils import SystemPaastaConfig
 
 
@@ -83,7 +88,13 @@ def clear_get_config_file_dict_cache():
 @patch("paasta_tools.cli.cmds.validate.validate_smartstack", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.validate_service_name", autospec=True)
 @patch("paasta_tools.cli.cmds.validate.check_monitoring_file_exists", autospec=True)
+@patch("paasta_tools.cli.cmds.validate.validate_flink_monitoring_team", autospec=True)
+@patch(
+    "paasta_tools.cli.cmds.validate.validate_single_replica_instances", autospec=True
+)
 def test_paasta_validate_calls_everything(
+    mock_validate_single_replica_instances,
+    mock_validate_flink_monitoring_team,
     mock_validate_monitoring_file,
     mock_validate_service_name,
     mock_validate_smartstack,
@@ -114,6 +125,8 @@ def test_paasta_validate_calls_everything(
     mock_validate_smartstack.return_value = True
     mock_validate_service_name.return_value = True
     mock_validate_monitoring_file.return_value = True
+    mock_validate_flink_monitoring_team.return_value = True
+    mock_validate_single_replica_instances.return_value = True
 
     args = mock.MagicMock()
     args.service = "test"
@@ -132,6 +145,7 @@ def test_paasta_validate_calls_everything(
     assert mock_validate_smartstack.called
     assert mock_validate_service_name.called
     assert mock_validate_monitoring_file.called
+    assert mock_validate_single_replica_instances.called
 
 
 @patch(
@@ -232,6 +246,225 @@ def test_validate_min_max_instances_success(
         "The number of min_instances (3) cannot be greater than the max_instances (1)."
         in output
     )
+
+
+@pytest.mark.parametrize(
+    "instances, comment, expected",
+    [
+        (3, "", True),
+        (1, "# override-single-replica (PAASTA-18934)", True),
+        (1, "# override-single-replica (DRE-1234#operator pattern)", True),
+        (1, "", False),
+        (1, "# some random comment", False),
+        (1, "# override-single-replicaXXX (PAASTA-18934)", False),
+    ],
+)
+@patch("paasta_tools.cli.cmds.validate.get_file_contents", autospec=True)
+@patch(
+    "paasta_tools.cli.cmds.validate.PaastaServiceConfigLoader",
+    autospec=True,
+)
+@patch("paasta_tools.cli.cmds.validate.path_to_soa_dir_service", autospec=True)
+@patch("paasta_tools.cli.cmds.validate.load_system_paasta_config", autospec=True)
+def test_validate_single_replica(
+    mock_load_system_paasta_config,
+    mock_path_to_soa_dir_service,
+    mock_config_loader_cls,
+    mock_get_file_contents,
+    instances,
+    comment,
+    expected,
+):
+    mock_load_system_paasta_config.return_value.get_ecosystem_for_cluster.return_value = (
+        "prod"
+    )
+    mock_load_system_paasta_config.return_value.get_common_canary_instance_names.return_value = (
+        []
+    )
+    mock_path_to_soa_dir_service.return_value = ("fake_soa_dir", "fake_service")
+    mock_instance_config = mock.Mock(
+        spec=EksDeploymentConfig,
+        is_autoscaling_enabled=mock.Mock(return_value=False),
+        get_instances=mock.Mock(return_value=instances),
+        get_instance=mock.Mock(return_value="fake_instance1"),
+        get_registrations=mock.Mock(return_value=["fake_service.fake_instance1"]),
+        get_config_path=mock.Mock(
+            return_value="fake_soa_dir/fake_service/eks-fake_cluster.yaml"
+        ),
+    )
+    mock_config_loader = mock_config_loader_cls.return_value
+    mock_config_loader.clusters = ["fake_cluster"]
+    mock_config_loader.instance_configs.return_value = iter([mock_instance_config])
+    mock_get_file_contents.return_value = f"""
+---
+fake_instance1:
+  instances: {instances} {comment}
+"""
+
+    assert validate_single_replica_instances("fake-service-path") is expected
+
+
+@pytest.mark.parametrize(
+    "yaml_content, expected",
+    [
+        # Template has override comment, instance inherits via merge — should pass
+        (
+            """\
+_template: &tmpl
+  instances: 1 # override-single-replica (PAASTA-18934)
+fake_instance1:
+  <<: *tmpl
+""",
+            True,
+        ),
+        # Template has no comment, instance inherits via merge — should fail
+        (
+            """\
+_template: &tmpl
+  instances: 1
+fake_instance1:
+  <<: *tmpl
+""",
+            False,
+        ),
+        # Multi-hop: instance -> template_a -> template_b (has comment) — should pass
+        (
+            """\
+_template_b: &tmpl_b
+  instances: 1 # override-single-replica (PAASTA-18934)
+_template_a: &tmpl_a
+  <<: *tmpl_b
+fake_instance1:
+  <<: *tmpl_a
+""",
+            True,
+        ),
+        # Instance explicitly sets instances: 1 with comment, even though template has none — should pass
+        (
+            """\
+_template: &tmpl
+  instances: 1
+fake_instance1:
+  <<: *tmpl
+  instances: 1 # override-single-replica (PAASTA-18934)
+""",
+            True,
+        ),
+        # Instance explicitly sets instances: 1 without comment, chain has comment two hops up — should fail
+        (
+            """\
+worker_a: &cool_template
+  instances: 1 # override-single-replica (PAASTA-18934)
+worker_b: &other_template
+  <<: *cool_template
+  instances: 2
+  mem: 12345
+fake_instance1:
+  <<: *other_template
+  instances: 1
+""",
+            False,
+        ),
+    ],
+)
+@patch("paasta_tools.cli.cmds.validate.get_file_contents", autospec=True)
+@patch(
+    "paasta_tools.cli.cmds.validate.PaastaServiceConfigLoader",
+    autospec=True,
+)
+@patch("paasta_tools.cli.cmds.validate.path_to_soa_dir_service", autospec=True)
+@patch("paasta_tools.cli.cmds.validate.load_system_paasta_config", autospec=True)
+def test_validate_single_replica_template_inheritance(
+    mock_load_system_paasta_config,
+    mock_path_to_soa_dir_service,
+    mock_config_loader_cls,
+    mock_get_file_contents,
+    yaml_content,
+    expected,
+):
+    mock_load_system_paasta_config.return_value.get_ecosystem_for_cluster.return_value = (
+        "prod"
+    )
+    mock_load_system_paasta_config.return_value.get_common_canary_instance_names.return_value = (
+        []
+    )
+    mock_path_to_soa_dir_service.return_value = ("fake_soa_dir", "fake_service")
+    mock_instance_config = mock.Mock(
+        spec=EksDeploymentConfig,
+        is_autoscaling_enabled=mock.Mock(return_value=False),
+        get_instances=mock.Mock(return_value=1),
+        get_instance=mock.Mock(return_value="fake_instance1"),
+        get_registrations=mock.Mock(return_value=["fake_service.fake_instance1"]),
+        get_config_path=mock.Mock(
+            return_value="fake_soa_dir/fake_service/eks-fake_cluster.yaml"
+        ),
+    )
+    mock_config_loader = mock_config_loader_cls.return_value
+    mock_config_loader.clusters = ["fake_cluster"]
+    mock_config_loader.instance_configs.return_value = iter([mock_instance_config])
+    mock_get_file_contents.return_value = yaml_content
+
+    assert validate_single_replica_instances("fake-service-path") is expected
+
+
+@pytest.mark.parametrize(
+    "registrations, other_registrations, other_instances_count, other_autoscaling, expected",
+    [
+        # Test case 1: No other registrations, should return false - not a canary
+        ([], ["fake_service.main"], 5, False, False),
+        # Test case 2: shares a registration with a service with more than 1 replica, returns true - is a canary
+        (["fake_service.main"], ["fake_service.main"], 5, False, True),
+        # Test case 3: shares a registration with a service with 1 replica, returns false - not a canary
+        (["fake_service.main"], ["fake_service.main"], 1, False, False),
+        # Test case 4: shares a registration with an autoscaled service, returns true - is a canary
+        (["fake_service.main"], ["fake_service.main"], 5, True, True),
+    ],
+)
+def test_is_canary(
+    registrations,
+    other_registrations,
+    other_instances_count,
+    other_autoscaling,
+    expected,
+):
+    mock_instance_config = mock.Mock(
+        spec=LongRunningServiceConfig,
+        get_instance=mock.Mock(return_value="fake_instance_canary"),
+        get_registrations=mock.Mock(return_value=registrations),
+    )
+    mock_other_instance_config = mock.Mock(
+        spec=LongRunningServiceConfig,
+        get_registrations=mock.Mock(return_value=other_registrations),
+        get_instance=mock.Mock(return_value="fake_instance_main"),
+        get_instances=mock.Mock(return_value=other_instances_count),
+        get_max_instances=mock.Mock(return_value=other_instances_count),
+        is_autoscaling_enabled=mock.Mock(return_value=other_autoscaling),
+    )
+    reg_lookup = instance_registration_lookup(
+        [mock_instance_config, mock_other_instance_config]
+    )
+    assert is_canary(mock_instance_config, reg_lookup) is expected
+
+
+def test_registration_lookup():
+    config_a = mock.Mock(
+        spec=LongRunningServiceConfig,
+        get_registrations=mock.Mock(
+            return_value=["fake_service.main", "fake_service.secondary"]
+        ),
+    )
+    config_b = mock.Mock(
+        spec=LongRunningServiceConfig,
+        get_registrations=mock.Mock(return_value=["fake_service.main"]),
+    )
+    config_c = mock.Mock(
+        spec=LongRunningServiceConfig,
+        get_registrations=mock.Mock(return_value=["fake_service.other"]),
+    )
+    reg_lookup = instance_registration_lookup([config_a, config_b, config_c])
+    assert reg_lookup["fake_service.main"] == [config_a, config_b]
+    assert reg_lookup["fake_service.secondary"] == [config_a]
+    assert reg_lookup["fake_service.other"] == [config_c]
 
 
 @patch("paasta_tools.cli.cmds.validate.os.path.isdir", autospec=True)
@@ -1291,6 +1524,9 @@ def test_validate_autoscaling_configs(
             mock.Mock(
                 get_instance=mock.Mock(return_value="fake_instance1"),
                 get_instance_type=mock.Mock(return_value="kubernetes"),
+                get_config_path=mock.Mock(
+                    return_value="fake_soa_dir/fake_service/eks-fake_cluster.yaml"
+                ),
                 is_autoscaling_enabled=mock.Mock(return_value=True),
                 get_autoscaling_params=mock.Mock(return_value=autoscaling_config),
                 get_registrations=mock.Mock(return_value=registrations),
@@ -1353,6 +1589,9 @@ def test_validate_cpu_autotune_override(
             mock.Mock(
                 get_instance=mock.Mock(return_value="fake_instance1"),
                 get_instance_type=mock.Mock(return_value=instance_type),
+                get_config_path=mock.Mock(
+                    return_value=f"fake_soa_dir/fake_service/{instance_type}-fake_cluster.yaml"
+                ),
                 is_autoscaling_enabled=mock.Mock(return_value=True),
                 get_autoscaling_params=mock.Mock(
                     return_value={
@@ -1466,6 +1705,9 @@ fake_instance1:
         return_value=mock.Mock(
             get_instance=mock.Mock(return_value="fake_instance1"),
             get_instance_type=mock.Mock(return_value=instance_type),
+            get_config_path=mock.Mock(
+                return_value=f"fake_soa_dir/fake_service/{instance_type}-fake_cluster.yaml"
+            ),
         ),
     ), mock.patch(
         "paasta_tools.cli.cmds.validate.list_all_instances_for_service",


### PR DESCRIPTION
1. Creating a commit check that will look for single replica instances. This is done in order to avoid an SPOF and to allow for recycling. 
3. The commit hook will only target services running in the production environment. 
5. If the instance is set implicitly (default) then an info message will be shown but passes the check. 
7. Skips canary services.
8. The validation check can be skipped using the `# override-single-replica (PROJ-1234)` comment in the respective service config files.