### PR TITLE
Upgrade paasta to python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
       fail-fast: false
       matrix:
         toxenv:
-          - py310-linux
+          - py311-linux
           - docs
           - tests
           - general_itests
@@ -29,7 +29,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-gha.txt
       - run: tox -e ${{ matrix.toxenv }}
@@ -43,7 +43,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - run: python -m pip install --upgrade pip virtualenv
       - run: curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && chmod +x kubectl && sudo mv kubectl /usr/local/bin/
       - run: python -m pip install --upgrade pip
@@ -59,7 +59,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - run: sudo apt-get update
       - run: sudo apt-get install -yq devscripts
       - run: make itest_${{ matrix.dist }}

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         toxenv:
-          - py310-linux,docs,tests
+          - py311-linux,docs,tests
           - general_itests
     env:
       DOCKER_REGISTRY: ""
@@ -23,7 +23,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - run: python -m pip install --upgrade pip
       - run: pip install -r requirements-gha.txt
       - run: tox -e ${{ matrix.toxenv }}
@@ -37,7 +37,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-python@v2
         with:
-          python-version: '3.10'
+          python-version: '3.11'
       - run: pip install build
       # this will create both a source distribution and a wheel
       - run: python -m build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 ---
 default_language_version:
-    python: python3.10
+    python: python3.11
 repos:
 -   repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v2.1.0
@@ -40,7 +40,7 @@ repos:
     rev: 22.3.0
     hooks:
     -   id: black
-        args: ['--target-version', 'py310']
+        args: ['--target-version', 'py311']
         exclude: ^paasta_tools/paastaapi
 -   repo: https://github.com/PyCQA/flake8
     rev: 7.3.0

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -37,7 +37,7 @@ repos:
         args: [--py36-plus]
         exclude: ^paasta_tools/paastaapi
 -   repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
     -   id: black
         args: ['--target-version', 'py311']

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -8,7 +8,7 @@ version: 2
 build:
   os: ubuntu-22.04
   tools:
-    python: "3.10"
+    python: "3.11"
     # You can also specify other tool versions:
     # nodejs: "20"
     # rust: "1.70"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -14,7 +14,7 @@ make dev           # create virtualenv via tox
 make install-hooks # pre-commit hooks
 ```
 
-Tox manages virtualenvs in `.tox/py310-linux/`. Use `tox` or `make` targets to ensure the env is built.
+Tox manages virtualenvs in `.tox/py311-linux/`. Use `tox` or `make` targets to ensure the env is built.
 
 ## Dependencies
 - Follow the application-style pinning model from requirements-tools: https://github.com/YelpArchive/requirements-tools
@@ -30,7 +30,7 @@ Tox manages virtualenvs in `.tox/py310-linux/`. Use `tox` or `make` targets to e
 ## Testing
 ```bash
 # Iterate with pytest directly
-.tox/py310-linux/bin/pytest tests/path/to/test_foo.py -x
+.tox/py311-linux/bin/pytest tests/path/to/test_foo.py -x
 
 # Full suite before committing
 make test         # pre-commit, mypy, pytest, coverage
@@ -50,11 +50,11 @@ Style is enforced by pre-commit (black, flake8, import ordering) and mypy.
 
 ```bash
 # Iterate on specific files
-.tox/py310-linux/bin/pre-commit run --files path/to/file.py
-.tox/py310-linux/bin/mypy path/to/file.py
+.tox/py311-linux/bin/pre-commit run --files path/to/file.py
+.tox/py311-linux/bin/mypy path/to/file.py
 
 # Check all staged files
-.tox/py310-linux/bin/pre-commit run
+.tox/py311-linux/bin/pre-commit run
 
 # Full check
 make test

--- a/Makefile
+++ b/Makefile
@@ -39,7 +39,7 @@ endif
 .PHONY: all docs test itest k8s_itests quick-test
 
 PIPX ?= pipx
-PYTHON ?= python3.10
+PYTHON ?= python3.11
 VIRTUALENV ?= $(shell if [ -n "$$PIPX_BIN_DIR" ]; then echo "$$PIPX_BIN_DIR/virtualenv"; else echo "$$HOME/.local/bin/virtualenv"; fi)
 
 dev: .paasta/bin/activate
@@ -61,13 +61,13 @@ test-yelpy: .paasta/bin/activate
 test-not-yelpy: .paasta/bin/activate
 	.paasta/bin/tox -e tests
 
-quick-test: .tox/py310-linux
-	TZ=UTC .tox/py310-linux/bin/py.test --failed-first -x --disable-warnings -- tests
+quick-test: .tox/py311-linux
+	TZ=UTC .tox/py311-linux/bin/py.test --failed-first -x --disable-warnings -- tests
 
-.tox/py310-linux: .paasta/bin/activate
+.tox/py311-linux: .paasta/bin/activate
 	.paasta/bin/tox
 
-dev-api: .tox/py310-linux
+dev-api: .tox/py311-linux
 	.paasta/bin/tox -e dev-api
 
 .paasta/bin/activate: requirements.txt requirements-dev.txt
@@ -113,11 +113,11 @@ k8s_itests: .paasta/bin/activate
 	make -C k8s_itests all
 
 .PHONY: k8s_fake_cluster
-k8s_fake_cluster: .tox/py310-linux | etc_paasta_playground soa_config_playground
+k8s_fake_cluster: .tox/py311-linux | etc_paasta_playground soa_config_playground
 	make -C k8s_itests .fake_cluster
 
 .PHONY: k8s_recreate_cluster
-k8s_recreate_cluster: .tox/py310-linux | etc_paasta_playground soa_config_playground
+k8s_recreate_cluster: .tox/py311-linux | etc_paasta_playground soa_config_playground
 	make -C k8s_itests recreate_cluster
 
 .PHONY: k8s_clean
@@ -148,25 +148,25 @@ swagger-validate:
 		-i paasta_tools/api/api_docs/swagger.json
 
 .PHONY: vscode_settings
-vscode_settings: .paasta/bin/activate .tox/py310-linux
+vscode_settings: .paasta/bin/activate .tox/py311-linux
 	.paasta/bin/python paasta_tools/contrib/ide_helper.py
 
-etc_paasta_playground soa_config_playground: .paasta/bin/activate .tox/py310-linux
-	.tox/py310-linux/bin/python paasta_tools/contrib/create_paasta_playground.py
+etc_paasta_playground soa_config_playground: .paasta/bin/activate .tox/py311-linux
+	.tox/py311-linux/bin/python paasta_tools/contrib/create_paasta_playground.py
 
 .PHONY: generate_deployments_for_service
 # TODO: Restore `paasta_tools.cli.cli list -a` once it works without a running API/zookeeper.
 # Currently it fails with KazooTimeoutError in the playground because there's no ZK.
 # Using `find` as a workaround to enumerate services from the filesystem directly.
-generate_deployments_for_service: | soa_config_playground .tox/py310-linux
+generate_deployments_for_service: | soa_config_playground .tox/py311-linux
 	export KUBECONFIG=./k8s_itests/kubeconfig;\
 	export PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_playground/;\
 	export PAASTA_TEST_CLUSTER=kind-${USER}-k8s-test;\
 	find ./soa_config_playground -mindepth 1 -maxdepth 1 -type d -printf '%f\n' | shuf | xargs -n 1 --no-run-if-empty \
-	.tox/py310-linux/bin/python -m paasta_tools.generate_deployments_for_service -d ./soa_config_playground -v -s
+	.tox/py311-linux/bin/python -m paasta_tools.generate_deployments_for_service -d ./soa_config_playground -v -s
 
 .PHONY: playground-api
-playground-api: .tox/py310-linux | soa_config_playground
+playground-api: .tox/py311-linux | soa_config_playground
 	.paasta/bin/tox -e playground-api
 
 .PHONY: setup-kubernetes-job
@@ -174,21 +174,21 @@ setup-kubernetes-job: k8s_fake_cluster generate_deployments_for_service
 	export KUBECONFIG=./k8s_itests/kubeconfig;\
 	export PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_playground/;\
 	export PAASTA_TEST_CLUSTER=kind-${USER}-k8s-test;\
-	.tox/py310-linux/bin/python -m paasta_tools.list_kubernetes_service_instances -d ./soa_config_playground --shuffle --group-lines 1 | xargs --no-run-if-empty .tox/py310-linux/bin/python -m paasta_tools.setup_kubernetes_job -d ./soa_config_playground -c kind-${USER}-k8s-test
+	.tox/py311-linux/bin/python -m paasta_tools.list_kubernetes_service_instances -d ./soa_config_playground --shuffle --group-lines 1 | xargs --no-run-if-empty .tox/py311-linux/bin/python -m paasta_tools.setup_kubernetes_job -d ./soa_config_playground -c kind-${USER}-k8s-test
 
 .PHONY: cleanup-kubernetes-jobs
 cleanup-kubernetes-jobs:
 	export KUBECONFIG=./k8s_itests/kubeconfig;\
 	export PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_playground/;\
 	export PAASTA_TEST_CLUSTER=kind-${USER}-k8s-test;\
-	.tox/py310-linux/bin/python -m paasta_tools.cleanup_kubernetes_jobs -d ./soa_config_playground -c kind-${USER}-k8s-test --force
+	.tox/py311-linux/bin/python -m paasta_tools.cleanup_kubernetes_jobs -d ./soa_config_playground -c kind-${USER}-k8s-test --force
 
 .PHONY: paasta-secrets-sync
 paasta-secrets-sync: setup-kubernetes-job .vault-token
 	export KUBECONFIG=./k8s_itests/kubeconfig;\
 	export PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_playground/;\
 	export PAASTA_TEST_CLUSTER=kind-${USER}-k8s-test;\
-	{ .tox/py310-linux/bin/python -m paasta_tools.list_kubernetes_service_instances -d ./soa_config_playground ; echo -n \ _shared; } | cut -f1 -d"." | uniq | shuf | xargs .tox/py310-linux/bin/python -m paasta_tools.kubernetes.bin.paasta_secrets_sync -v -d ./soa_config_playground -t ./.vault-token
+	{ .tox/py311-linux/bin/python -m paasta_tools.list_kubernetes_service_instances -d ./soa_config_playground ; echo -n \ _shared; } | cut -f1 -d"." | uniq | shuf | xargs .tox/py311-linux/bin/python -m paasta_tools.kubernetes.bin.paasta_secrets_sync -v -d ./soa_config_playground -t ./.vault-token
 
 define ANNOUNCE_CRONS_BODY
 The following PaaSTA cron jobs will run on an infinite loop using the PaaSTA Playground k8s cluster:
@@ -214,16 +214,16 @@ setup-kubernetes-cr:
 	export KUBECONFIG=./k8s_itests/kubeconfig;\
 	export PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_playground/;\
 	export PAASTA_TEST_CLUSTER=kind-${USER}-k8s-test;\
-	.tox/py310-linux/bin/python -m paasta_tools.setup_kubernetes_cr -d ./soa_config_playground -c kind-${USER}-k8s-test
+	.tox/py311-linux/bin/python -m paasta_tools.setup_kubernetes_cr -d ./soa_config_playground -c kind-${USER}-k8s-test
 
 .PHONY: setup-flink
 setup-flink: setup-kubernetes-job
 	export KUBECONFIG=./k8s_itests/kubeconfig;\
 	export PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_playground/;\
 	export PAASTA_TEST_CLUSTER=kind-${USER}-k8s-test;\
-	.tox/py310-linux/bin/python -m paasta_tools.setup_kubernetes_crd -d ./soa_config_playground -c kind-${USER}-k8s-test flink-operator;\
+	.tox/py311-linux/bin/python -m paasta_tools.setup_kubernetes_crd -d ./soa_config_playground -c kind-${USER}-k8s-test flink-operator;\
 	KUBECONFIG=./k8s_itests/kubeconfig kubectl apply -f k8s_itests/flink/;\
-	.tox/py310-linux/bin/python -m paasta_tools.setup_kubernetes_cr -d ./soa_config_playground -c kind-${USER}-k8s-test
+	.tox/py311-linux/bin/python -m paasta_tools.setup_kubernetes_cr -d ./soa_config_playground -c kind-${USER}-k8s-test
 
 .PHONY: clean-playground
 clean-playground:

--- a/debian/control
+++ b/debian/control
@@ -2,11 +2,11 @@ Source: paasta-tools
 Section: python
 Priority: optional
 Maintainer: Compute Infrastructure <compute-infra@yelp.com>
-Build-Depends: debhelper (>= 7), python3.10, dh-virtualenv
+Build-Depends: debhelper (>= 7), python3.11, dh-virtualenv
 Standards-Version: 3.8.3
 
 Package: paasta-tools
 Architecture: any
-Depends: python3.10, ${shlibs:Depends}, ${misc:Depends}
+Depends: python3.11, ${shlibs:Depends}, ${misc:Depends}
 Description: CLI tools for PaaSTA
 Conflicts: service-deployment-tools

--- a/debian/rules
+++ b/debian/rules
@@ -20,11 +20,11 @@ DH_VIRTUALENV_INSTALL_ROOT=/opt/venvs
 DH_VENV_DIR=debian/$(PACKAGE)$(DH_VIRTUALENV_INSTALL_ROOT)/$(PACKAGE)
 override_dh_virtualenv:
 	dh_virtualenv \
-        --python=/usr/bin/python3.10 \
+        --python=/usr/bin/python3.11 \
 		--preinstall=-rrequirements-bootstrap.txt
 	cp yelp_package/gopath/paasta_go $(DH_VENV_DIR)/bin/paasta_go
 	@echo patching k8s client lib
-	patch $(DH_VENV_DIR)/lib/python3.10/site-packages/kubernetes/client/api_client.py contrib/python-k8s-client.diff
+	patch $(DH_VENV_DIR)/lib/python3.11/site-packages/kubernetes/client/api_client.py contrib/python-k8s-client.diff
 
 override_dh_shlibdeps:
 	# pylibmc manylinux bundle libraries fail unless this is passed.

--- a/docs/source/contributing.rst
+++ b/docs/source/contributing.rst
@@ -7,7 +7,7 @@ Running The Tests
 Unit Tests
 ^^^^^^^^^^
 
-Python 3.10 and virtualenv are required for running the unit tests. You can simply run
+Python 3.11 and virtualenv are required for running the unit tests. You can simply run
 ``make test`` to execute them.
 
 This will build a virtualenv with the required python packages, then run the tests
@@ -16,7 +16,7 @@ written in the ``tests`` directory.
 Integration Tests
 ^^^^^^^^^^^^^^^^^
 
-Python 3.10, virtualenv, and Docker are required to run the integration test suite.
+Python 3.11, virtualenv, and Docker are required to run the integration test suite.
 You can run ``make itest`` to execute them.
 
 System Package Building / itests

--- a/docs/source/paasta_development.rst
+++ b/docs/source/paasta_development.rst
@@ -66,7 +66,7 @@ Steps below outline running PaaSTA playground components with a debugger attache
 
    .. sourcecode:: shell
 
-      (py310-linux) user@dev55-uswest1adevc:~/pg/paasta$ KUBECONFIG=./k8s_itests/kubeconfig kubectl get pods -n paasta
+      (py311-linux) user@dev55-uswest1adevc:~/pg/paasta$ KUBECONFIG=./k8s_itests/kubeconfig kubectl get pods -n paasta
       NAME                                                      READY   STATUS    RESTARTS   AGE
       compute-infra-test-service-autoscaling-6fdf96b485-2fkd5   1/1     Running   0          25s
       compute-infra-test-service-autoscaling-6fdf96b485-44lqp   1/1     Running   0          25s

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,5 +1,5 @@
 [mypy]
-python_version = 3.10
+python_version = 3.11
 check_untyped_defs = False
 warn_incomplete_stub = True
 show_error_codes = True

--- a/paasta_tools/contrib/bounce_log_latency_parser.py
+++ b/paasta_tools/contrib/bounce_log_latency_parser.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.10
+#!/usr/bin/env python3.11
 import itertools
 import json
 import sys

--- a/paasta_tools/contrib/ide_helper.py
+++ b/paasta_tools/contrib/ide_helper.py
@@ -53,12 +53,12 @@ def install_vscode_support() -> None:
                 "python": "${workspaceFolder}/.paasta/bin/python",
                 "program": "${workspaceFolder}/.paasta/bin/tox",
                 "subProcess": True,
-                "args": ["-e", "py310-linux,docs,mypy,tests"],
+                "args": ["-e", "py311-linux,docs,mypy,tests"],
             },
             {
                 "name": "paasta cli",
                 "cwd": "${workspaceFolder}",
-                "python": "${workspaceFolder}/.tox/py310-linux/bin/python",
+                "python": "${workspaceFolder}/.tox/py311-linux/bin/python",
                 "type": "debugpy",
                 "request": "launch",
                 "module": "paasta_tools.cli.cli",
@@ -66,7 +66,7 @@ def install_vscode_support() -> None:
             {
                 "name": "paasta rollback",
                 "cwd": "${workspaceFolder}",
-                "python": "${workspaceFolder}/.tox/py310-linux/bin/python",
+                "python": "${workspaceFolder}/.tox/py311-linux/bin/python",
                 "type": "debugpy",
                 "request": "launch",
                 "module": "paasta_tools.cli.cli",
@@ -83,7 +83,7 @@ def install_vscode_support() -> None:
             {
                 "name": "paasta mark-for-deployment",
                 "cwd": "${workspaceFolder}",
-                "python": "${workspaceFolder}/.tox/py310-linux/bin/python",
+                "python": "${workspaceFolder}/.tox/py311-linux/bin/python",
                 "type": "debugpy",
                 "request": "launch",
                 "module": "paasta_tools.cli.cli",
@@ -101,7 +101,7 @@ def install_vscode_support() -> None:
             {
                 "name": "paasta status",
                 "cwd": "${workspaceFolder}",
-                "python": "${workspaceFolder}/.tox/py310-linux/bin/python",
+                "python": "${workspaceFolder}/.tox/py311-linux/bin/python",
                 "type": "debugpy",
                 "request": "launch",
                 "module": "paasta_tools.cli.cli",
@@ -118,7 +118,7 @@ def install_vscode_support() -> None:
             {
                 "name": "paasta playground",
                 "cwd": "${workspaceFolder}",
-                "python": "${workspaceFolder}/.tox/py310-linux/bin/python",
+                "python": "${workspaceFolder}/.tox/py311-linux/bin/python",
                 "type": "debugpy",
                 "request": "launch",
                 "module": "paasta_tools.cli.cli",
@@ -138,7 +138,7 @@ def install_vscode_support() -> None:
             {
                 "name": "paasta status playground",
                 "cwd": "${workspaceFolder}",
-                "python": "${workspaceFolder}/.tox/py310-linux/bin/python",
+                "python": "${workspaceFolder}/.tox/py311-linux/bin/python",
                 "type": "debugpy",
                 "request": "launch",
                 "module": "paasta_tools.cli.cli",
@@ -157,7 +157,7 @@ def install_vscode_support() -> None:
             {
                 "name": "paasta logs",
                 "cwd": "${workspaceFolder}",
-                "python": "${workspaceFolder}/.tox/py310-linux/bin/python",
+                "python": "${workspaceFolder}/.tox/py311-linux/bin/python",
                 "type": "debugpy",
                 "request": "launch",
                 "module": "paasta_tools.cli.cli",
@@ -175,7 +175,7 @@ def install_vscode_support() -> None:
                 "name": "paasta validate",
                 # This command has to be ran from inside the service repo in yelpsoa-configs
                 "cwd": "${userHome}/pg/yelpsoa-configs/",
-                "python": "${workspaceFolder}/.tox/py310-linux/bin/python",
+                "python": "${workspaceFolder}/.tox/py311-linux/bin/python",
                 "type": "debugpy",
                 "request": "launch",
                 "module": "paasta_tools.cli.cli",
@@ -184,10 +184,10 @@ def install_vscode_support() -> None:
             {
                 # 1) Follow step 1 in "Running the PaaSTA HTTP API Locally" wiki
                 # 2) Run this "paasta API" test to debug paasta API
-                # 3) Run client command, e.g. PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_for_development/  .tox/py310-linux/bin/python paasta_tools/cli/cli.py status --clusters norcal-devc --service katamari_test_service
+                # 3) Run client command, e.g. PAASTA_SYSTEM_CONFIG_DIR=./etc_paasta_for_development/  .tox/py311-linux/bin/python paasta_tools/cli/cli.py status --clusters norcal-devc --service katamari_test_service
                 "name": "paasta API",
                 "cwd": "${workspaceFolder}",
-                "python": "${workspaceFolder}/.tox/py310-linux/bin/python",
+                "python": "${workspaceFolder}/.tox/py311-linux/bin/python",
                 "type": "debugpy",
                 "request": "launch",
                 "module": "paasta_tools.run-paasta-api-in-dev-mode",
@@ -203,7 +203,7 @@ def install_vscode_support() -> None:
             {
                 "name": "paasta API playground",
                 "cwd": "${workspaceFolder}",
-                "python": "${workspaceFolder}/.tox/py310-linux/bin/python",
+                "python": "${workspaceFolder}/.tox/py311-linux/bin/python",
                 "type": "debugpy",
                 "request": "launch",
                 "module": "paasta_tools.run-paasta-api-playground",
@@ -221,7 +221,7 @@ def install_vscode_support() -> None:
             {
                 "name": "Run setup k8s job in playground",
                 "cwd": "${workspaceFolder}",
-                "python": "${workspaceFolder}/.tox/py310-linux/bin/python",
+                "python": "${workspaceFolder}/.tox/py311-linux/bin/python",
                 "type": "debugpy",
                 "request": "launch",
                 "module": "paasta_tools.setup_kubernetes_job",
@@ -244,7 +244,7 @@ def install_vscode_support() -> None:
             {
                 "name": "Generate deployments.json in playground",
                 "cwd": "${workspaceFolder}",
-                "python": "${workspaceFolder}/.tox/py310-linux/bin/python",
+                "python": "${workspaceFolder}/.tox/py311-linux/bin/python",
                 "type": "debugpy",
                 "request": "launch",
                 "module": "paasta_tools.generate_deployments_for_service",

--- a/paasta_tools/contrib/mock_patch_checker.py
+++ b/paasta_tools/contrib/mock_patch_checker.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.10
+#!/usr/bin/env python3.11
 import ast
 import sys
 

--- a/paasta_tools/contrib/render_template.py
+++ b/paasta_tools/contrib/render_template.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3.10
+#!/usr/bin/env python3.11
 import argparse
 import os
 import re

--- a/paasta_tools/run-paasta-api-in-dev-mode.py
+++ b/paasta_tools/run-paasta-api-in-dev-mode.py
@@ -53,8 +53,8 @@ def main():
             api.main("dev-mode")
     else:
         os.execl(
-            ".tox/py310-linux/bin/python",
-            ".tox/py310-linux/bin/python",
+            ".tox/py311-linux/bin/python",
+            ".tox/py311-linux/bin/python",
             "-m",
             "paasta_tools.api.api",
             *["-D", "-c", cluster, str(port)],

--- a/paasta_tools/run-paasta-api-playground.py
+++ b/paasta_tools/run-paasta-api-playground.py
@@ -39,8 +39,8 @@ def main():
             api.main("dev-mode")
     else:
         os.execl(
-            ".tox/py310-linux/bin/python",
-            ".tox/py310-linux/bin/python",
+            ".tox/py311-linux/bin/python",
+            ".tox/py311-linux/bin/python",
             "-m",
             "paasta_tools.api.api",
             *["-D", "-c", cluster, str(port)],

--- a/paasta_tools/yaml_tools.py
+++ b/paasta_tools/yaml_tools.py
@@ -2,7 +2,7 @@ import sys
 
 import yaml
 
-# try and catch both /opt/venvs/paasta-tools and ~/pg/paasta/.tox/py310-linux as if we're being run as an application,
+# try and catch both /opt/venvs/paasta-tools and ~/pg/paasta/.tox/py311-linux as if we're being run as an application,
 # we likely want to fail on a potential slowdown rather than experience a performance regression
 if "paasta" in sys.prefix:
     from yaml import CSafeDumper as Dumper

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,7 +5,6 @@ coverage==6.5.0
 debugpy==1.8.0
 distlib==0.3.9
 docutils==0.12
-exceptiongroup==1.1.2
 filelock==3.20.3
 flake8==7.3.0
 freezegun==1.5.5
@@ -39,7 +38,6 @@ sphinxcontrib-htmlhelp==1.0.2
 sphinxcontrib-jsmath==1.0.1
 sphinxcontrib-qthelp==1.0.2
 sphinxcontrib-serializinghtml==1.1.3
-tomli==2.0.1
 tomli-w==1.2.0
 types-cachetools==6.0.0.20250525
 types-croniter==6.0.0.20250809

--- a/requirements.txt
+++ b/requirements.txt
@@ -63,7 +63,7 @@ ply==3.4
 progressbar2==4.3.2
 prometheus-client==0.7.1
 protobuf==3.15.0
-py==1.5.2
+py==1.11.0
 pyasn1==0.4.2
 pyasn1-modules==0.2.1
 pyformance==0.4

--- a/requirements.txt
+++ b/requirements.txt
@@ -49,7 +49,7 @@ manhole==1.5.0
 MarkupSafe==1.1.1
 monotonic==1.4
 msgpack-python==0.5.6
-multidict==4.7.6
+multidict==6.0.5
 mypy-extensions==1.0.0
 nats-py==2.8.0
 networkx==2.4
@@ -115,6 +115,6 @@ WebOb==1.8.7
 websocket-client==0.44.0
 ws4py==0.5.1
 wsgicors==0.7.0
-yarl==1.1.1
+yarl==1.9.3
 zope.deprecation==4.2.0
 zope.interface==7.2

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup(
     description="Tools for Yelps SOA infrastructure",
     packages=find_packages(exclude=("tests*", "scripts*")),
     include_package_data=True,
-    python_requires=">=3.10.0",
+    python_requires=">=3.11.0",
     install_requires=get_install_requires(),
     scripts=[
         "paasta_tools/apply_external_resources.py",

--- a/tests/cli/test_cmds_local_run.py
+++ b/tests/cli/test_cmds_local_run.py
@@ -249,7 +249,7 @@ def test_perform_http_healthcheck_failure_with_multiple_content_type(mock_http_c
 
 
 @mock.patch("paasta_tools.cli.cmds.local_run.perform_http_healthcheck", autospec=True)
-@mock.patch("time.sleep", autospec=True)
+@mock.patch("time.sleep", autospec=None)
 def test_run_healthcheck_http_success(mock_sleep, mock_perform_http_healthcheck):
     mock_docker_client = mock.MagicMock(spec_set=docker.APIClient)
     fake_container_id = "fake_container_id"
@@ -265,7 +265,7 @@ def test_run_healthcheck_http_success(mock_sleep, mock_perform_http_healthcheck)
 
 
 @mock.patch("paasta_tools.cli.cmds.local_run.perform_http_healthcheck", autospec=True)
-@mock.patch("time.sleep", autospec=True)
+@mock.patch("time.sleep", autospec=None)
 def test_run_healthcheck_http_fails(mock_sleep, mock_perform_http_healthcheck):
     mock_docker_client = mock.MagicMock(spec_set=docker.APIClient)
     fake_container_id = "fake_container_id"
@@ -281,7 +281,7 @@ def test_run_healthcheck_http_fails(mock_sleep, mock_perform_http_healthcheck):
 
 
 @mock.patch("paasta_tools.cli.cmds.local_run.perform_tcp_healthcheck", autospec=True)
-@mock.patch("time.sleep", autospec=True)
+@mock.patch("time.sleep", autospec=None)
 def test_run_healthcheck_tcp_success(mock_sleep, mock_perform_tcp_healthcheck):
     mock_docker_client = mock.MagicMock(spec_set=docker.APIClient)
     fake_container_id = "fake_container_id"
@@ -298,7 +298,7 @@ def test_run_healthcheck_tcp_success(mock_sleep, mock_perform_tcp_healthcheck):
 
 
 @mock.patch("paasta_tools.cli.cmds.local_run.perform_tcp_healthcheck", autospec=True)
-@mock.patch("time.sleep", autospec=True)
+@mock.patch("time.sleep", autospec=None)
 def test_run_healthcheck_tcp_fails(mock_sleep, mock_perform_tcp_healthcheck):
     mock_docker_client = mock.MagicMock(spec_set=docker.APIClient)
     fake_container_id = "fake_container_id"
@@ -315,7 +315,7 @@ def test_run_healthcheck_tcp_fails(mock_sleep, mock_perform_tcp_healthcheck):
 
 
 @mock.patch("paasta_tools.cli.cmds.local_run.perform_cmd_healthcheck", autospec=True)
-@mock.patch("time.sleep", autospec=True)
+@mock.patch("time.sleep", autospec=None)
 def test_run_healthcheck_cmd_success(mock_sleep, mock_perform_cmd_healthcheck):
     mock_docker_client = mock.MagicMock(spec_set=docker.APIClient)
     fake_container_id = "fake_container_id"
@@ -334,7 +334,7 @@ def test_run_healthcheck_cmd_success(mock_sleep, mock_perform_cmd_healthcheck):
 
 
 @mock.patch("paasta_tools.cli.cmds.local_run.perform_cmd_healthcheck", autospec=True)
-@mock.patch("time.sleep", autospec=True)
+@mock.patch("time.sleep", autospec=None)
 def test_run_healthcheck_cmd_fails(mock_sleep, mock_perform_cmd_healthcheck):
     mock_docker_client = mock.MagicMock(spec_set=docker.APIClient)
     fake_container_id = "fake_container_id"
@@ -1646,7 +1646,7 @@ def test_run_docker_container_with_user_specified_port(
     assert mock_execlpe.call_count == 1
 
 
-@mock.patch("time.sleep", autospec=True)
+@mock.patch("time.sleep", autospec=None)
 def test_simulate_healthcheck_on_service_disabled(mock_sleep):
     mock_docker_client = mock.MagicMock(spec_set=docker.APIClient)
     mock_service_manifest = mock.MagicMock(spec_set=KubernetesDeploymentConfig)
@@ -1663,7 +1663,7 @@ def test_simulate_healthcheck_on_service_disabled(mock_sleep):
     )
 
 
-@mock.patch("time.sleep", autospec=True)
+@mock.patch("time.sleep", autospec=None)
 @mock.patch(
     "paasta_tools.cli.cmds.local_run.run_healthcheck_on_container", autospec=True
 )
@@ -1692,7 +1692,7 @@ def test_simulate_healthcheck_on_service_enabled_success(
     )
 
 
-@mock.patch("time.sleep", autospec=True)
+@mock.patch("time.sleep", autospec=None)
 @mock.patch(
     "paasta_tools.cli.cmds.local_run.run_healthcheck_on_container", autospec=True
 )
@@ -1724,7 +1724,7 @@ def test_simulate_healthcheck_on_service_enabled_failure(
     assert actual is False
 
 
-@mock.patch("time.sleep", autospec=True)
+@mock.patch("time.sleep", autospec=None)
 @mock.patch(
     "paasta_tools.cli.cmds.local_run.run_healthcheck_on_container", autospec=True
 )
@@ -1763,8 +1763,8 @@ def test_simulate_healthcheck_on_service_enabled_partial_failure(
     assert mock_sleep.call_count == 4
 
 
-@mock.patch("time.sleep", autospec=True)
-@mock.patch("time.time", autospec=True)
+@mock.patch("time.sleep", autospec=None)
+@mock.patch("time.time", autospec=None)
 @mock.patch(
     "paasta_tools.cli.cmds.local_run.run_healthcheck_on_container",
     autospec=True,
@@ -1799,8 +1799,8 @@ def test_simulate_healthcheck_on_service_enabled_during_grace_period(
     assert mock_run_healthcheck_on_container.call_count == 1
 
 
-@mock.patch("time.sleep", autospec=True)
-@mock.patch("time.time", autospec=True)
+@mock.patch("time.sleep", autospec=None)
+@mock.patch("time.time", autospec=None)
 @mock.patch(
     "paasta_tools.cli.cmds.local_run.run_healthcheck_on_container", autospec=True
 )

--- a/tests/cli/test_cmds_mark_for_deployment.py
+++ b/tests/cli/test_cmds_mark_for_deployment.py
@@ -125,7 +125,7 @@ def mock_periodically_update_slack():
 @patch("paasta_tools.cli.cmds.mark_for_deployment._log_audit", autospec=True)
 @patch("paasta_tools.remote_git.create_remote_refs", autospec=True)
 @patch(
-    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
+    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=None
 )
 def test_mark_for_deployment_happy(
     mock_load_system_paasta_config, mock_create_remote_refs, mock__log_audit, mock__log
@@ -159,7 +159,7 @@ def test_mark_for_deployment_happy(
 @patch("paasta_tools.cli.cmds.mark_for_deployment._log_audit", autospec=True)
 @patch("paasta_tools.remote_git.create_remote_refs", autospec=True)
 @patch(
-    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
+    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=None
 )
 def test_mark_for_deployment_sad(
     mock_load_system_paasta_config, mock_create_remote_refs, mock__log_audit, mock__log
@@ -234,7 +234,7 @@ def test_paasta_mark_for_deployment_when_verify_image_fails(
 )
 @patch("paasta_tools.cli.cmds.mark_for_deployment.list_deploy_groups", autospec=True)
 @patch(
-    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
+    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=None
 )
 @patch("paasta_tools.metrics.metrics_lib.get_metrics_interface", autospec=True)
 @patch("paasta_tools.remote_git.list_remote_refs", autospec=True)
@@ -378,7 +378,7 @@ def test_paasta_mark_for_deployment_with_good_rollback(
 @patch("paasta_tools.remote_git.create_remote_refs", autospec=True)
 @patch("paasta_tools.cli.cmds.mark_for_deployment.trigger_deploys", autospec=True)
 @patch(
-    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
+    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=None
 )
 def test_mark_for_deployment_yelpy_repo(
     mock_load_system_paasta_config,
@@ -404,7 +404,7 @@ def test_mark_for_deployment_yelpy_repo(
 @patch("paasta_tools.remote_git.create_remote_refs", autospec=True)
 @patch("paasta_tools.cli.cmds.mark_for_deployment.trigger_deploys", autospec=True)
 @patch(
-    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
+    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=None
 )
 def test_mark_for_deployment_nonyelpy_repo(
     mock_load_system_paasta_config,
@@ -439,7 +439,7 @@ def test_mark_for_deployment_nonyelpy_repo(
     new_callable=AsyncMock,
 )
 @patch(
-    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
+    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=None
 )
 @patch("sticht.rollbacks.slo.get_slos_for_service", autospec=True)
 def test_MarkForDeployProcess_handles_wait_for_deployment_failure(
@@ -498,7 +498,7 @@ def test_MarkForDeployProcess_handles_wait_for_deployment_failure(
     new_callable=AsyncMock,
 )
 @patch(
-    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
+    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=None
 )
 @patch("sticht.rollbacks.slo.get_slos_for_service", autospec=True)
 def test_MarkForDeployProcess_handles_first_time_deploys(
@@ -548,7 +548,7 @@ def test_MarkForDeployProcess_handles_first_time_deploys(
 @patch.object(mark_for_deployment, "get_authors_to_be_notified", autospec=True)
 @patch.object(mark_for_deployment, "get_currently_deployed_sha", autospec=True)
 @patch.object(mark_for_deployment, "get_slack_client", autospec=True)
-@patch.object(mark_for_deployment, "load_system_paasta_config", autospec=True)
+@patch.object(mark_for_deployment, "load_system_paasta_config", autospec=None)
 @patch("sticht.rollbacks.slo.get_slos_for_service", autospec=True)
 def test_MarkForDeployProcess_get_authors_diffs_against_prod_deploy_group(
     mock_get_slos_for_service,
@@ -595,7 +595,7 @@ def test_MarkForDeployProcess_get_authors_diffs_against_prod_deploy_group(
 @patch.object(mark_for_deployment, "get_authors_to_be_notified", autospec=True)
 @patch.object(mark_for_deployment, "get_currently_deployed_sha", autospec=True)
 @patch.object(mark_for_deployment, "get_slack_client", autospec=True)
-@patch.object(mark_for_deployment, "load_system_paasta_config", autospec=True)
+@patch.object(mark_for_deployment, "load_system_paasta_config", autospec=None)
 @patch("sticht.rollbacks.slo.get_slos_for_service", autospec=True)
 def test_MarkForDeployProcess_get_authors_falls_back_to_current_deploy_group(
     mock_get_slos_for_service,
@@ -647,7 +647,7 @@ def test_MarkForDeployProcess_get_authors_falls_back_to_current_deploy_group(
     new_callable=AsyncMock,
 )
 @patch(
-    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
+    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=None
 )
 @patch("sticht.rollbacks.slo.get_slos_for_service", autospec=True)
 def test_MarkForDeployProcess_handles_wait_for_deployment_cancelled(
@@ -708,7 +708,7 @@ def test_MarkForDeployProcess_handles_wait_for_deployment_cancelled(
 @patch("sticht.slack.get_slack_events", autospec=True)
 @patch("sticht.rollbacks.slo.get_slos_for_service", autospec=True)
 @patch(
-    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
+    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=None
 )
 def test_MarkForDeployProcess_skips_wait_for_deployment_when_block_is_False(
     mock_load_system_paasta_config,
@@ -762,7 +762,7 @@ def test_MarkForDeployProcess_skips_wait_for_deployment_when_block_is_False(
     new_callable=AsyncMock,
 )
 @patch(
-    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=True
+    "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config", autospec=None
 )
 @patch("sticht.rollbacks.slo.get_slos_for_service", autospec=True)
 def test_MarkForDeployProcess_goes_to_mfd_failed_when_mark_for_deployment_fails(
@@ -1281,7 +1281,7 @@ def test_crashloop_auto_rollback_disabled_does_not_pass_crashloop_fn(
         autospec=True,
     ), patch(
         "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config",
-        autospec=True,
+        autospec=None,
         return_value=mock_config,
     ):
         mfdp = WrappedMarkForDeploymentProcess(
@@ -1505,7 +1505,7 @@ def test_alertmanager_rollback_config_from_system_config(
         autospec=True,
     ), patch(
         "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config",
-        autospec=True,
+        autospec=None,
         return_value=mock_config,
     ):
         mfdp = WrappedMarkForDeploymentProcess(
@@ -1701,7 +1701,7 @@ def test_build_alertmanager_rollback_filters_multi_cluster_multi_instance():
     )
     with patch(
         "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config",
-        autospec=True,
+        autospec=None,
         return_value=mock_config,
     ):
         assert mark_for_deployment.build_alertmanager_rollback_filters(
@@ -1771,7 +1771,7 @@ def test_default_error_alert_filter_skips_unknown_cluster():
     )
     with patch(
         "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config",
-        autospec=True,
+        autospec=None,
         return_value=mock_config,
     ):
         result = mark_for_deployment._build_default_error_alert_filter(
@@ -1810,7 +1810,7 @@ def test_default_error_alert_filter_multiple_registrations():
     )
     with patch(
         "paasta_tools.cli.cmds.mark_for_deployment.load_system_paasta_config",
-        autospec=True,
+        autospec=None,
         return_value=mock_config,
     ):
         result = mark_for_deployment._build_default_error_alert_filter(

--- a/tests/cli/test_cmds_verify_image_exists.py
+++ b/tests/cli/test_cmds_verify_image_exists.py
@@ -28,7 +28,7 @@ def test_wait_polls_until_found():
         side_effect=[False, False, True],
     ), mock.patch(
         "paasta_tools.cli.cmds.verify_image_exists.time.sleep",
-        autospec=True,
+        autospec=None,
     ):
         assert (
             verify_image_exists(service="fake_service", commit="abc1234", wait=True)
@@ -43,10 +43,10 @@ def test_timeout_expires():
         return_value=False,
     ), mock.patch(
         "paasta_tools.cli.cmds.verify_image_exists.time.sleep",
-        autospec=True,
+        autospec=None,
     ), mock.patch(
         "paasta_tools.cli.cmds.verify_image_exists.time.time",
-        autospec=True,
+        autospec=None,
         # slightly brittle, but oh well.
         # first call is for setting the start_time, second one
         # is after the mocked sleep and is past the timeout

--- a/tests/test_kubernetes_tools.py
+++ b/tests/test_kubernetes_tools.py
@@ -944,7 +944,7 @@ class TestKubernetesDeploymentConfig:
             return_value=["mock_sidecar"],
         ), mock.patch(
             "paasta_tools.kubernetes_tools.load_system_paasta_config",
-            autospec=True,
+            autospec=None,
         ):
             if prometheus_port:
                 self.deployment.config_dict["prometheus_port"] = prometheus_port
@@ -1516,7 +1516,7 @@ class TestKubernetesDeploymentConfig:
             autospec=True,
         ) as mock_get_git_sha, mock.patch(
             "paasta_tools.kubernetes_tools.load_system_paasta_config",
-            autospec=True,
+            autospec=None,
         ) as mock_load_system_config, mock.patch(
             "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_docker_url",
             autospec=True,
@@ -1586,7 +1586,7 @@ class TestKubernetesDeploymentConfig:
     )
     def test_format_kubernetes_app_dict(self, _):
         with mock.patch(
-            "paasta_tools.kubernetes_tools.load_system_paasta_config", autospec=True
+            "paasta_tools.kubernetes_tools.load_system_paasta_config", autospec=None
         ) as mock_load_system_config, mock.patch(
             "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_docker_url",
             autospec=True,
@@ -1735,7 +1735,7 @@ class TestKubernetesDeploymentConfig:
 
     @mock.patch(
         "paasta_tools.kubernetes_tools.load_system_paasta_config",
-        autospec=True,
+        autospec=None,
     )
     @mock.patch(
         "paasta_tools.kubernetes_tools.KubernetesDeploymentConfig.get_volumes",
@@ -1952,7 +1952,7 @@ class TestKubernetesDeploymentConfig:
 
     @mock.patch(
         "paasta_tools.kubernetes_tools.load_system_paasta_config",
-        autospec=True,
+        autospec=None,
     )
     @mock.patch(
         "paasta_tools.kubernetes_tools.load_service_namespace_config", autospec=True
@@ -2941,7 +2941,7 @@ class TestKubernetesDeploymentConfig:
 
     @mock.patch(
         "paasta_tools.kubernetes_tools.load_system_paasta_config",
-        autospec=True,
+        autospec=None,
         return_value=mock.Mock(
             get_legacy_autoscaling_signalflow=lambda: "fake_signalflow_query",
         ),
@@ -3032,7 +3032,7 @@ class TestKubernetesDeploymentConfig:
 
     @mock.patch(
         "paasta_tools.kubernetes_tools.load_system_paasta_config",
-        autospec=True,
+        autospec=None,
         return_value=mock.Mock(
             get_legacy_autoscaling_signalflow=lambda: "fake_signalflow_query",
         ),
@@ -3123,7 +3123,7 @@ class TestKubernetesDeploymentConfig:
 
     @mock.patch(
         "paasta_tools.kubernetes_tools.load_system_paasta_config",
-        autospec=True,
+        autospec=None,
     )
     def test_get_autoscaling_metric_spec_worker_load_prometheus(
         self, fake_system_paasta_config
@@ -3211,7 +3211,7 @@ class TestKubernetesDeploymentConfig:
 
     @mock.patch(
         "paasta_tools.kubernetes_tools.load_system_paasta_config",
-        autospec=True,
+        autospec=None,
         return_value=mock.Mock(
             get_legacy_autoscaling_signalflow=lambda: "fake_signalflow_query",
         ),
@@ -3608,7 +3608,7 @@ class TestKubernetesDeploymentConfig:
     @pytest.mark.parametrize("storage_class_name", ["ebs", "ebs-slow", "ebs-retain"])
     def test_get_storage_class_name_correct(self, storage_class_name):
         with mock.patch(
-            "paasta_tools.kubernetes_tools.load_system_paasta_config", autospec=True
+            "paasta_tools.kubernetes_tools.load_system_paasta_config", autospec=None
         ) as mock_load_system_config:
             mock_load_system_config.side_effect = None
             mock_load_system_config.return_value = mock.Mock(

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
 skipsdist=True
-envlist=py310-linux
+envlist=py311-linux
 docker_compose_version = 1.26.2
 requires =
     tox==3.28.0
 
 
 [testenv]
-basepython = python3.10
+basepython = python3.11
 passenv = SSH_AUTH_SOCK PAASTA_ENV DOCKER_HOST CI
 deps =
     --only-binary=grpcio
@@ -23,7 +23,7 @@ commands =
     -pip install -r yelp_package/extra_requirements_yelp.txt
 
 [testenv:dev-api]
-envdir = .tox/py310-linux/
+envdir = .tox/py311-linux/
 passenv = PAASTA_TEST_CLUSTER KUBECONFIG PAASTA_SYSTEM_CONFIG_DIR KUBECONTEXT AWS_PROFILE
 deps =
     --only-binary=grpcio
@@ -35,7 +35,7 @@ commands =
     python -m paasta_tools.run-paasta-api-in-dev-mode
 
 [testenv:playground-api]
-envdir = .tox/py310-linux/
+envdir = .tox/py311-linux/
 passenv = PAASTA_TEST_CLUSTER KUBECONFIG PAASTA_SYSTEM_CONFIG_DIR PAASTA_API_SOA_DIR USER
 setenv =
     KUBECONFIG = ./k8s_itests/kubeconfig
@@ -52,7 +52,7 @@ commands =
     python -m paasta_tools.run-paasta-api-playground
 
 [testenv:tests]
-envdir = .tox/py310-linux/
+envdir = .tox/py311-linux/
 commands =
     check-requirements -vv
     pre-commit install -f --install-hooks
@@ -63,7 +63,7 @@ commands =
     coverage report -m
 
 [testenv:tests-yelpy]
-envdir = .tox/py310-linux/
+envdir = .tox/py311-linux/
 setenv =
     PIP_INDEX_URL = http://169.254.255.254:20641/simple/
 deps =
@@ -92,7 +92,7 @@ commands =
     python -m sphinx -T -b html -d docs/build/doctrees -D language=en docs/source docs/build/html
 
 [testenv:k8s_itests]
-basepython = python3.10
+basepython = python3.11
 whitelist_externals = bash
 # one day we'll use a fully pinned venv here...
 deps =
@@ -127,7 +127,7 @@ commands =
         --abort-on-container-exit
 
 [testenv:general_itests]
-basepython = python3.10
+basepython = python3.11
 setenv =
     PAASTA_SYSTEM_CONFIG_DIR = {toxinidir}/general_itests/fake_etc_paasta
 changedir=general_itests/
@@ -143,7 +143,7 @@ commands =
     behave {posargs}
 
 [testenv:install-hooks]
-basepython = python3.10
+basepython = python3.11
 deps =
     pre-commit
 commands = pre-commit install -f --install-hooks

--- a/yelp_package/dockerfiles/itest/api/Dockerfile
+++ b/yelp_package/dockerfiles/itest/api/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update > /dev/null && \
         gcc \
         git \
         curl \
-        python3.10-dev \
+        python3.11-dev \
         libffi-dev \
         libssl-dev \
         libyaml-dev \
@@ -39,7 +39,7 @@ RUN apt-get update > /dev/null && \
 WORKDIR /work
 
 ADD requirements.txt /work/
-RUN virtualenv /venv -ppython3.10 --no-download
+RUN virtualenv /venv -ppython3.11 --no-download
 ENV PATH=/venv/bin:$PATH
 RUN pip install --only-binary=grpcio -r requirements.txt
 

--- a/yelp_package/dockerfiles/itest/k8s/Dockerfile
+++ b/yelp_package/dockerfiles/itest/k8s/Dockerfile
@@ -29,7 +29,7 @@ RUN apt-get update > /dev/null && \
         gcc \
         git \
         curl \
-        python3.10-dev \
+        python3.11-dev \
         libffi-dev \
         libssl-dev \
         libyaml-dev \
@@ -44,7 +44,7 @@ RUN mv ./kubectl /usr/local/bin/kubectl
 WORKDIR /work
 
 ADD requirements.txt /work/
-RUN virtualenv /venv -ppython3.10 --no-download
+RUN virtualenv /venv -ppython3.11 --no-download
 ENV PATH=/venv/bin:$PATH
 RUN pip install --only-binary=grpcio -r requirements.txt
 ADD yelp_package/dockerfiles/itest/k8s/wait_paasta_api.sh /venv/bin

--- a/yelp_package/dockerfiles/jammy/Dockerfile
+++ b/yelp_package/dockerfiles/jammy/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update > /dev/null && \
         libgpgme-dev \
         libssl-dev \
         libyaml-dev \
-        python3.10-dev \
+        python3.11-dev \
         python3-pip \
         tox \
         wget \
@@ -45,8 +45,8 @@ RUN apt-get update > /dev/null && \
         zsh > /dev/null \
     && rm -rf /var/lib/apt/lists/*
 
-RUN python3.10 -m pip install --upgrade pip==20.0.2
-RUN pip3.10 install virtualenv==20.29.3
+RUN python3.11 -m pip install --upgrade pip==20.0.2
+RUN pip3.11 install virtualenv==20.29.3
 
 ADD mesos-slave-secret /etc/mesos-slave-secret
 

--- a/yelp_package/dockerfiles/noble/Dockerfile
+++ b/yelp_package/dockerfiles/noble/Dockerfile
@@ -37,7 +37,7 @@ RUN apt-get update > /dev/null && \
         libgpgme-dev \
         libssl-dev \
         libyaml-dev \
-        python3.10-dev \
+        python3.11-dev \
         python3-pip \
         tox \
         wget \

--- a/yelp_package/dockerfiles/resolute/Dockerfile
+++ b/yelp_package/dockerfiles/resolute/Dockerfile
@@ -36,7 +36,7 @@ RUN apt-get update > /dev/null && \
         libgpgme-dev \
         libssl-dev \
         libyaml-dev \
-        python3.10-dev \
+        python3.11-dev \
         python3-pip \
         tox \
         wget \

--- a/yelp_package/extra_requirements_yelp.txt
+++ b/yelp_package/extra_requirements_yelp.txt
@@ -19,7 +19,7 @@ named-decorator==0.1.4              # yelp-profiling dependency
 ndg-httpsclient==0.4.3              # vault-tools dependency
 okta-auth==1.3.2
 pycparser==2.20                     # vault-tools dependency
-pygpgme==0.3                        # vault-tools dependency
+pygpgme==0.6                        # vault-tools dependency
 pyjwt==2.9.0                        # okta-auth dependency
 pyopenssl==19.0.0                   # vault-tools dependency
 PySubnetTree==0.34                  # yelp-lib dependency


### PR DESCRIPTION
PaaSTA python upgrade from 3.10 to 3.11 alognside other requirements upgrades and test fixes.

- upgrade paasta to python from 3.10 to 3.11 
- upgrade `black` version from 22.3.0 to 22.10.0.
- upgrade `multidict` from 4.7.6 to 6.0.5
- upgrade `yarl` from 1.1.1 to 1.9.3
- upgrade `pygpgme` from 0.3 to 0.6
- fix tests that failed due to `InvalidSpecError` in` test_kubernetes_tools, test_cmds_local_run, test_cmds_mark_for_deployment and test_cmds_verify_image_exists`

PAASTA-18819
