### PR TITLE
Build arm64 paasta-tools debs in the release pipeline - COMPINFRA-6038

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,11 +50,21 @@ jobs:
       - run: pip install coveralls tox==3.2 tox-pip-extensions==1.3.0 ephemeral-port-reserve
       - run: make k8s_itests
   build_debs:
-    runs-on: ubuntu-22.04
+    runs-on: ${{ matrix.runner }}
     strategy:
       fail-fast: false
       matrix:
         dist: [jammy, noble, resolute]
+        arch: [amd64]
+        runner: [ubuntu-22.04]
+        include:
+          # Arm64 builds run on arm64 runners; the deb build and itest are
+          # arch-agnostic as of #4383. Only jammy is built for arm64 for now,
+          # since the other dists' arm64 builds are untested and a failure
+          # would block the release job.
+          - dist: jammy
+            arch: arm64
+            runner: ubuntu-22.04-arm
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
@@ -65,7 +75,7 @@ jobs:
       - run: make itest_${{ matrix.dist }}
       - uses: actions/upload-artifact@v4
         with:
-          name: deb-${{ matrix.dist }}
+          name: deb-${{ matrix.dist }}-${{ matrix.arch }}
           path: dist/paasta-tools_*.deb
   cut_release:
     runs-on: ubuntu-22.04
@@ -75,11 +85,15 @@ jobs:
       - run: mkdir -p dist/
       - uses: actions/download-artifact@v4
         with:
-          name: deb-jammy
+          name: deb-jammy-amd64
           path: dist/
       - uses: actions/download-artifact@v4
         with:
-          name: deb-resolute
+          name: deb-jammy-arm64
+          path: dist/
+      - uses: actions/download-artifact@v4
+        with:
+          name: deb-resolute-amd64
           path: dist/
       - name: Release
         uses: softprops/action-gh-release@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,10 +58,7 @@ jobs:
         arch: [amd64]
         runner: [ubuntu-22.04]
         include:
-          # Arm64 builds run on arm64 runners; the deb build and itest are
-          # arch-agnostic as of #4383. Only jammy is built for arm64 for now,
-          # since the other dists' arm64 builds are untested and a failure
-          # would block the release job.
+          # Only build jammy on arm64 for now
           - dist: jammy
             arch: arm64
             runner: ubuntu-22.04-arm


### PR DESCRIPTION
COMPINFRA-6038

Have Github Actions build jammy/arm64 debs as well. (I'm open to the idea of building arm debs on noble+resolute as well).