### PR TITLE
Only call ensure_service_account once per iam_role per service.

### DIFF
--- a/paasta_tools/setup_tron_namespace.py
+++ b/paasta_tools/setup_tron_namespace.py
@@ -25,6 +25,7 @@ import logging
 import sys
 from typing import Dict
 from typing import List
+from typing import Set
 
 import ruamel.yaml as yaml
 
@@ -83,15 +84,17 @@ def ensure_service_accounts(job_configs: List[TronJobConfig]) -> None:
     # NOTE: these are lru_cache'd so it should be fine to call these for every service
     system_paasta_config = load_system_paasta_config()
     kube_client = KubeClient()
+    spark_kube_client = KubeClient(
+        config_file=system_paasta_config.get_spark_kubeconfig()
+    )
+
+    regular_service_accounts_to_ensure: Set[str] = set()
+    spark_service_accounts_to_ensure: Set[str] = set()
 
     for job in job_configs:
         for action in job.get_actions():
             if action.get_iam_role():
-                ensure_service_account(
-                    action.get_iam_role(),
-                    namespace=KUBERNETES_NAMESPACE,
-                    kube_client=kube_client,
-                )
+                regular_service_accounts_to_ensure.add(action.get_iam_role())
                 # spark executors are special in that we want the SA to exist in two namespaces:
                 # the tron namespace - for the spark driver (which will be created by the ensure_service_account() above)
                 # and the spark namespace - for the spark executor (which we'll create below)
@@ -100,18 +103,26 @@ def ensure_service_accounts(job_configs: List[TronJobConfig]) -> None:
                     # this should always be truthy, but let's be safe since this comes from SystemPaastaConfig
                     and action.get_spark_executor_iam_role()
                 ):
-                    # this kubeclient creation is lru_cache'd so it should be fine to call this for every spark action
-                    spark_kube_client = KubeClient(
-                        config_file=system_paasta_config.get_spark_kubeconfig()
-                    )
                     # this will look quite similar to the above, but we're ensuring that a potentially different SA exists:
                     # this one is for the actual spark executors to use. if an iam_role is set, we'll use that, otherwise
                     # there's an executor-specifc default role just like there is for the drivers :)
-                    ensure_service_account(
-                        action.get_spark_executor_iam_role(),
-                        namespace=spark_tools.SPARK_EXECUTOR_NAMESPACE,
-                        kube_client=spark_kube_client,
+                    spark_service_accounts_to_ensure.add(
+                        action.get_spark_executor_iam_role()
                     )
+
+    for iam_role in regular_service_accounts_to_ensure:
+        ensure_service_account(
+            iam_role,
+            namespace=KUBERNETES_NAMESPACE,
+            kube_client=kube_client,
+        )
+
+    for iam_role in spark_service_accounts_to_ensure:
+        ensure_service_account(
+            iam_role,
+            namespace=spark_tools.SPARK_EXECUTOR_NAMESPACE,
+            kube_client=spark_kube_client,
+        )
 
 
 def main() -> None:

--- a/tests/test_setup_tron_namespace.py
+++ b/tests/test_setup_tron_namespace.py
@@ -1,0 +1,91 @@
+from typing import List
+from unittest import mock
+
+from paasta_tools import setup_tron_namespace
+from paasta_tools import spark_tools
+from paasta_tools.kubernetes_tools import KubeClient
+from paasta_tools.tron_tools import KUBERNETES_NAMESPACE
+from paasta_tools.tron_tools import TronActionConfig
+from paasta_tools.tron_tools import TronJobConfig
+
+
+def _make_action(
+    iam_role: str = "",
+    executor: str = "paasta",
+    spark_executor_iam_role: str = "",
+) -> mock.Mock:
+    action = mock.Mock(spec_set=TronActionConfig)
+    action.get_iam_role.return_value = iam_role
+    action.get_executor.return_value = executor
+    action.get_spark_executor_iam_role.return_value = spark_executor_iam_role
+    return action
+
+
+def _make_job(actions: List[TronActionConfig]) -> mock.Mock:
+    job = mock.Mock(spec_set=TronJobConfig)
+    job.get_actions.return_value = actions
+    return job
+
+
+def test_ensure_service_accounts():
+    regular_kube_client = mock.Mock(spec=KubeClient)
+    spark_kube_client = mock.Mock(spec=KubeClient)
+
+    with mock.patch.object(
+        setup_tron_namespace, "ensure_service_account", autospec=True
+    ) as mock_ensure_service_account, mock.patch.object(
+        setup_tron_namespace, "KubeClient", autospec=True
+    ) as mock_kube_client_class, mock.patch.object(
+        setup_tron_namespace, "load_system_paasta_config", autospec=True
+    ) as mock_load_system_paasta_config:
+        mock_kube_client_class.side_effect = [regular_kube_client, spark_kube_client]
+
+        job_configs = [
+            _make_job(
+                [
+                    _make_action(iam_role="role-a"),
+                    _make_action(
+                        iam_role="role-b",
+                        executor="spark",
+                        spark_executor_iam_role="spark-role-b",
+                    ),
+                    # actions without an iam role should be skipped
+                    _make_action(),
+                ]
+            ),
+            # duplicate iam roles across jobs should only be ensured once
+            _make_job([_make_action(iam_role="role-a")]),
+        ]
+
+        setup_tron_namespace.ensure_service_accounts(job_configs)
+
+        # the spark executor SA is ensured with a client pointing at the spark cluster
+        assert mock_kube_client_class.call_args_list == [
+            mock.call(),
+            mock.call(
+                config_file=mock_load_system_paasta_config.return_value.get_spark_kubeconfig.return_value
+            ),
+        ]
+
+        # sets are iterated in an arbitrary order, so we can't assert on call order
+        assert mock_ensure_service_account.call_count == 3
+        mock_ensure_service_account.assert_has_calls(
+            [
+                mock.call(
+                    "role-a",
+                    namespace=KUBERNETES_NAMESPACE,
+                    kube_client=regular_kube_client,
+                ),
+                mock.call(
+                    "role-b",
+                    namespace=KUBERNETES_NAMESPACE,
+                    kube_client=regular_kube_client,
+                ),
+                mock.call(
+                    "spark-role-b",
+                    namespace=spark_tools.SPARK_EXECUTOR_NAMESPACE,
+                    kube_client=spark_kube_client,
+                ),
+            ],
+            any_order=True,
+        )


### PR DESCRIPTION
Seems like we're spending a significant amount of time on ensure_service_accounts, and setup_tron_namespace has gotten quite slow. Hopefully this should speed it up.