### PR TITLE
Refactor the cpu limit check

### DIFF
--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -943,6 +943,8 @@ def validate_pool_limits(service_path: str) -> bool:
     Validate that services in specific pools won't exceed per-node capacities.
     For the most part, this isn't normally an issue - but there are several pools where
     folks tend to want to run extra-large workloads that won't fit (e.g., large single-node batches).
+
+    Users can override this check by adding any comment next to `cpus` in their yelpsoa config.
     """
     soa_dir, service = path_to_soa_dir_service(service_path)
     returncode = True
@@ -961,15 +963,46 @@ def validate_pool_limits(service_path: str) -> bool:
             if pool_limits is None:
                 continue
 
-            if cpu >= pool_limits["max_cpus"]:
-                returncode = False
-                print(
-                    failure(
-                        f"""{service}.{instance} in {cluster} has {cpu} CPUs, which exceeds the limit of {pool_limits['max_cpus']} for the {pool} pool.
-                        If you need to run a workload with this many CPUs, consider using the {pool_limits['recommended_pool']} pool instead.""",
-                        "",
-                    )
+            if cpu < pool_limits["max_cpus"]:
+                continue
+
+            if __is_templated(
+                service, soa_dir, cluster, workload="kubernetes"
+            ) or __is_templated(service, soa_dir, cluster, workload="eks"):
+                continue
+
+            config_file_path = os.path.join(
+                soa_dir,
+                service,
+                f"{instance_config.get_instance_type()}-{cluster}.yaml",
+            )
+            config = get_config_file_dict(
+                config_file_path,
+                use_ruamel=True,
+            )
+
+            config_flattened = _get_config_flattened(config_file_path)
+
+            cpu_comment = _get_comments_for_key(
+                data=config[instance],
+                key="cpus",
+                full_config=config,
+                key_value=config[instance].get("cpus"),
+                full_config_flattened=config_flattened,
+            )
+
+            if cpu_comment is not None and cpu_comment.strip():
+                continue
+
+            returncode = False
+            print(
+                failure(
+                    msg=f"{service}.{instance} in {cluster} has {cpu} CPUs, which exceeds the limit of {pool_limits['max_cpus']} for the {pool} pool."
+                    " To override, add a comment next to cpus in your yelpsoa config (e.g. cpus: 32  # need large pod for batch)."
+                    " Please read the following link for next steps:",
+                    link="y/pool-cpu-limits",
                 )
+            )
     return returncode
 
 

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -963,6 +963,9 @@ def validate_pool_limits(service_path: str) -> bool:
             if pool_limits is None or cpu < pool_limits["max_cpus"]:
                 continue
 
+            if instance_config.get_instance_type() not in ("kubernetes", "eks"):
+                continue
+
             if __is_templated(
                 service, soa_dir, cluster, workload="kubernetes"
             ) or __is_templated(service, soa_dir, cluster, workload="eks"):

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -142,6 +142,10 @@ OVERRIDE_CPU_AUTOTUNE_ACK_PATTERN = r"#\s*override-cpu-setting\s+\(.+[A-Z]+-[0-9
 # but we don't have a $ anchor in case users want to add an additional
 # comment
 OVERRIDE_CPU_BURST_ACK_PATTERN = r"#\s*override-cpu-burst\s+\(.+[A-Z]+-[0-9]+.+\)"
+
+# we expect a comment that starts with # override-
+OVERRIDE_POOL_CPU_LIMIT_PATTERN = r"#\s*override-"
+
 # for now, double the autotune cap to give people the benefit of the doubt
 # if we see that people are still misusing this configuration, we can lower
 # this to the autotune cap (i.e., 1)
@@ -966,9 +970,7 @@ def validate_pool_limits(service_path: str) -> bool:
             if instance_config.get_instance_type() not in ("kubernetes", "eks"):
                 continue
 
-            if __is_templated(
-                service, soa_dir, cluster, workload="kubernetes"
-            ) or __is_templated(service, soa_dir, cluster, workload="eks"):
+            if __is_templated(service, soa_dir, cluster, workload="eks"):
                 continue
 
             config_file_path = os.path.join(
@@ -991,14 +993,17 @@ def validate_pool_limits(service_path: str) -> bool:
                 full_config_flattened=config_flattened,
             )
 
-            if cpu_comment is not None and cpu_comment.strip():
+            if cpu_comment is not None and re.search(
+                pattern=OVERRIDE_POOL_CPU_LIMIT_PATTERN,
+                string=cpu_comment,
+            ):
                 continue
 
             returncode = False
             print(
                 failure(
-                    f"{service}.{instance} in {cluster} has {cpu} CPUs, which exceeds the limit of {pool_limits['max_cpus']} for the {pool} pool."
-                    " To override, add a comment next to cpus in your yelpsoa config (e.g. cpus: 32  # need large pod for batch)."
+                    f"{service}.{instance} in {cluster} has {cpu} CPUs, which exceeds the recommended limit of {pool_limits['max_cpus']} for the {pool} pool."
+                    " To override, add a comment next to cpus in your yelpsoa config (e.g. cpus: 32  # override-need-large-pod)."
                     " If you have any questions, reach out to #compute-infra.",
                     "",
                 )

--- a/paasta_tools/cli/cmds/validate.py
+++ b/paasta_tools/cli/cmds/validate.py
@@ -960,10 +960,7 @@ def validate_pool_limits(service_path: str) -> bool:
             pool = instance_config.get_pool()
 
             pool_limits = pool_limits_for_cluster.get(pool)
-            if pool_limits is None:
-                continue
-
-            if cpu < pool_limits["max_cpus"]:
+            if pool_limits is None or cpu < pool_limits["max_cpus"]:
                 continue
 
             if __is_templated(
@@ -997,10 +994,10 @@ def validate_pool_limits(service_path: str) -> bool:
             returncode = False
             print(
                 failure(
-                    msg=f"{service}.{instance} in {cluster} has {cpu} CPUs, which exceeds the limit of {pool_limits['max_cpus']} for the {pool} pool."
+                    f"{service}.{instance} in {cluster} has {cpu} CPUs, which exceeds the limit of {pool_limits['max_cpus']} for the {pool} pool."
                     " To override, add a comment next to cpus in your yelpsoa config (e.g. cpus: 32  # need large pod for batch)."
-                    " Please read the following link for next steps:",
-                    link="y/pool-cpu-limits",
+                    " If you have any questions, reach out to #compute-infra.",
+                    "",
                 )
             )
     return returncode

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -1919,7 +1919,6 @@ class TopologySpreadConstraintDict(TypedDict, total=False):
 
 class PoolLimits(TypedDict):
     max_cpus: float
-    recommended_pool: str
 
 
 class SystemPaastaConfigDict(TypedDict, total=False):

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -2078,6 +2078,8 @@ def test_check_monitoring_file_exists_non_service(tmp_path):
         (20, "", False, "eks"),
         (20, "# large batch job", True, "eks"),
         (8, "", True, "eks"),
+        # non-k8s instance types are skipped (e.g., tron uses dotted job.action names)
+        (20, "", True, "tron"),
     ],
 )
 def test_validate_pool_limits(cpus, comment, expected, instance_type):

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -2072,11 +2072,12 @@ def test_check_monitoring_file_exists_non_service(tmp_path):
     "cpus, comment, expected, instance_type",
     [
         (20, "", False, "kubernetes"),
-        (20, "# need large pod for batch", True, "kubernetes"),
-        (20, "# any reason at all", True, "kubernetes"),
+        (20, "# override-need-large-pod", True, "kubernetes"),
+        (20, "# override-approved-by-compute-infra", True, "kubernetes"),
+        (20, "# not a valid override comment", False, "kubernetes"),
         (8, "", True, "kubernetes"),
         (20, "", False, "eks"),
-        (20, "# large batch job", True, "eks"),
+        (20, "# override-large-batch-job", True, "eks"),
         (8, "", True, "eks"),
         # non-k8s instance types are skipped (e.g., tron uses dotted job.action names)
         (20, "", True, "tron"),

--- a/tests/cli/test_cmds_validate.py
+++ b/tests/cli/test_cmds_validate.py
@@ -2068,76 +2068,70 @@ def test_check_monitoring_file_exists_non_service(tmp_path):
     assert check_monitoring_file_exists(str(tmp_path)) is True
 
 
-@patch("paasta_tools.cli.cmds.validate.load_system_paasta_config", autospec=True)
-@patch(
-    "paasta_tools.cli.cmds.validate.load_all_instance_configs_for_service",
-    autospec=True,
+@pytest.mark.parametrize(
+    "cpus, comment, expected, instance_type",
+    [
+        (20, "", False, "kubernetes"),
+        (20, "# need large pod for batch", True, "kubernetes"),
+        (20, "# any reason at all", True, "kubernetes"),
+        (8, "", True, "kubernetes"),
+        (20, "", False, "eks"),
+        (20, "# large batch job", True, "eks"),
+        (8, "", True, "eks"),
+    ],
 )
-@patch("paasta_tools.cli.cmds.validate.list_clusters", autospec=True)
-@patch("paasta_tools.cli.cmds.validate.path_to_soa_dir_service", autospec=True)
-def test_validate_pool_limits_fails_for_giant_pod(
-    mock_path_to_soa_dir_service,
-    mock_list_clusters,
-    mock_load_all_instance_configs_for_service,
-    mock_load_system_paasta_config,
-    capsys,
-):
-    mock_path_to_soa_dir_service.return_value = ("fake_soa_dir", "fake_service")
-    mock_list_clusters.return_value = ["fake_cluster"]
-    mock_load_system_paasta_config.return_value.get_pool_limits.return_value = {
-        "fake_cluster": {
-            "stable": {"max_cpus": 16, "recommended_pool": "stable-giant"},
-        }
-    }
-    mock_load_all_instance_configs_for_service.return_value = [
-        (
-            "fake_instance",
-            mock.Mock(
-                get_cpus=mock.Mock(return_value=20),
-                get_pool=mock.Mock(return_value="stable"),
-            ),
-        )
-    ]
+def test_validate_pool_limits(cpus, comment, expected, instance_type):
+    instance_config = f"""
+---
+fake_instance:
+  cpus: {cpus} {comment}
+  pool: stable
+"""
 
-    assert validate_pool_limits("fake-service-path") is False
-    output, _ = capsys.readouterr()
-    assert "fake_instance" in output
-    assert "20" in output
-    assert "stable" in output
-    assert "stable-giant" in output
-
-
-@patch("paasta_tools.cli.cmds.validate.load_system_paasta_config", autospec=True)
-@patch(
-    "paasta_tools.cli.cmds.validate.load_all_instance_configs_for_service",
-    autospec=True,
-)
-@patch("paasta_tools.cli.cmds.validate.list_clusters", autospec=True)
-@patch("paasta_tools.cli.cmds.validate.path_to_soa_dir_service", autospec=True)
-def test_validate_pool_limits_passes_for_small_pod(
-    mock_path_to_soa_dir_service,
-    mock_list_clusters,
-    mock_load_all_instance_configs_for_service,
-    mock_load_system_paasta_config,
-):
-    mock_path_to_soa_dir_service.return_value = ("fake_soa_dir", "fake_service")
-    mock_list_clusters.return_value = ["fake_cluster"]
-    mock_load_system_paasta_config.return_value.get_pool_limits.return_value = {
-        "fake_cluster": {
-            "stable": {"max_cpus": 16, "recommended_pool": "stable-giant"},
-        }
-    }
-    mock_load_all_instance_configs_for_service.return_value = [
-        (
-            "fake_instance",
-            mock.Mock(
-                get_cpus=mock.Mock(return_value=8),
-                get_pool=mock.Mock(return_value="stable"),
-            ),
-        )
-    ]
-
-    assert validate_pool_limits("fake-service-path") is True
+    with mock.patch(
+        "paasta_tools.cli.cmds.validate.load_system_paasta_config",
+        autospec=True,
+        return_value=SystemPaastaConfig(
+            config={
+                "pool_limits": {
+                    "fake_cluster": {
+                        "stable": {"max_cpus": 16},
+                    }
+                }
+            },
+            directory="/some/test/dir",
+        ),
+    ), mock.patch(
+        "paasta_tools.cli.cmds.validate.get_file_contents",
+        autospec=True,
+        return_value=instance_config,
+    ), mock.patch(
+        "paasta_tools.cli.cmds.validate.load_all_instance_configs_for_service",
+        autospec=True,
+        return_value=[
+            (
+                "fake_instance",
+                mock.Mock(
+                    get_cpus=mock.Mock(return_value=cpus),
+                    get_pool=mock.Mock(return_value="stable"),
+                    get_instance_type=mock.Mock(return_value=instance_type),
+                ),
+            )
+        ],
+    ), mock.patch(
+        "paasta_tools.cli.cmds.validate.list_clusters",
+        autospec=True,
+        return_value=["fake_cluster"],
+    ), mock.patch(
+        "paasta_tools.cli.cmds.validate.path_to_soa_dir_service",
+        autospec=True,
+        return_value=("fake_soa_dir", "fake_service"),
+    ), mock.patch(
+        "paasta_tools.cli.cmds.validate.os.path.exists",
+        autospec=True,
+        return_value=False,
+    ):
+        assert validate_pool_limits("fake-service-path") is expected
 
 
 @patch("paasta_tools.cli.cmds.validate.load_system_paasta_config", autospec=True)
@@ -2157,7 +2151,7 @@ def test_validate_pool_limits_passes_for_unconfigured_pool(
     mock_list_clusters.return_value = ["fake_cluster"]
     mock_load_system_paasta_config.return_value.get_pool_limits.return_value = {
         "fake_cluster": {
-            "stable": {"max_cpus": 16, "recommended_pool": "stable-giant"},
+            "stable": {"max_cpus": 16},
         }
     }
     mock_load_all_instance_configs_for_service.return_value = [


### PR DESCRIPTION
Refactor the cpu limit check:

- remove recommended pool
- require comment next to `cpu` in yelpsoa to override