### PR TITLE
Build paasta-tools for arm64 - COMPINFRA-5995

### DIFF
--- a/yelp_package/Makefile
+++ b/yelp_package/Makefile
@@ -19,6 +19,7 @@ SHELL=/bin/bash
 
 UID:=`id -u`
 GID:=`id -g`
+DPKG_ARCH:=$(shell dpkg --print-architecture)
 DOCKER_RUN=docker run -t -v $(CURDIR)/../:/work:rw docker.io/yelp/paastatools_$*_container
 
 NOOP = true
@@ -41,7 +42,7 @@ build_%_docker:
 
 .SECONDEXPANSION:
 itest_%: package_$$*
-	$(DOCKER_RUN) /work/yelp_package/itest/ubuntu.sh paasta-tools_$(ACTUAL_PACKAGE_VERSION)_amd64.deb
+	$(DOCKER_RUN) /work/yelp_package/itest/ubuntu.sh paasta-tools_$(ACTUAL_PACKAGE_VERSION)_$(DPKG_ARCH).deb
 
 PTG_VERSION=0.0.20
 PTG_SUM=17fabafb3aa8ea728c8c4a62927fc699b7b16ad0bd561ed822096f2da329eed1

--- a/yelp_package/dockerfiles/itest/k8s/Dockerfile
+++ b/yelp_package/dockerfiles/itest/k8s/Dockerfile
@@ -37,9 +37,10 @@ RUN apt-get update > /dev/null && \
     && apt-get clean > /dev/null
 
 # Install kubectl
-RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/`curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt`/bin/linux/amd64/kubectl
-RUN chmod +x ./kubectl
-RUN mv ./kubectl /usr/local/bin/kubectl
+RUN KUBE_ARCH=$(dpkg --print-architecture) && \
+    curl -LO "https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/${KUBE_ARCH}/kubectl" && \
+    chmod +x ./kubectl && \
+    mv ./kubectl /usr/local/bin/kubectl
 
 WORKDIR /work
 

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -1,8 +1,8 @@
 atomicfile==1.0                     # vault-tools dependency
 cached-property==1.3.1              # slo-transcoder dependency
-cffi==1.15.0                        # vault-tools dependency
+cffi==1.17.1                        # vault-tools dependency
 crypto-lib==4.0.0                   # vault-tools dependency
-cryptography==3.0                   # vault-tools dependency
+cryptography==42.0.8                # vault-tools dependency
 dateglob==0.3                       # scribereader dependency
 geogrid==1.3.5                      # scribereader dependency
 gitdb==4.0.12                       # slo-transcoder, vault-tools dependency
@@ -21,7 +21,7 @@ okta-auth==1.3.2
 pycparser==2.20                     # vault-tools dependency
 pygpgme==0.3                        # vault-tools dependency
 pyjwt==2.9.0                        # okta-auth dependency
-pyopenssl==19.0.0                   # vault-tools dependency
+pyopenssl==24.0.0                   # vault-tools dependency
 PySubnetTree==0.34                  # yelp-lib dependency
 python-jsonschema-objects==0.4.1    # slo-transcoder dependency
 saml-helper==3.1.2                  # okta-auth dependency


### PR DESCRIPTION
## Summary

Use dpkg --print-architecture instead of hardcoded amd64 references in the build system so paasta-tools can be built natively on both amd64 and arm64.

## Changes

### yelp_package/Makefile
- Added DPKG_ARCH variable using dpkg --print-architecture
- Changed itest target to reference the dynamic arch instead of hardcoded amd64

### yelp_package/dockerfiles/itest/k8s/Dockerfile
- Changed kubectl download URL to use dpkg --print-architecture instead of hardcoded amd64

### yelp_package/extra_requirements_yelp.txt
- bumped cryptography/pyopenssl/cffi to versions with arm64 wheels

## How it works

debian/control already has Architecture: any, so dpkg-buildpackage produces a .deb named with the native architecture. The only issue was the itest target that hardcoded amd64.deb in the expected filename.

## Testing

Tested on an arm64 build host:
- make itest_jammy completes successfully producing paasta-tools_1.60.3-yelp1_arm64.deb
- The deb installs correctly and all itest checks pass
- Architecture metadata verified: both filename and metadata report arm64

## Notes

- Noble/resolute: No additional changes needed, the architecture detection applies to all distros.

Jira: COMPINFRA-5995