### PR TITLE
chore: remove rollout

### DIFF
--- a/paasta_tools/setup_prometheus_adapter_config.py
+++ b/paasta_tools/setup_prometheus_adapter_config.py
@@ -75,7 +75,6 @@ from paasta_tools.long_running_service_tools import METRICS_PROVIDER_WORKER_LOAD
 from paasta_tools.paasta_service_config_loader import PaastaServiceConfigLoader
 from paasta_tools.utils import DEFAULT_SOA_DIR
 from paasta_tools.utils import get_services_for_cluster
-from paasta_tools.utils import load_system_paasta_config
 
 log = logging.getLogger(__name__)
 
@@ -974,66 +973,38 @@ def create_shared_uwsgi_v2_scaling_rule(
     )
     worker_filter_terms = f"paasta_cluster='{paasta_cluster}',paasta_service='<<index .LabelValuesByName \"paasta_service\">>',paasta_instance='<<index .LabelValuesByName \"paasta_instance\">>',kube_deployment='<<index .LabelValuesByName \"kube_deployment\">>'"
 
-    use_raw_ksm_queries = load_system_paasta_config().get_use_raw_ksm_queries()
-
     load_per_instance = f"""
         avg(
             uwsgi_worker_busy{{{worker_filter_terms}}}
         ) by (kube_pod, kube_deployment)
     """
-    if use_raw_ksm_queries:
-        replicas_filter_terms = (
-            f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)'"
-        )
-        deployment_labels_filter_terms = f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)',label_paasta_yelp_com_service='<<index .LabelValuesByName \"paasta_service\">>',label_paasta_yelp_com_instance='<<index .LabelValuesByName \"paasta_instance\">>'"
-        missing_instances = f"""
-            (clamp_min(
-                label_replace(
-                    kube_deployment_status_replicas_ready{{{replicas_filter_terms}}}
-                    * on (deployment)
-                    kube_deployment_labels{{{deployment_labels_filter_terms}}},
-                    "kube_deployment", "$1", "deployment", "(.*)")
-                - on (kube_deployment)
-                count by (kube_deployment) (
-                    {load_per_instance}
-                ),
-                0
-            ) or on() vector(0))
-        """
-        total_load = f"""
-        (
-            sum(
+    replicas_filter_terms = (
+        f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)'"
+    )
+    deployment_labels_filter_terms = f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)',label_paasta_yelp_com_service='<<index .LabelValuesByName \"paasta_service\">>',label_paasta_yelp_com_instance='<<index .LabelValuesByName \"paasta_instance\">>'"
+    missing_instances = f"""
+        (clamp_min(
+            label_replace(
+                kube_deployment_status_replicas_ready{{{replicas_filter_terms}}}
+                * on (deployment)
+                kube_deployment_labels{{{deployment_labels_filter_terms}}},
+                "kube_deployment", "$1", "deployment", "(.*)")
+            - on (kube_deployment)
+            count by (kube_deployment) (
                 {load_per_instance}
-            ) by (kube_deployment)
-            + ignoring(kube_deployment) group_left()
-            {missing_instances}
-        )
-        """
-    else:
-        ready_pods = f"""
-            (sum(
-                k8s:deployment:pods_status_ready{{{worker_filter_terms}}} >= 0
-                or
-                max_over_time(
-                    k8s:deployment:pods_status_ready{{{worker_filter_terms}}}[{DEFAULT_EXTRAPOLATION_TIME}s]
-                )
-            ) by (kube_deployment))
-        """
-        missing_instances = f"""
-            clamp_min(
-                {ready_pods} - count({load_per_instance}) by (kube_deployment),
-                0
-            )
-        """
-        total_load = f"""
-        (
-            sum(
-                {load_per_instance}
-            ) by (kube_deployment)
-            +
-            {missing_instances}
-        )
-        """
+            ),
+            0
+        ) or on() vector(0))
+    """
+    total_load = f"""
+    (
+        sum(
+            {load_per_instance}
+        ) by (kube_deployment)
+        + ignoring(kube_deployment) group_left()
+        {missing_instances}
+    )
+    """
 
     total_load_smoothed = f"""
         avg_over_time(
@@ -1059,83 +1030,45 @@ def create_shared_uwsgi_scaling_rule(
     )
     worker_filter_terms = f"paasta_cluster='{paasta_cluster}',paasta_service='<<index .LabelValuesByName \"paasta_service\">>',paasta_instance='<<index .LabelValuesByName \"paasta_instance\">>',kube_deployment='<<index .LabelValuesByName \"kube_deployment\">>'"
 
-    use_raw_ksm_queries = load_system_paasta_config().get_use_raw_ksm_queries()
-
     load_per_instance = f"""
         avg(
             uwsgi_worker_busy{{{worker_filter_terms}}}
         ) by (kube_pod, kube_deployment)
     """
-    if use_raw_ksm_queries:
-        replicas_filter_terms = (
-            f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)'"
-        )
-        deployment_labels_filter_terms = f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)',label_paasta_yelp_com_service='<<index .LabelValuesByName \"paasta_service\">>',label_paasta_yelp_com_instance='<<index .LabelValuesByName \"paasta_instance\">>'"
-        ready_replicas = f"""
+    replicas_filter_terms = (
+        f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)'"
+    )
+    deployment_labels_filter_terms = f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)',label_paasta_yelp_com_service='<<index .LabelValuesByName \"paasta_service\">>',label_paasta_yelp_com_instance='<<index .LabelValuesByName \"paasta_instance\">>'"
+    ready_replicas = f"""
+        label_replace(
+            kube_deployment_status_replicas_ready{{{replicas_filter_terms}}}
+            * on (deployment)
+            kube_deployment_labels{{{deployment_labels_filter_terms}}},
+            "kube_deployment", "$1", "deployment", "(.*)")
+    """
+    missing_instances = f"""
+        (clamp_min(
             label_replace(
                 kube_deployment_status_replicas_ready{{{replicas_filter_terms}}}
                 * on (deployment)
                 kube_deployment_labels{{{deployment_labels_filter_terms}}},
                 "kube_deployment", "$1", "deployment", "(.*)")
-        """
-        missing_instances = f"""
-            (clamp_min(
-                label_replace(
-                    kube_deployment_status_replicas_ready{{{replicas_filter_terms}}}
-                    * on (deployment)
-                    kube_deployment_labels{{{deployment_labels_filter_terms}}},
-                    "kube_deployment", "$1", "deployment", "(.*)")
-                - on (kube_deployment)
-                count by (kube_deployment) (
-                    {load_per_instance}
-                ),
-                0
-            ) or on() vector(0))
-        """
-        total_load = f"""
-        (
-            sum(
+            - on (kube_deployment)
+            count by (kube_deployment) (
                 {load_per_instance}
-            ) by (kube_deployment)
-            + ignoring(kube_deployment) group_left()
-            {missing_instances}
-        )
-        """
-    else:
-        replica_filter_terms = f"paasta_cluster='{paasta_cluster}',kube_deployment='<<index .LabelValuesByName \"kube_deployment\">>',namespace='<<index .LabelValuesByName \"kube_namespace\">>'"
-        ready_pods = f"""
-            (sum(
-                k8s:deployment:pods_status_ready{{{worker_filter_terms}}} >= 0
-                or
-                max_over_time(
-                    k8s:deployment:pods_status_ready{{{worker_filter_terms}}}[{DEFAULT_EXTRAPOLATION_TIME}s]
-                )
-            ) by (kube_deployment))
-        """
-        ready_replicas = f"""
-            (sum(
-                k8s:deployment:pods_status_ready{{{replica_filter_terms}}} >= 0
-                or
-                max_over_time(
-                    k8s:deployment:pods_status_ready{{{replica_filter_terms}}}[{DEFAULT_EXTRAPOLATION_TIME}s]
-                )
-            ) by (kube_deployment))
-        """
-        missing_instances = f"""
-            clamp_min(
-                {ready_pods} - count({load_per_instance}) by (kube_deployment),
-                0
-            )
-        """
-        total_load = f"""
-        (
-            sum(
-                {load_per_instance}
-            ) by (kube_deployment)
-            +
-            {missing_instances}
-        )
-        """
+            ),
+            0
+        ) or on() vector(0))
+    """
+    total_load = f"""
+    (
+        sum(
+            {load_per_instance}
+        ) by (kube_deployment)
+        + ignoring(kube_deployment) group_left()
+        {missing_instances}
+    )
+    """
 
     desired_instances = f"""
         avg_over_time(
@@ -1165,8 +1098,6 @@ def create_shared_piscina_scaling_rule(
     worker_filter_terms = f"paasta_cluster='{paasta_cluster}',paasta_service='<<index .LabelValuesByName \"paasta_service\">>',paasta_instance='<<index .LabelValuesByName \"paasta_instance\">>',kube_deployment='<<index .LabelValuesByName \"kube_deployment\">>'"
     replica_filter_terms = f"paasta_cluster='{paasta_cluster}',deployment='<<index .LabelValuesByName \"kube_deployment\">>',namespace='<<index .LabelValuesByName \"kube_namespace\">>'"
 
-    use_raw_ksm_queries = load_system_paasta_config().get_use_raw_ksm_queries()
-
     current_replicas = f"""
         sum(
             label_join(
@@ -1184,59 +1115,33 @@ def create_shared_piscina_scaling_rule(
     load_per_instance = f"""
         (piscina_pool_utilization{{{worker_filter_terms}}})
     """
-    if use_raw_ksm_queries:
-        replicas_filter_terms = (
-            f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)'"
-        )
-        deployment_labels_filter_terms = f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)',label_paasta_yelp_com_service='<<index .LabelValuesByName \"paasta_service\">>',label_paasta_yelp_com_instance='<<index .LabelValuesByName \"paasta_instance\">>'"
-        missing_instances = f"""
-            (clamp_min(
-                label_replace(
-                    kube_deployment_status_replicas_ready{{{replicas_filter_terms}}}
-                    * on (deployment)
-                    kube_deployment_labels{{{deployment_labels_filter_terms}}},
-                    "kube_deployment", "$1", "deployment", "(.*)")
-                - on (kube_deployment)
-                count by (kube_deployment) (
-                    {load_per_instance}
-                ),
-                0
-            ) or on() vector(0))
-        """
-        total_load = f"""
-        (
-            sum(
+    replicas_filter_terms = (
+        f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)'"
+    )
+    deployment_labels_filter_terms = f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)',label_paasta_yelp_com_service='<<index .LabelValuesByName \"paasta_service\">>',label_paasta_yelp_com_instance='<<index .LabelValuesByName \"paasta_instance\">>'"
+    missing_instances = f"""
+        (clamp_min(
+            label_replace(
+                kube_deployment_status_replicas_ready{{{replicas_filter_terms}}}
+                * on (deployment)
+                kube_deployment_labels{{{deployment_labels_filter_terms}}},
+                "kube_deployment", "$1", "deployment", "(.*)")
+            - on (kube_deployment)
+            count by (kube_deployment) (
                 {load_per_instance}
-            ) by (kube_deployment)
-            + ignoring(kube_deployment) group_left()
-            {missing_instances}
-        )
-        """
-    else:
-        ready_pods = f"""
-            (sum(
-                k8s:deployment:pods_status_ready{{{worker_filter_terms}}} >= 0
-                or
-                max_over_time(
-                    k8s:deployment:pods_status_ready{{{worker_filter_terms}}}[{DEFAULT_EXTRAPOLATION_TIME}s]
-                )
-            ) by (kube_deployment))
-        """
-        missing_instances = f"""
-            clamp_min(
-                {ready_pods} - count({load_per_instance}) by (kube_deployment),
-                0
-            )
-        """
-        total_load = f"""
-        (
-            sum(
-                {load_per_instance}
-            ) by (kube_deployment)
-            +
-            {missing_instances}
-        )
-        """
+            ),
+            0
+        ) or on() vector(0))
+    """
+    total_load = f"""
+    (
+        sum(
+            {load_per_instance}
+        ) by (kube_deployment)
+        + ignoring(kube_deployment) group_left()
+        {missing_instances}
+    )
+    """
 
     desired_instances = f"""
         avg_over_time(
@@ -1266,8 +1171,6 @@ def create_shared_gunicorn_scaling_rule(
     worker_filter_terms = f"paasta_cluster='{paasta_cluster}',paasta_service='<<index .LabelValuesByName \"paasta_service\">>',paasta_instance='<<index .LabelValuesByName \"paasta_instance\">>',kube_deployment='<<index .LabelValuesByName \"kube_deployment\">>'"
     replica_filter_terms = f"paasta_cluster='{paasta_cluster}',deployment='<<index .LabelValuesByName \"kube_deployment\">>',namespace='<<index .LabelValuesByName \"kube_namespace\">>'"
 
-    use_raw_ksm_queries = load_system_paasta_config().get_use_raw_ksm_queries()
-
     current_replicas = f"""
         sum(
             label_join(
@@ -1287,59 +1190,33 @@ def create_shared_gunicorn_scaling_rule(
             gunicorn_worker_busy{{{worker_filter_terms}}}
         ) by (kube_pod, kube_deployment)
     """
-    if use_raw_ksm_queries:
-        replicas_filter_terms = (
-            f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)'"
-        )
-        deployment_labels_filter_terms = f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)',label_paasta_yelp_com_service='<<index .LabelValuesByName \"paasta_service\">>',label_paasta_yelp_com_instance='<<index .LabelValuesByName \"paasta_instance\">>'"
-        missing_instances = f"""
-            (clamp_min(
-                label_replace(
-                    kube_deployment_status_replicas_ready{{{replicas_filter_terms}}}
-                    * on (deployment)
-                    kube_deployment_labels{{{deployment_labels_filter_terms}}},
-                    "kube_deployment", "$1", "deployment", "(.*)")
-                - on (kube_deployment)
-                count by (kube_deployment) (
-                    {load_per_instance}
-                ),
-                0
-            ) or on() vector(0))
-        """
-        total_load = f"""
-        (
-            sum(
+    replicas_filter_terms = (
+        f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)'"
+    )
+    deployment_labels_filter_terms = f"paasta_cluster='{paasta_cluster}',namespace=~'(paasta|paastasvc-.*)',label_paasta_yelp_com_service='<<index .LabelValuesByName \"paasta_service\">>',label_paasta_yelp_com_instance='<<index .LabelValuesByName \"paasta_instance\">>'"
+    missing_instances = f"""
+        (clamp_min(
+            label_replace(
+                kube_deployment_status_replicas_ready{{{replicas_filter_terms}}}
+                * on (deployment)
+                kube_deployment_labels{{{deployment_labels_filter_terms}}},
+                "kube_deployment", "$1", "deployment", "(.*)")
+            - on (kube_deployment)
+            count by (kube_deployment) (
                 {load_per_instance}
-            ) by (kube_deployment)
-            + ignoring(kube_deployment) group_left()
-            {missing_instances}
-        )
-        """
-    else:
-        ready_pods = f"""
-            (sum(
-                k8s:deployment:pods_status_ready{{{worker_filter_terms}}} >= 0
-                or
-                max_over_time(
-                    k8s:deployment:pods_status_ready{{{worker_filter_terms}}}[{DEFAULT_EXTRAPOLATION_TIME}s]
-                )
-            ) by (kube_deployment))
-        """
-        missing_instances = f"""
-            clamp_min(
-                {ready_pods} - count({load_per_instance}) by (kube_deployment),
-                0
-            )
-        """
-        total_load = f"""
-        (
-            sum(
-                {load_per_instance}
-            ) by (kube_deployment)
-            +
-            {missing_instances}
-        )
-        """
+            ),
+            0
+        ) or on() vector(0))
+    """
+    total_load = f"""
+    (
+        sum(
+            {load_per_instance}
+        ) by (kube_deployment)
+        + ignoring(kube_deployment) group_left()
+        {missing_instances}
+    )
+    """
 
     desired_instances = f"""
         avg_over_time(

--- a/paasta_tools/utils.py
+++ b/paasta_tools/utils.py
@@ -2056,7 +2056,6 @@ class SystemPaastaConfigDict(TypedDict, total=False):
     readonly_docker_registry_auth_file: str
     private_docker_registries: List[str]
     unhealthy_pod_eviction_policy: str
-    use_raw_ksm_queries: bool
 
 
 def load_system_paasta_config(
@@ -2821,9 +2820,6 @@ class SystemPaastaConfig:
 
     def get_enable_cost_owner_label(self) -> bool:
         return self.config_dict.get("enable_cost_owner_label", False)
-
-    def get_use_raw_ksm_queries(self) -> bool:
-        return self.config_dict.get("use_raw_ksm_queries", False)
 
     def get_remote_run_duration_limit(self, default: int) -> int:
         return self.config_dict.get("remote_run_duration_limit", default)

--- a/tests/test_setup_prometheus_adapter_config.py
+++ b/tests/test_setup_prometheus_adapter_config.py
@@ -431,52 +431,7 @@ def test_create_shared_scaling_rule(
     paasta_cluster = "test_cluster"
     moving_average_window = 20120302
 
-    with mock.patch(
-        "paasta_tools.setup_prometheus_adapter_config.load_system_paasta_config",
-        autospec=True,
-    ) as mock_config:
-        mock_config.return_value.get_use_raw_ksm_queries.return_value = False
-        rule = rule_func(paasta_cluster, moving_average_window)
-
-    assert str(moving_average_window) in rule["metricsQuery"]
-    assert paasta_cluster in rule["seriesQuery"]
-    assert expected_series_metric in rule["seriesQuery"]
-    assert rule["name"]["as"] == f"{expected_name_prefix}-{moving_average_window}"
-    assert (
-        "<<index .LabelValuesByName" in rule["metricsQuery"]
-        or LABEL_MATCHERS in rule["metricsQuery"]
-    )
-    # no hardcoded service/instance values — only template references
-    assert "paasta_service='" not in rule["metricsQuery"].replace(
-        "paasta_service='<<index .LabelValuesByName", ""
-    )
-
-
-@pytest.mark.parametrize(
-    "rule_func,expected_series_metric,expected_name_prefix",
-    [
-        (create_shared_uwsgi_v2_scaling_rule, "uwsgi_worker_busy", "uwsgi-v2-prom"),
-        (create_shared_uwsgi_scaling_rule, "uwsgi_worker_busy", "uwsgi-prom"),
-        (
-            create_shared_piscina_scaling_rule,
-            "piscina_pool_utilization",
-            "piscina-prom",
-        ),
-        (create_shared_gunicorn_scaling_rule, "gunicorn_worker_busy", "gunicorn-prom"),
-    ],
-)
-def test_create_shared_scaling_rule_with_raw_ksm_queries(
-    rule_func, expected_series_metric, expected_name_prefix
-) -> None:
-    paasta_cluster = "test_cluster"
-    moving_average_window = 20120302
-
-    with mock.patch(
-        "paasta_tools.setup_prometheus_adapter_config.load_system_paasta_config",
-        autospec=True,
-    ) as mock_config:
-        mock_config.return_value.get_use_raw_ksm_queries.return_value = True
-        rule = rule_func(paasta_cluster, moving_average_window)
+    rule = rule_func(paasta_cluster, moving_average_window)
 
     assert str(moving_average_window) in rule["metricsQuery"]
     assert paasta_cluster in rule["seriesQuery"]
@@ -486,6 +441,10 @@ def test_create_shared_scaling_rule_with_raw_ksm_queries(
     assert "kube_deployment_status_replicas_ready" in rule["metricsQuery"]
     assert "kube_deployment_labels" in rule["metricsQuery"]
     assert "k8s:deployment:pods_status_ready" not in rule["metricsQuery"]
+    # no hardcoded service/instance values — only template references
+    assert "paasta_service='" not in rule["metricsQuery"].replace(
+        "paasta_service='<<index .LabelValuesByName", ""
+    )
 
 
 def _make_instance_config(


### PR DESCRIPTION
Th ksm raw queries was already rolled out to all environments but rolled back when the rollout flags were removed incorrectly. This should roll out this change to all environments.

After this merge, then clean up in Puppet: https://github.yelpcorp.com/sysgit/puppet/pull/16949