### PR TITLE
Add resolute .deb to releases

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,10 @@ jobs:
         with:
           name: deb-jammy
           path: dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: deb-resolute
+          path: dist/
       - name: Release
         uses: softprops/action-gh-release@v1
         if: startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
@vulpine says I'll be their new best friend if I do this

real description: Yelp/nerve-tools tests currently grab paasta-tools debs from our releases for GHA builds. this is fine, but what is not fine is that we are only uploading (and testing against) a jammy deb - which doesn't quite work out so well if you're trying to add a resolute build to nerve-tools