### PR TITLE
filter instances with service override from deployments

### DIFF
--- a/paasta_tools/generate_deployments_for_service.py
+++ b/paasta_tools/generate_deployments_for_service.py
@@ -147,7 +147,9 @@ def get_deploy_group_mappings(
     service_configs = get_instance_configs_for_service(soa_dir=soa_dir, service=service)
 
     deploy_group_branch_mappings = {
-        config.get_branch(): config.get_deploy_group() for config in service_configs
+        config.get_branch(): config.get_deploy_group()
+        for config in service_configs
+        if not config.get_service_override()
     }
     if not deploy_group_branch_mappings:
         log.info("Service %s has no valid deploy groups. Skipping.", service)

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -492,6 +492,9 @@ class InstanceConfig:
             cluster=self.get_cluster(), instance=self.get_instance()
         )
 
+    def get_service_override(self) -> Optional[str]:
+        return self.config_dict.get("service", None)
+
     def get_deploy_group(self) -> str:
         return self.config_dict.get("deploy_group", self.get_branch())
 


### PR DESCRIPTION
Tron configuration allows setting a `service` parameter for job actions which loads a different service container for that specific action. Of course in those cases the deploy group needs to belong to the service being specified, so if that matches a deploy group of the service related to the configuration, it generates a bogus entry in the deployments.json file for that service.

That's not a big deal usually, but can be when said deploy group name is from 4 years ago, and it make it look like we are deploying in production a very out of date container.

I tried to check if removing those deployments instances has any ramification, but it should be fine, as Tron does not rely on them for such actions. [It will load the other service deployments file](https://github.com/Yelp/paasta/blob/master/paasta_tools/tron_tools.py#L839-L841).